### PR TITLE
fix(crd): mobile chord queue layout

### DIFF
--- a/crd/index.html
+++ b/crd/index.html
@@ -361,13 +361,12 @@ textarea:focus, input:focus { border-color: var(--accent); }
     gap: 8px;
   }
 
-  /* Chord pills scroll horizontally so the panel stays compact */
+  /* Chord pills wrap and the panel scrolls vertically — no horizontal bleed */
   #q-list {
-    white-space: nowrap;
-    overflow-x: auto;
+    max-height: 110px;
+    overflow-y: auto;
     -webkit-overflow-scrolling: touch;
-    line-height: 1;
-    padding-bottom: 4px;
+    line-height: 1.7;
   }
 
   /* Hide the verbose hint on small screens */


### PR DESCRIPTION
Replaces the horizontal-scroll chord queue on mobile with a wrapping multi-line layout capped at 110px height. The previous `white-space: nowrap` approach caused the entire page to overflow horizontally, pushing the Undo/Reset buttons off-screen.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MCYgWHs6nXVk8aahSvTvpz)_