### PR TITLE
Restructure navigation into productivity / personal / games categories

### DIFF
--- a/games/index.html
+++ b/games/index.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>games · endermatx</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+background: #2a2a2a;
+color: #e0e0e0;
+font-family: 'Courier New', Courier, monospace;
+min-height: 100vh;
+display: flex;
+flex-direction: column;
+align-items: center;
+justify-content: center;
+padding: 40px 20px;
+}
+
+header {
+text-align: center;
+margin-bottom: 60px;
+}
+
+.back {
+display: inline-block;
+font-size: 0.65rem;
+color: #bbb;
+letter-spacing: 0.2em;
+text-transform: uppercase;
+text-decoration: none;
+margin-bottom: 20px;
+}
+.back:hover { color: #fff; }
+
+header h1 {
+font-size: 2rem;
+font-weight: normal;
+letter-spacing: 0.15em;
+color: #ffffff;
+text-transform: uppercase;
+font-family: 'Courier New', Courier, monospace;
+line-height: 1.15;
+}
+
+header p {
+margin-top: 8px;
+font-size: 0.75rem;
+color: #ccc;
+letter-spacing: 0.2em;
+text-transform: uppercase;
+}
+
+.empty {
+font-size: 0.75rem;
+color: #bbb;
+letter-spacing: 0.2em;
+text-transform: uppercase;
+text-align: center;
+}
+
+footer {
+margin-top: 60px;
+font-size: 0.65rem;
+color: #bbb;
+letter-spacing: 0.2em;
+text-align: center;
+}
+</style>
+</head>
+<body>
+
+<header>
+  <a class="back" href="../">&larr; endermatx</a>
+  <h1>GAM<br>ES</h1>
+  <p>games</p>
+</header>
+
+<div class="empty">coming soon</div>
+
+<footer>matmaxx2317 &middot; github pages</footer>
+
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -263,40 +263,22 @@ transform-origin: top center;
 
 <nav class="grid">
 
-  <a class="card" href="./tts/">
+  <a class="card" href="./productivity/">
     <div class="card-label">01</div>
-    <div class="card-name">tts</div>
-    <div class="card-arrow">time tracker &rarr;</div>
+    <div class="card-name">productivity</div>
+    <div class="card-arrow">tts · cal · pom · mtg &rarr;</div>
   </a>
 
-  <a class="card" href="./cal/">
+  <a class="card" href="./personal/">
     <div class="card-label">02</div>
-    <div class="card-name">cal</div>
-    <div class="card-arrow">calendar &rarr;</div>
+    <div class="card-name">personal</div>
+    <div class="card-arrow">str · crd &rarr;</div>
   </a>
 
-  <a class="card" href="./pom/">
+  <a class="card" href="./games/">
     <div class="card-label">03</div>
-    <div class="card-name">pom</div>
-    <div class="card-arrow">pomodoro &rarr;</div>
-  </a>
-
-  <a class="card" href="./mtg/">
-    <div class="card-label">04</div>
-    <div class="card-name">mtg</div>
-    <div class="card-arrow">meeting notes &rarr;</div>
-  </a>
-
-  <a class="card" href="./str/">
-    <div class="card-label">05</div>
-    <div class="card-name">str</div>
-    <div class="card-arrow">string tracker &rarr;</div>
-  </a>
-
-  <a class="card" href="./crd/">
-    <div class="card-label">06</div>
-    <div class="card-name">crd</div>
-    <div class="card-arrow">chord aligner &rarr;</div>
+    <div class="card-name">games</div>
+    <div class="card-arrow">coming soon &rarr;</div>
   </a>
 
 </nav>

--- a/personal/index.html
+++ b/personal/index.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>personal · endermatx</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+background: #2a2a2a;
+color: #e0e0e0;
+font-family: 'Courier New', Courier, monospace;
+min-height: 100vh;
+display: flex;
+flex-direction: column;
+align-items: center;
+justify-content: center;
+padding: 40px 20px;
+}
+
+header {
+text-align: center;
+margin-bottom: 60px;
+}
+
+.back {
+display: inline-block;
+font-size: 0.65rem;
+color: #bbb;
+letter-spacing: 0.2em;
+text-transform: uppercase;
+text-decoration: none;
+margin-bottom: 20px;
+}
+.back:hover { color: #fff; }
+
+header h1 {
+font-size: 2rem;
+font-weight: normal;
+letter-spacing: 0.15em;
+color: #ffffff;
+text-transform: uppercase;
+font-family: 'Courier New', Courier, monospace;
+line-height: 1.15;
+}
+
+header p {
+margin-top: 8px;
+font-size: 0.75rem;
+color: #ccc;
+letter-spacing: 0.2em;
+text-transform: uppercase;
+}
+
+.grid {
+display: flex;
+flex-direction: column;
+gap: 8px;
+width: 300px;
+}
+
+a.card {
+display: flex;
+flex-direction: row;
+align-items: center;
+text-decoration: none;
+padding: 12px 16px;
+border: 1px solid #2a2a2a;
+border-left: 2px solid #6b1010;
+background: #1e1e1e;
+color: #e0e0e0;
+transition: border-color 0.15s, background 0.15s;
+}
+
+a.card:hover {
+border-color: #ccc;
+border-left-color: #9b1a1a;
+background: #222;
+}
+
+a.card:active { background: #252525; }
+
+.card-label {
+font-size: 0.65rem;
+letter-spacing: 0.2em;
+text-transform: uppercase;
+color: #ccc;
+width: 28px;
+flex-shrink: 0;
+}
+
+.card-name {
+font-size: 1rem;
+font-weight: normal;
+letter-spacing: 0.05em;
+color: #ffffff;
+flex: 1;
+margin-left: 16px;
+}
+
+.card-arrow {
+font-size: 0.7rem;
+color: #ccc;
+letter-spacing: 0.05em;
+}
+
+a.card:hover .card-arrow { color: #bbb; }
+
+footer {
+margin-top: 60px;
+font-size: 0.65rem;
+color: #bbb;
+letter-spacing: 0.2em;
+text-align: center;
+}
+</style>
+</head>
+<body>
+
+<header>
+  <a class="back" href="../">&larr; endermatx</a>
+  <h1>PER<br>SON<br>AL</h1>
+  <p>personal</p>
+</header>
+
+<nav class="grid">
+
+  <a class="card" href="../str/">
+    <div class="card-label">01</div>
+    <div class="card-name">str</div>
+    <div class="card-arrow">string tracker &rarr;</div>
+  </a>
+
+  <a class="card" href="../crd/">
+    <div class="card-label">02</div>
+    <div class="card-name">crd</div>
+    <div class="card-arrow">chord aligner &rarr;</div>
+  </a>
+
+</nav>
+
+<footer>matmaxx2317 &middot; github pages</footer>
+
+</body>
+</html>

--- a/productivity/index.html
+++ b/productivity/index.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>productivity · endermatx</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+background: #2a2a2a;
+color: #e0e0e0;
+font-family: 'Courier New', Courier, monospace;
+min-height: 100vh;
+display: flex;
+flex-direction: column;
+align-items: center;
+justify-content: center;
+padding: 40px 20px;
+}
+
+header {
+text-align: center;
+margin-bottom: 60px;
+}
+
+.back {
+display: inline-block;
+font-size: 0.65rem;
+color: #bbb;
+letter-spacing: 0.2em;
+text-transform: uppercase;
+text-decoration: none;
+margin-bottom: 20px;
+}
+.back:hover { color: #fff; }
+
+header h1 {
+font-size: 2rem;
+font-weight: normal;
+letter-spacing: 0.15em;
+color: #ffffff;
+text-transform: uppercase;
+font-family: 'Courier New', Courier, monospace;
+line-height: 1.15;
+}
+
+header p {
+margin-top: 8px;
+font-size: 0.75rem;
+color: #ccc;
+letter-spacing: 0.2em;
+text-transform: uppercase;
+}
+
+.grid {
+display: flex;
+flex-direction: column;
+gap: 8px;
+width: 300px;
+}
+
+a.card {
+display: flex;
+flex-direction: row;
+align-items: center;
+text-decoration: none;
+padding: 12px 16px;
+border: 1px solid #2a2a2a;
+border-left: 2px solid #6b1010;
+background: #1e1e1e;
+color: #e0e0e0;
+transition: border-color 0.15s, background 0.15s;
+}
+
+a.card:hover {
+border-color: #ccc;
+border-left-color: #9b1a1a;
+background: #222;
+}
+
+a.card:active { background: #252525; }
+
+.card-label {
+font-size: 0.65rem;
+letter-spacing: 0.2em;
+text-transform: uppercase;
+color: #ccc;
+width: 28px;
+flex-shrink: 0;
+}
+
+.card-name {
+font-size: 1rem;
+font-weight: normal;
+letter-spacing: 0.05em;
+color: #ffffff;
+flex: 1;
+margin-left: 16px;
+}
+
+.card-arrow {
+font-size: 0.7rem;
+color: #ccc;
+letter-spacing: 0.05em;
+}
+
+a.card:hover .card-arrow { color: #bbb; }
+
+footer {
+margin-top: 60px;
+font-size: 0.65rem;
+color: #bbb;
+letter-spacing: 0.2em;
+text-align: center;
+}
+</style>
+</head>
+<body>
+
+<header>
+  <a class="back" href="../">&larr; endermatx</a>
+  <h1>PRO<br>DUC<br>TIV</h1>
+  <p>productivity</p>
+</header>
+
+<nav class="grid">
+
+  <a class="card" href="../tts/">
+    <div class="card-label">01</div>
+    <div class="card-name">tts</div>
+    <div class="card-arrow">time tracker &rarr;</div>
+  </a>
+
+  <a class="card" href="../cal/">
+    <div class="card-label">02</div>
+    <div class="card-name">cal</div>
+    <div class="card-arrow">calendar &rarr;</div>
+  </a>
+
+  <a class="card" href="../pom/">
+    <div class="card-label">03</div>
+    <div class="card-name">pom</div>
+    <div class="card-arrow">pomodoro &rarr;</div>
+  </a>
+
+  <a class="card" href="../mtg/">
+    <div class="card-label">04</div>
+    <div class="card-name">mtg</div>
+    <div class="card-arrow">meeting notes &rarr;</div>
+  </a>
+
+</nav>
+
+<footer>matmaxx2317 &middot; github pages</footer>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Landing page now shows 3 category cards instead of individual tool cards
- Created `/productivity/` subpage with tts, cal, pom, mtg
- Created `/personal/` subpage with str, crd
- Created `/games/` subpage with "coming soon" placeholder
- Each subpage has a ← endermatx back link and matching 3-line stacked title style

https://claude.ai/code/session_01RzvsgcnP1NovPrgnCM3AzQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RzvsgcnP1NovPrgnCM3AzQ)_