### PR TITLE
fix: back button text, category headers, tts sort order (#15, #16, #17)

### DIFF
--- a/games/index.html
+++ b/games/index.html
@@ -57,12 +57,146 @@ color: #bbb;
 letter-spacing: 0.2em;
 text-align: center;
 }
+
+/* ── ENDERMAN ───────────────────────────────────── */
+
+#enderman {
+position: fixed;
+top: 0;
+left: 0;
+z-index: 5;
+pointer-events: none;
+}
+
+.ender-figure {
+display: flex;
+flex-direction: column;
+align-items: center;
+animation: ender-bob 0.7s ease-in-out infinite;
+}
+
+.ender-head {
+width: 11px;
+height: 11px;
+background: linear-gradient(150deg, #1e1e1e 0%, #0c0c0c 100%);
+border-radius: 2px;
+position: relative;
+box-shadow: 0 1px 5px rgba(0,0,0,0.9);
+flex-shrink: 0;
+}
+
+.ender-eye {
+position: absolute;
+width: 2px;
+height: 4px;
+background: #cc00ee;
+top: 3px;
+border-radius: 1px;
+box-shadow: 0 0 4px #cc00ee, 0 0 8px #9900bb;
+}
+.ender-eye.left  { left: 1px; }
+.ender-eye.right { right: 1px; }
+
+.ender-body-wrap {
+display: flex;
+align-items: flex-start;
+margin-top: 1px;
+}
+
+.ender-column {
+display: flex;
+flex-direction: column;
+align-items: center;
+}
+
+.ender-torso {
+width: 8px;
+height: 14px;
+background: linear-gradient(160deg, #2a2a2a 0%, #1a1a1a 40%, #111 100%);
+border-left: 1px solid #333;
+border-right: 1px solid #333;
+box-shadow: inset 1px 0 0 rgba(255,255,255,0.04);
+}
+
+.ender-arm {
+width: 2px;
+height: 28px;
+background: linear-gradient(180deg, #151515, #0a0a0a);
+border-radius: 1px;
+transform-origin: top center;
+}
+.ender-arm.left  { animation: ender-arm-l 1.1s ease-in-out infinite; }
+.ender-arm.right { animation: ender-arm-r 0.9s ease-in-out infinite; }
+
+.ender-legs {
+display: flex;
+gap: 1px;
+margin-top: 0;
+}
+
+.ender-leg {
+width: 2px;
+height: 30px;
+background: linear-gradient(180deg, #111, #080808);
+border-radius: 1px;
+transform-origin: top center;
+}
+.ender-leg.left  { animation: ender-leg-l 0.7s ease-in-out infinite; }
+.ender-leg.right { animation: ender-leg-r 0.7s ease-in-out infinite; }
+
+@keyframes ender-bob {
+  0%, 100% { transform: translateY(0); }
+  50%       { transform: translateY(-2px); }
+}
+@keyframes ender-arm-l {
+  0%   { transform: rotate(-5deg); }
+  40%  { transform: rotate(7deg); }
+  70%  { transform: rotate(2deg); }
+  100% { transform: rotate(-5deg); }
+}
+@keyframes ender-arm-r {
+  0%   { transform: rotate(3deg); }
+  30%  { transform: rotate(-6deg); }
+  65%  { transform: rotate(4deg); }
+  100% { transform: rotate(3deg); }
+}
+@keyframes ender-leg-l {
+  0%, 100% { transform: rotate(-10deg); }
+  50%       { transform: rotate(10deg); }
+}
+@keyframes ender-leg-r {
+  0%, 100% { transform: rotate(10deg); }
+  50%       { transform: rotate(-10deg); }
+}
 </style>
 </head>
 <body>
 
+<!-- ENDERMAN -->
+<div id="enderman">
+  <div class="ender-flip" id="enderFlip">
+    <div class="ender-figure">
+      <div class="ender-head">
+        <div class="ender-eye left"></div>
+        <div class="ender-eye right"></div>
+      </div>
+      <div class="ender-body-wrap">
+        <div class="ender-arm left"></div>
+        <div class="ender-column">
+          <div class="ender-torso"></div>
+          <div class="ender-legs">
+            <div class="ender-leg left"></div>
+            <div class="ender-leg right"></div>
+          </div>
+        </div>
+        <div class="ender-arm right"></div>
+      </div>
+    </div>
+  </div>
+</div>
+
 <header>
-  <h1>GAM<br>ES</h1>
+  <h1>END<br>ERM<br>ATX</h1>
   <p>games</p>
 </header>
 
@@ -70,7 +204,7 @@ text-align: center;
 
   <a class="card" href="../">
     <div class="card-label">&larr;</div>
-    <div class="card-name">endermatx</div>
+    <div class="card-name">back</div>
     <div class="card-arrow">&nbsp;</div>
   </a>
 
@@ -79,6 +213,148 @@ text-align: center;
 <div class="empty" style="margin-top:32px">coming soon</div>
 
 <footer>matmaxx2317 &middot; github pages</footer>
+
+<script>
+(function() {
+  var ENDER_W = 14;
+  var ENDER_H = 70;
+
+  var enderman = document.getElementById('enderman');
+  var flip     = document.getElementById('enderFlip');
+
+  var x              = 20;
+  var dir            = 1;
+  var teleporting    = false;
+  var last           = null;
+  var sinceLastTport = 0;
+  var nextTport      = randomInterval();
+
+  var currentSpeed   = 30;
+  var targetSpeed    = 30;
+  var sinceSpeedChange = 0;
+  var nextSpeedChange  = randomSpeedInterval();
+
+  function randomInterval() { return 2800 + Math.random() * 2400; }
+  function randomSpeedInterval() { return 600 + Math.random() * 1400; }
+  function randomTargetSpeed() {
+    var r = Math.random();
+    if (r < 0.2) return 0;
+    if (r < 0.5) return 18 + Math.random() * 14;
+    if (r < 0.85) return 45 + Math.random() * 25;
+    return 90 + Math.random() * 40;
+  }
+
+  function positionV() {
+    var rect = document.querySelector('header').getBoundingClientRect();
+    var top  = rect.top + rect.height / 2 - ENDER_H / 2;
+    enderman.style.top = Math.max(8, top) + 'px';
+  }
+
+  var PARTICLE_COLORS = ['#cc00ee','#dd44ff','#9900bb','#ee88ff','#aa00dd'];
+
+  function spawnParticles(px, py, count) {
+    for (var i = 0; i < count; i++) {
+      (function() {
+        var p    = document.createElement('div');
+        var size = 2 + Math.random() * 2.5;
+        var col  = PARTICLE_COLORS[Math.floor(Math.random() * PARTICLE_COLORS.length)];
+        p.style.cssText = 'position:fixed;border-radius:50%;pointer-events:none;z-index:6;' +
+          'width:' + size + 'px;height:' + size + 'px;' +
+          'background:' + col + ';box-shadow:0 0 4px ' + col + ';';
+        document.body.appendChild(p);
+
+        var angle  = Math.random() * Math.PI * 2;
+        var dist   = 18 + Math.random() * 55;
+        var vx     = Math.cos(angle) * dist;
+        var vy     = Math.sin(angle) * dist;
+        var maxLife = 420 + Math.random() * 320;
+        var t0 = null;
+
+        function frame(ts) {
+          if (!t0) t0 = ts;
+          var t = (ts - t0) / maxLife;
+          if (t >= 1) { p.remove(); return; }
+          var e = 1 - (1 - t) * (1 - t);
+          p.style.left    = (px + vx * e) + 'px';
+          p.style.top     = (py + vy * e - 28 * t) + 'px';
+          p.style.opacity = (1 - t).toFixed(3);
+          requestAnimationFrame(frame);
+        }
+        requestAnimationFrame(frame);
+      })();
+    }
+  }
+
+  function enderPos() {
+    return {
+      px: x + ENDER_W / 2,
+      py: parseFloat(enderman.style.top || 0) + ENDER_H / 2
+    };
+  }
+
+  function teleport() {
+    teleporting = true;
+    var from = enderPos();
+    spawnParticles(from.px, from.py, 14);
+    enderman.style.opacity = '0';
+    setTimeout(function() {
+      var maxX = window.innerWidth - ENDER_W;
+      x   = Math.random() * maxX;
+      dir = Math.random() > 0.5 ? 1 : -1;
+      enderman.style.transform = 'translateX(' + x + 'px)';
+      flip.style.transform     = dir === -1 ? 'scaleX(-1)' : 'scaleX(1)';
+      enderman.style.opacity   = '1';
+      var to = enderPos();
+      spawnParticles(to.px, to.py, 14);
+      teleporting    = false;
+      sinceLastTport = 0;
+      nextTport      = randomInterval();
+    }, 200);
+  }
+
+  function step(dt) {
+    if (teleporting) return;
+    sinceLastTport   += dt;
+    sinceSpeedChange += dt;
+
+    if (sinceSpeedChange >= nextSpeedChange) {
+      targetSpeed      = randomTargetSpeed();
+      nextSpeedChange  = randomSpeedInterval();
+      sinceSpeedChange = 0;
+    }
+
+    currentSpeed += (targetSpeed - currentSpeed) * Math.min(1, dt / 180);
+
+    x += dir * currentSpeed * (dt / 1000);
+    var maxX = window.innerWidth - ENDER_W;
+    if (x >= maxX) { x = maxX; dir = -1; flip.style.transform = 'scaleX(-1)'; }
+    if (x <= 0)    { x = 0;    dir =  1; flip.style.transform = 'scaleX(1)';  }
+    enderman.style.transform = 'translateX(' + x + 'px)';
+
+    var walkDur = currentSpeed < 5 ? '9999s' : (1.4 - Math.min(currentSpeed, 130) / 130 * 0.9) + 's';
+    enderman.querySelectorAll('.ender-arm, .ender-leg, .ender-figure').forEach(function(el) {
+      el.style.animationDuration = walkDur;
+    });
+
+    if (sinceLastTport >= nextTport) teleport();
+  }
+
+  function loop(ts) {
+    if (last !== null) step(ts - last);
+    last = ts;
+    requestAnimationFrame(loop);
+  }
+
+  positionV();
+  enderman.style.transform = 'translateX(' + x + 'px)';
+  window.addEventListener('resize', function() {
+    positionV();
+    x = Math.min(x, window.innerWidth - ENDER_W);
+  });
+
+  requestAnimationFrame(loop);
+})();
+</script>
 
 </body>
 </html>

--- a/games/index.html
+++ b/games/index.html
@@ -42,6 +42,60 @@ letter-spacing: 0.2em;
 text-transform: uppercase;
 }
 
+.grid {
+display: flex;
+flex-direction: column;
+gap: 8px;
+width: 300px;
+}
+
+a.card {
+display: flex;
+flex-direction: row;
+align-items: center;
+text-decoration: none;
+padding: 12px 16px;
+border: 1px solid #2a2a2a;
+border-left: 2px solid #6b1010;
+background: #1e1e1e;
+color: #e0e0e0;
+transition: border-color 0.15s, background 0.15s;
+}
+
+a.card:hover {
+border-color: #ccc;
+border-left-color: #9b1a1a;
+background: #222;
+}
+
+a.card:active { background: #252525; }
+
+.card-label {
+font-size: 0.65rem;
+letter-spacing: 0.2em;
+text-transform: uppercase;
+color: #ccc;
+width: 28px;
+flex-shrink: 0;
+}
+
+.card-name {
+font-size: 1rem;
+font-weight: normal;
+letter-spacing: 0.05em;
+color: #ffffff;
+flex: 1;
+margin-left: 16px;
+}
+
+.card-arrow {
+font-size: 0.7rem;
+color: #ccc;
+letter-spacing: 0.05em;
+}
+
+a.card:hover .card-arrow { color: #bbb; }
+
 .empty {
 font-size: 0.75rem;
 color: #bbb;

--- a/personal/index.html
+++ b/personal/index.html
@@ -103,12 +103,146 @@ color: #bbb;
 letter-spacing: 0.2em;
 text-align: center;
 }
+
+/* ── ENDERMAN ───────────────────────────────────── */
+
+#enderman {
+position: fixed;
+top: 0;
+left: 0;
+z-index: 5;
+pointer-events: none;
+}
+
+.ender-figure {
+display: flex;
+flex-direction: column;
+align-items: center;
+animation: ender-bob 0.7s ease-in-out infinite;
+}
+
+.ender-head {
+width: 11px;
+height: 11px;
+background: linear-gradient(150deg, #1e1e1e 0%, #0c0c0c 100%);
+border-radius: 2px;
+position: relative;
+box-shadow: 0 1px 5px rgba(0,0,0,0.9);
+flex-shrink: 0;
+}
+
+.ender-eye {
+position: absolute;
+width: 2px;
+height: 4px;
+background: #cc00ee;
+top: 3px;
+border-radius: 1px;
+box-shadow: 0 0 4px #cc00ee, 0 0 8px #9900bb;
+}
+.ender-eye.left  { left: 1px; }
+.ender-eye.right { right: 1px; }
+
+.ender-body-wrap {
+display: flex;
+align-items: flex-start;
+margin-top: 1px;
+}
+
+.ender-column {
+display: flex;
+flex-direction: column;
+align-items: center;
+}
+
+.ender-torso {
+width: 8px;
+height: 14px;
+background: linear-gradient(160deg, #2a2a2a 0%, #1a1a1a 40%, #111 100%);
+border-left: 1px solid #333;
+border-right: 1px solid #333;
+box-shadow: inset 1px 0 0 rgba(255,255,255,0.04);
+}
+
+.ender-arm {
+width: 2px;
+height: 28px;
+background: linear-gradient(180deg, #151515, #0a0a0a);
+border-radius: 1px;
+transform-origin: top center;
+}
+.ender-arm.left  { animation: ender-arm-l 1.1s ease-in-out infinite; }
+.ender-arm.right { animation: ender-arm-r 0.9s ease-in-out infinite; }
+
+.ender-legs {
+display: flex;
+gap: 1px;
+margin-top: 0;
+}
+
+.ender-leg {
+width: 2px;
+height: 30px;
+background: linear-gradient(180deg, #111, #080808);
+border-radius: 1px;
+transform-origin: top center;
+}
+.ender-leg.left  { animation: ender-leg-l 0.7s ease-in-out infinite; }
+.ender-leg.right { animation: ender-leg-r 0.7s ease-in-out infinite; }
+
+@keyframes ender-bob {
+  0%, 100% { transform: translateY(0); }
+  50%       { transform: translateY(-2px); }
+}
+@keyframes ender-arm-l {
+  0%   { transform: rotate(-5deg); }
+  40%  { transform: rotate(7deg); }
+  70%  { transform: rotate(2deg); }
+  100% { transform: rotate(-5deg); }
+}
+@keyframes ender-arm-r {
+  0%   { transform: rotate(3deg); }
+  30%  { transform: rotate(-6deg); }
+  65%  { transform: rotate(4deg); }
+  100% { transform: rotate(3deg); }
+}
+@keyframes ender-leg-l {
+  0%, 100% { transform: rotate(-10deg); }
+  50%       { transform: rotate(10deg); }
+}
+@keyframes ender-leg-r {
+  0%, 100% { transform: rotate(10deg); }
+  50%       { transform: rotate(-10deg); }
+}
 </style>
 </head>
 <body>
 
+<!-- ENDERMAN -->
+<div id="enderman">
+  <div class="ender-flip" id="enderFlip">
+    <div class="ender-figure">
+      <div class="ender-head">
+        <div class="ender-eye left"></div>
+        <div class="ender-eye right"></div>
+      </div>
+      <div class="ender-body-wrap">
+        <div class="ender-arm left"></div>
+        <div class="ender-column">
+          <div class="ender-torso"></div>
+          <div class="ender-legs">
+            <div class="ender-leg left"></div>
+            <div class="ender-leg right"></div>
+          </div>
+        </div>
+        <div class="ender-arm right"></div>
+      </div>
+    </div>
+  </div>
+</div>
+
 <header>
-  <h1>PER<br>SON<br>AL</h1>
+  <h1>END<br>ERM<br>ATX</h1>
   <p>personal</p>
 </header>
 
@@ -116,7 +250,7 @@ text-align: center;
 
   <a class="card" href="../">
     <div class="card-label">&larr;</div>
-    <div class="card-name">endermatx</div>
+    <div class="card-name">back</div>
     <div class="card-arrow">&nbsp;</div>
   </a>
 
@@ -135,6 +269,148 @@ text-align: center;
 </nav>
 
 <footer>matmaxx2317 &middot; github pages</footer>
+
+<script>
+(function() {
+  var ENDER_W = 14;
+  var ENDER_H = 70;
+
+  var enderman = document.getElementById('enderman');
+  var flip     = document.getElementById('enderFlip');
+
+  var x              = 20;
+  var dir            = 1;
+  var teleporting    = false;
+  var last           = null;
+  var sinceLastTport = 0;
+  var nextTport      = randomInterval();
+
+  var currentSpeed   = 30;
+  var targetSpeed    = 30;
+  var sinceSpeedChange = 0;
+  var nextSpeedChange  = randomSpeedInterval();
+
+  function randomInterval() { return 2800 + Math.random() * 2400; }
+  function randomSpeedInterval() { return 600 + Math.random() * 1400; }
+  function randomTargetSpeed() {
+    var r = Math.random();
+    if (r < 0.2) return 0;
+    if (r < 0.5) return 18 + Math.random() * 14;
+    if (r < 0.85) return 45 + Math.random() * 25;
+    return 90 + Math.random() * 40;
+  }
+
+  function positionV() {
+    var rect = document.querySelector('header').getBoundingClientRect();
+    var top  = rect.top + rect.height / 2 - ENDER_H / 2;
+    enderman.style.top = Math.max(8, top) + 'px';
+  }
+
+  var PARTICLE_COLORS = ['#cc00ee','#dd44ff','#9900bb','#ee88ff','#aa00dd'];
+
+  function spawnParticles(px, py, count) {
+    for (var i = 0; i < count; i++) {
+      (function() {
+        var p    = document.createElement('div');
+        var size = 2 + Math.random() * 2.5;
+        var col  = PARTICLE_COLORS[Math.floor(Math.random() * PARTICLE_COLORS.length)];
+        p.style.cssText = 'position:fixed;border-radius:50%;pointer-events:none;z-index:6;' +
+          'width:' + size + 'px;height:' + size + 'px;' +
+          'background:' + col + ';box-shadow:0 0 4px ' + col + ';';
+        document.body.appendChild(p);
+
+        var angle  = Math.random() * Math.PI * 2;
+        var dist   = 18 + Math.random() * 55;
+        var vx     = Math.cos(angle) * dist;
+        var vy     = Math.sin(angle) * dist;
+        var maxLife = 420 + Math.random() * 320;
+        var t0 = null;
+
+        function frame(ts) {
+          if (!t0) t0 = ts;
+          var t = (ts - t0) / maxLife;
+          if (t >= 1) { p.remove(); return; }
+          var e = 1 - (1 - t) * (1 - t);
+          p.style.left    = (px + vx * e) + 'px';
+          p.style.top     = (py + vy * e - 28 * t) + 'px';
+          p.style.opacity = (1 - t).toFixed(3);
+          requestAnimationFrame(frame);
+        }
+        requestAnimationFrame(frame);
+      })();
+    }
+  }
+
+  function enderPos() {
+    return {
+      px: x + ENDER_W / 2,
+      py: parseFloat(enderman.style.top || 0) + ENDER_H / 2
+    };
+  }
+
+  function teleport() {
+    teleporting = true;
+    var from = enderPos();
+    spawnParticles(from.px, from.py, 14);
+    enderman.style.opacity = '0';
+    setTimeout(function() {
+      var maxX = window.innerWidth - ENDER_W;
+      x   = Math.random() * maxX;
+      dir = Math.random() > 0.5 ? 1 : -1;
+      enderman.style.transform = 'translateX(' + x + 'px)';
+      flip.style.transform     = dir === -1 ? 'scaleX(-1)' : 'scaleX(1)';
+      enderman.style.opacity   = '1';
+      var to = enderPos();
+      spawnParticles(to.px, to.py, 14);
+      teleporting    = false;
+      sinceLastTport = 0;
+      nextTport      = randomInterval();
+    }, 200);
+  }
+
+  function step(dt) {
+    if (teleporting) return;
+    sinceLastTport   += dt;
+    sinceSpeedChange += dt;
+
+    if (sinceSpeedChange >= nextSpeedChange) {
+      targetSpeed      = randomTargetSpeed();
+      nextSpeedChange  = randomSpeedInterval();
+      sinceSpeedChange = 0;
+    }
+
+    currentSpeed += (targetSpeed - currentSpeed) * Math.min(1, dt / 180);
+
+    x += dir * currentSpeed * (dt / 1000);
+    var maxX = window.innerWidth - ENDER_W;
+    if (x >= maxX) { x = maxX; dir = -1; flip.style.transform = 'scaleX(-1)'; }
+    if (x <= 0)    { x = 0;    dir =  1; flip.style.transform = 'scaleX(1)';  }
+    enderman.style.transform = 'translateX(' + x + 'px)';
+
+    var walkDur = currentSpeed < 5 ? '9999s' : (1.4 - Math.min(currentSpeed, 130) / 130 * 0.9) + 's';
+    enderman.querySelectorAll('.ender-arm, .ender-leg, .ender-figure').forEach(function(el) {
+      el.style.animationDuration = walkDur;
+    });
+
+    if (sinceLastTport >= nextTport) teleport();
+  }
+
+  function loop(ts) {
+    if (last !== null) step(ts - last);
+    last = ts;
+    requestAnimationFrame(loop);
+  }
+
+  positionV();
+  enderman.style.transform = 'translateX(' + x + 'px)';
+  window.addEventListener('resize', function() {
+    positionV();
+    x = Math.min(x, window.innerWidth - ENDER_W);
+  });
+
+  requestAnimationFrame(loop);
+})();
+</script>
 
 </body>
 </html>

--- a/productivity/index.html
+++ b/productivity/index.html
@@ -103,12 +103,146 @@ color: #bbb;
 letter-spacing: 0.2em;
 text-align: center;
 }
+
+/* ── ENDERMAN ───────────────────────────────────── */
+
+#enderman {
+position: fixed;
+top: 0;
+left: 0;
+z-index: 5;
+pointer-events: none;
+}
+
+.ender-figure {
+display: flex;
+flex-direction: column;
+align-items: center;
+animation: ender-bob 0.7s ease-in-out infinite;
+}
+
+.ender-head {
+width: 11px;
+height: 11px;
+background: linear-gradient(150deg, #1e1e1e 0%, #0c0c0c 100%);
+border-radius: 2px;
+position: relative;
+box-shadow: 0 1px 5px rgba(0,0,0,0.9);
+flex-shrink: 0;
+}
+
+.ender-eye {
+position: absolute;
+width: 2px;
+height: 4px;
+background: #cc00ee;
+top: 3px;
+border-radius: 1px;
+box-shadow: 0 0 4px #cc00ee, 0 0 8px #9900bb;
+}
+.ender-eye.left  { left: 1px; }
+.ender-eye.right { right: 1px; }
+
+.ender-body-wrap {
+display: flex;
+align-items: flex-start;
+margin-top: 1px;
+}
+
+.ender-column {
+display: flex;
+flex-direction: column;
+align-items: center;
+}
+
+.ender-torso {
+width: 8px;
+height: 14px;
+background: linear-gradient(160deg, #2a2a2a 0%, #1a1a1a 40%, #111 100%);
+border-left: 1px solid #333;
+border-right: 1px solid #333;
+box-shadow: inset 1px 0 0 rgba(255,255,255,0.04);
+}
+
+.ender-arm {
+width: 2px;
+height: 28px;
+background: linear-gradient(180deg, #151515, #0a0a0a);
+border-radius: 1px;
+transform-origin: top center;
+}
+.ender-arm.left  { animation: ender-arm-l 1.1s ease-in-out infinite; }
+.ender-arm.right { animation: ender-arm-r 0.9s ease-in-out infinite; }
+
+.ender-legs {
+display: flex;
+gap: 1px;
+margin-top: 0;
+}
+
+.ender-leg {
+width: 2px;
+height: 30px;
+background: linear-gradient(180deg, #111, #080808);
+border-radius: 1px;
+transform-origin: top center;
+}
+.ender-leg.left  { animation: ender-leg-l 0.7s ease-in-out infinite; }
+.ender-leg.right { animation: ender-leg-r 0.7s ease-in-out infinite; }
+
+@keyframes ender-bob {
+  0%, 100% { transform: translateY(0); }
+  50%       { transform: translateY(-2px); }
+}
+@keyframes ender-arm-l {
+  0%   { transform: rotate(-5deg); }
+  40%  { transform: rotate(7deg); }
+  70%  { transform: rotate(2deg); }
+  100% { transform: rotate(-5deg); }
+}
+@keyframes ender-arm-r {
+  0%   { transform: rotate(3deg); }
+  30%  { transform: rotate(-6deg); }
+  65%  { transform: rotate(4deg); }
+  100% { transform: rotate(3deg); }
+}
+@keyframes ender-leg-l {
+  0%, 100% { transform: rotate(-10deg); }
+  50%       { transform: rotate(10deg); }
+}
+@keyframes ender-leg-r {
+  0%, 100% { transform: rotate(10deg); }
+  50%       { transform: rotate(-10deg); }
+}
 </style>
 </head>
 <body>
 
+<!-- ENDERMAN -->
+<div id="enderman">
+  <div class="ender-flip" id="enderFlip">
+    <div class="ender-figure">
+      <div class="ender-head">
+        <div class="ender-eye left"></div>
+        <div class="ender-eye right"></div>
+      </div>
+      <div class="ender-body-wrap">
+        <div class="ender-arm left"></div>
+        <div class="ender-column">
+          <div class="ender-torso"></div>
+          <div class="ender-legs">
+            <div class="ender-leg left"></div>
+            <div class="ender-leg right"></div>
+          </div>
+        </div>
+        <div class="ender-arm right"></div>
+      </div>
+    </div>
+  </div>
+</div>
+
 <header>
-  <h1>PRO<br>DUC<br>TIV</h1>
+  <h1>END<br>ERM<br>ATX</h1>
   <p>productivity</p>
 </header>
 
@@ -116,7 +250,7 @@ text-align: center;
 
   <a class="card" href="../">
     <div class="card-label">&larr;</div>
-    <div class="card-name">endermatx</div>
+    <div class="card-name">back</div>
     <div class="card-arrow">&nbsp;</div>
   </a>
 
@@ -147,6 +281,148 @@ text-align: center;
 </nav>
 
 <footer>matmaxx2317 &middot; github pages</footer>
+
+<script>
+(function() {
+  var ENDER_W = 14;
+  var ENDER_H = 70;
+
+  var enderman = document.getElementById('enderman');
+  var flip     = document.getElementById('enderFlip');
+
+  var x              = 20;
+  var dir            = 1;
+  var teleporting    = false;
+  var last           = null;
+  var sinceLastTport = 0;
+  var nextTport      = randomInterval();
+
+  var currentSpeed   = 30;
+  var targetSpeed    = 30;
+  var sinceSpeedChange = 0;
+  var nextSpeedChange  = randomSpeedInterval();
+
+  function randomInterval() { return 2800 + Math.random() * 2400; }
+  function randomSpeedInterval() { return 600 + Math.random() * 1400; }
+  function randomTargetSpeed() {
+    var r = Math.random();
+    if (r < 0.2) return 0;
+    if (r < 0.5) return 18 + Math.random() * 14;
+    if (r < 0.85) return 45 + Math.random() * 25;
+    return 90 + Math.random() * 40;
+  }
+
+  function positionV() {
+    var rect = document.querySelector('header').getBoundingClientRect();
+    var top  = rect.top + rect.height / 2 - ENDER_H / 2;
+    enderman.style.top = Math.max(8, top) + 'px';
+  }
+
+  var PARTICLE_COLORS = ['#cc00ee','#dd44ff','#9900bb','#ee88ff','#aa00dd'];
+
+  function spawnParticles(px, py, count) {
+    for (var i = 0; i < count; i++) {
+      (function() {
+        var p    = document.createElement('div');
+        var size = 2 + Math.random() * 2.5;
+        var col  = PARTICLE_COLORS[Math.floor(Math.random() * PARTICLE_COLORS.length)];
+        p.style.cssText = 'position:fixed;border-radius:50%;pointer-events:none;z-index:6;' +
+          'width:' + size + 'px;height:' + size + 'px;' +
+          'background:' + col + ';box-shadow:0 0 4px ' + col + ';';
+        document.body.appendChild(p);
+
+        var angle  = Math.random() * Math.PI * 2;
+        var dist   = 18 + Math.random() * 55;
+        var vx     = Math.cos(angle) * dist;
+        var vy     = Math.sin(angle) * dist;
+        var maxLife = 420 + Math.random() * 320;
+        var t0 = null;
+
+        function frame(ts) {
+          if (!t0) t0 = ts;
+          var t = (ts - t0) / maxLife;
+          if (t >= 1) { p.remove(); return; }
+          var e = 1 - (1 - t) * (1 - t);
+          p.style.left    = (px + vx * e) + 'px';
+          p.style.top     = (py + vy * e - 28 * t) + 'px';
+          p.style.opacity = (1 - t).toFixed(3);
+          requestAnimationFrame(frame);
+        }
+        requestAnimationFrame(frame);
+      })();
+    }
+  }
+
+  function enderPos() {
+    return {
+      px: x + ENDER_W / 2,
+      py: parseFloat(enderman.style.top || 0) + ENDER_H / 2
+    };
+  }
+
+  function teleport() {
+    teleporting = true;
+    var from = enderPos();
+    spawnParticles(from.px, from.py, 14);
+    enderman.style.opacity = '0';
+    setTimeout(function() {
+      var maxX = window.innerWidth - ENDER_W;
+      x   = Math.random() * maxX;
+      dir = Math.random() > 0.5 ? 1 : -1;
+      enderman.style.transform = 'translateX(' + x + 'px)';
+      flip.style.transform     = dir === -1 ? 'scaleX(-1)' : 'scaleX(1)';
+      enderman.style.opacity   = '1';
+      var to = enderPos();
+      spawnParticles(to.px, to.py, 14);
+      teleporting    = false;
+      sinceLastTport = 0;
+      nextTport      = randomInterval();
+    }, 200);
+  }
+
+  function step(dt) {
+    if (teleporting) return;
+    sinceLastTport   += dt;
+    sinceSpeedChange += dt;
+
+    if (sinceSpeedChange >= nextSpeedChange) {
+      targetSpeed      = randomTargetSpeed();
+      nextSpeedChange  = randomSpeedInterval();
+      sinceSpeedChange = 0;
+    }
+
+    currentSpeed += (targetSpeed - currentSpeed) * Math.min(1, dt / 180);
+
+    x += dir * currentSpeed * (dt / 1000);
+    var maxX = window.innerWidth - ENDER_W;
+    if (x >= maxX) { x = maxX; dir = -1; flip.style.transform = 'scaleX(-1)'; }
+    if (x <= 0)    { x = 0;    dir =  1; flip.style.transform = 'scaleX(1)';  }
+    enderman.style.transform = 'translateX(' + x + 'px)';
+
+    var walkDur = currentSpeed < 5 ? '9999s' : (1.4 - Math.min(currentSpeed, 130) / 130 * 0.9) + 's';
+    enderman.querySelectorAll('.ender-arm, .ender-leg, .ender-figure').forEach(function(el) {
+      el.style.animationDuration = walkDur;
+    });
+
+    if (sinceLastTport >= nextTport) teleport();
+  }
+
+  function loop(ts) {
+    if (last !== null) step(ts - last);
+    last = ts;
+    requestAnimationFrame(loop);
+  }
+
+  positionV();
+  enderman.style.transform = 'translateX(' + x + 'px)';
+  window.addEventListener('resize', function() {
+    positionV();
+    x = Math.min(x, window.innerWidth - ENDER_W);
+  });
+
+  requestAnimationFrame(loop);
+})();
+</script>
 
 </body>
 </html>

--- a/tts/index.html
+++ b/tts/index.html
@@ -1031,7 +1031,7 @@ function renderGrid() {
     grid.innerHTML = '<div class="empty-state" style="grid-column:1/-1">Add projects below to get started.</div>';
     return;
   }
-  const sorted = active.slice().sort(function(a,b) { return a.name.localeCompare(b.name); });
+  const sorted = active.slice().sort(function(a,b) { return getProjectTotal(b.id) - getProjectTotal(a.id); });
   grid.innerHTML = sorted.map(function(p) {
     const isActive = state.timerRunning && state.activeProjectId === p.id;
     const isInactive = !state.timerRunning;


### PR DESCRIPTION
## Summary

- **#16 (bug)** — Back cards on `productivity/`, `personal/`, and `games/` now read `back` instead of `endermatx`
- **#15 (bug)** — Category pages (`productivity/`, `personal/`, `games/`) now show the `END / ERM / ATX` site header with the full enderman animation instead of auto-generated text like `PRO / DUC / TIV`
- **#17 (enhancement)** — TTS project cards are now sorted by total logged time descending (highest first) instead of alphabetically

## Test plan

- [ ] Open `productivity/index.html` — header reads END/ERM/ATX, enderman walks across, back card reads "back"
- [ ] Open `personal/index.html` — same checks
- [ ] Open `games/index.html` — same checks
- [ ] Open `tts/index.html`, log time on several projects, confirm cards re-order so the most-time project is first

https://claude.ai/code/session_01AjD1yhr1JD8sUtW6h9XMPF

---
_Generated by [Claude Code](https://claude.ai/code/session_01AjD1yhr1JD8sUtW6h9XMPF)_