### PR TITLE
tts: adjust context-switch time + test mode

### DIFF
--- a/tts/index.html
+++ b/tts/index.html
@@ -794,6 +794,10 @@ letter-spacing: 0.05em;
   </div>
 </div>
 
+<div style="width:100%;max-width:560px;margin-top:48px;padding-top:24px;border-top:1px solid #1a1a1a;display:flex;justify-content:center;">
+  <button class="btn-ghost" style="font-size:10px;letter-spacing:0.15em;color:#555;border-color:#1e1e1e;" onclick="resetAllEntries()">RESET ALL LOGGED TIMES</button>
+</div>
+
 <script>
 const COLORS = [
   '#7effa0','#ff6b6b','#6bb5ff','#ffd56b','#d06bff',
@@ -1182,6 +1186,15 @@ function deleteEntry(id) {
   schedulePush();
   renderLog();
   renderReport();
+}
+
+function resetAllEntries() {
+  if (!confirm('Delete all logged time entries? This cannot be undone.')) return;
+  state.entries = [];
+  schedulePush();
+  renderLog();
+  renderReport();
+  renderGrid();
 }
 
 // ---- REPORT ----

--- a/tts/index.html
+++ b/tts/index.html
@@ -491,6 +491,19 @@ margin-bottom: 16px;
 
 .adjust-project-label strong { font-weight: normal; }
 
+/* FICTIONAL CLOCK */
+#fictionalClock {
+font-size: 12px;
+letter-spacing: 0.2em;
+color: #888;
+margin-bottom: 12px;
+font-variant-numeric: tabular-nums;
+text-align: center;
+display: none;
+}
+
+#fictionalClock .fclock-time { color: #ffd56b; }
+
 /* SWITCHES */
 .switches-row {
 display: flex;
@@ -761,6 +774,8 @@ letter-spacing: 0.05em;
   <button class="btn-control start" id="btnControl" onclick="toggleTimer()">START</button>
 </div>
 
+<div id="fictionalClock">fictional &nbsp;<span class="fclock-time" id="fclockTime">00:00</span></div>
+
 <div class="active-indicator" id="activeIndicator">&#8212;</div>
 
 <div class="projects-grid" id="projectsGrid"></div>
@@ -794,8 +809,9 @@ letter-spacing: 0.05em;
   </div>
 </div>
 
-<div style="width:100%;max-width:560px;margin-top:48px;padding-top:24px;border-top:1px solid #1a1a1a;display:flex;justify-content:center;">
+<div style="width:100%;max-width:560px;margin-top:48px;padding-top:24px;border-top:1px solid #1a1a1a;display:flex;flex-direction:column;align-items:center;gap:10px;">
   <button class="btn-ghost" style="font-size:10px;letter-spacing:0.15em;color:#555;border-color:#1e1e1e;" onclick="resetAllEntries()">RESET ALL LOGGED TIMES</button>
+  <button class="btn-ghost" id="testModeBtn" style="font-size:10px;letter-spacing:0.15em;color:#555;border-color:#1e1e1e;" onclick="toggleTestMode()">TEST MODE: OFF</button>
 </div>
 
 <script>
@@ -825,6 +841,39 @@ let gistToken = '';
 let gistId = '';
 let tickInterval = null;
 let syncTimeout = null;
+let testMode = localStorage.getItem('tt_testmode') === '1';
+
+const TEST_MULTIPLIER = 600; // 1 real second = 10 fictional minutes
+
+function fictionalNow() {
+  if (!testMode || !state.timerStart) return Date.now();
+  return state.timerStart + (Date.now() - state.timerStart) * TEST_MULTIPLIER;
+}
+
+function fictionalTs(realTs) {
+  if (!testMode || !state.timerStart) return realTs;
+  return state.timerStart + (realTs - state.timerStart) * TEST_MULTIPLIER;
+}
+
+function realFromFictional(fictTs) {
+  if (!testMode || !state.timerStart) return fictTs;
+  return state.timerStart + (fictTs - state.timerStart) / TEST_MULTIPLIER;
+}
+
+// Converts fictional HH:MM entered by the user into a real timestamp.
+function fictionalHMToReal(h, m) {
+  if (!testMode || !state.timerStart) {
+    const n = new Date();
+    return new Date(n.getFullYear(), n.getMonth(), n.getDate(), h, m, 0, 0).getTime();
+  }
+  const fd = new Date(fictionalNow());
+  const fictTs = new Date(fd.getFullYear(), fd.getMonth(), fd.getDate(), h, m, 0, 0).getTime();
+  return realFromFictional(fictTs);
+}
+
+function formatTimeDisplay(ts) {
+  return formatTime(testMode && state.timerStart ? fictionalTs(ts) : ts);
+}
 
 function loadCredentials() {
   gistToken = localStorage.getItem('tt_token') || '';
@@ -976,6 +1025,7 @@ function stopAll() {
   updateIndicator();
   document.getElementById('timerDisplay').classList.remove('running');
   document.getElementById('timerDisplay').textContent = '00:00:00';
+  document.getElementById('fictionalClock').style.display = 'none';
   renderGrid();
   renderLog();
   renderReport();
@@ -994,12 +1044,13 @@ function selectProject(id) {
 
 function openAdjustModal() {
   const p = getProject(state.activeProjectId);
-  const t = new Date(state.activeSegmentStart);
+  const displayTs = testMode ? fictionalTs(state.activeSegmentStart) : state.activeSegmentStart;
+  const t = new Date(displayTs);
   const timeStr = pad(t.getHours()) + ':' + pad(t.getMinutes());
   document.getElementById('adjustTimeInput').value = timeStr;
   document.getElementById('adjustModalDesc').innerHTML =
-    'Tracking <strong style="color:' + p.color + '">' + escHtml(p.name) + '</strong> since ' + timeStr +
-    '. Set the actual start time of this segment.';
+    'Tracking <strong style="color:' + p.color + '">' + escHtml(p.name) + '</strong> since ' +
+    (testMode ? 'fictional ' : '') + timeStr + '. Set the actual start time of this segment.';
   document.getElementById('adjustModal').classList.add('active');
 }
 
@@ -1011,28 +1062,31 @@ function confirmAdjust() {
   const input = document.getElementById('adjustTimeInput').value;
   if (!input) return;
   const [h, m] = input.split(':').map(Number);
-  const now = new Date();
-  const newTime = new Date(now.getFullYear(), now.getMonth(), now.getDate(), h, m, 0, 0).getTime();
+  // Convert the entered time (fictional in test mode, real otherwise) to a real timestamp.
+  const newTime = fictionalHMToReal(h, m);
 
   if (newTime >= Date.now()) { alert('Time must be in the past.'); return; }
   if (state.timerStart && newTime < state.timerStart) { alert('Time cannot be before the timer started.'); return; }
 
   const oldSegmentStart = state.activeSegmentStart;
-  const deltaSec = Math.round((newTime - oldSegmentStart) / 1000);
+  const deltaRealMs = newTime - oldSegmentStart;
+  // Duration units match whatever flushSegment stored (fictional secs in test mode, real secs otherwise).
+  const deltaStoredSec = Math.round(deltaRealMs / 1000) * (testMode ? TEST_MULTIPLIER : 1);
 
-  // Patch the preceding entry: its effective end time was oldSegmentStart
+  // Preceding entry's real end time = start + duration / multiplier * 1000
+  const mult = testMode ? TEST_MULTIPLIER : 1;
   const tolerance = 5000;
   const preceding = state.entries
     .filter(function(e) {
-      return Math.abs((e.start + e.duration * 1000) - oldSegmentStart) <= tolerance;
+      return Math.abs((e.start + (e.duration / mult) * 1000) - oldSegmentStart) <= tolerance;
     })
     .sort(function(a, b) {
-      return Math.abs((a.start + a.duration * 1000) - oldSegmentStart) -
-             Math.abs((b.start + b.duration * 1000) - oldSegmentStart);
+      return Math.abs((a.start + (a.duration / mult) * 1000) - oldSegmentStart) -
+             Math.abs((b.start + (b.duration / mult) * 1000) - oldSegmentStart);
     })[0];
 
   if (preceding) {
-    const newDuration = preceding.duration + deltaSec;
+    const newDuration = preceding.duration + deltaStoredSec;
     if (newDuration <= 0) { alert('Time too early — would make the previous segment duration zero or negative.'); return; }
     preceding.duration = newDuration;
   }
@@ -1048,7 +1102,8 @@ function confirmAdjust() {
 
 function flushSegment() {
   if (state.activeProjectId && state.activeSegmentStart) {
-    const dur = Math.floor((Date.now() - state.activeSegmentStart) / 1000);
+    const realSec = (Date.now() - state.activeSegmentStart) / 1000;
+    const dur = Math.floor(testMode ? realSec * TEST_MULTIPLIER : realSec);
     if (dur >= 2) {
       state.entries.push({
         id: Date.now() + Math.random(),
@@ -1062,10 +1117,19 @@ function flushSegment() {
 
 function tick() {
   if (!state.timerStart) return;
-  const elapsed = Math.floor((Date.now() - state.timerStart) / 1000);
+  const realElapsed = (Date.now() - state.timerStart) / 1000;
+  const elapsed = Math.floor(testMode ? realElapsed * TEST_MULTIPLIER : realElapsed);
   const el = document.getElementById('timerDisplay');
   el.textContent = formatDuration(elapsed);
   el.classList.add('running');
+  const fc = document.getElementById('fictionalClock');
+  if (testMode) {
+    const fd = new Date(fictionalNow());
+    document.getElementById('fclockTime').textContent = pad(fd.getHours()) + ':' + pad(fd.getMinutes());
+    fc.style.display = 'block';
+  } else {
+    fc.style.display = 'none';
+  }
   updateGridTimes();
 }
 
@@ -1143,7 +1207,8 @@ function getProjectTotal(id) {
   let total = state.entries.filter(function(e) { return e.projectId === id; })
     .reduce(function(s, e) { return s + e.duration; }, 0);
   if (state.timerRunning && state.activeProjectId === id && state.activeSegmentStart) {
-    total += Math.floor((Date.now() - state.activeSegmentStart) / 1000);
+    const realSec = (Date.now() - state.activeSegmentStart) / 1000;
+    total += Math.floor(testMode ? realSec * TEST_MULTIPLIER : realSec);
   }
   return total;
 }
@@ -1174,7 +1239,7 @@ function renderLog() {
     return '<div class="log-entry">' +
       '<div class="log-dot" style="background:' + p.color + '"></div>' +
       '<div class="log-info"><div class="log-project">' + escHtml(p.name) + '</div>' +
-      '<div class="log-meta">' + formatTime(e.start) + '</div></div>' +
+      '<div class="log-meta">' + formatTimeDisplay(e.start) + '</div></div>' +
       '<div class="log-duration">' + formatDurationShort(e.duration) + '</div>' +
       '<button class="log-delete" onclick="deleteEntry(' + e.id + ')">&#215;</button>' +
       '</div>';
@@ -1195,6 +1260,16 @@ function resetAllEntries() {
   renderLog();
   renderReport();
   renderGrid();
+}
+
+function toggleTestMode() {
+  if (state.timerRunning) { alert('Stop the timer before toggling test mode.'); return; }
+  testMode = !testMode;
+  localStorage.setItem('tt_testmode', testMode ? '1' : '0');
+  const btn = document.getElementById('testModeBtn');
+  btn.textContent = 'TEST MODE: ' + (testMode ? 'ON' : 'OFF');
+  btn.style.color = testMode ? '#ffd56b' : '#555';
+  btn.style.borderColor = testMode ? '#ffd56b' : '#1e1e1e';
 }
 
 // ---- REPORT ----
@@ -1584,6 +1659,13 @@ function escHtml(s) {
 
 async function init() {
   loadCredentials();
+  // Reflect persisted test mode state on the button.
+  if (testMode) {
+    const btn = document.getElementById('testModeBtn');
+    btn.textContent = 'TEST MODE: ON';
+    btn.style.color = '#ffd56b';
+    btn.style.borderColor = '#ffd56b';
+  }
   if (state.projects.length === 0) {
     DEFAULTS.forEach(function(name, i) {
       state.projects.push({ id: Date.now() + i, name: name, color: COLORS[i % COLORS.length] });


### PR DESCRIPTION
## Summary

- **Adjust switch time modal** — clicking the active project card while the timer is running opens a modal to correct the segment start time (HH:MM). Applying the new time also patches the preceding flushed entry's duration so both sides of the boundary stay consistent.
- **Reset all logged times** — button at the bottom of the page clears all entries after a confirmation prompt and syncs to Gist.
- **Test mode** — toggle at the bottom (persisted in localStorage) runs the tracker at 600× speed (1 real second = 10 fictional minutes). The timer display, project totals, flushed durations, and the adjust modal all operate in fictional time. A fictional wall-clock (`HH:MM`) is shown below the running timer when test mode is active. The toggle is disabled while the timer is running to prevent mixing real and fictional durations.

## Test plan

- [x] Start timer, switch to a project, switch to another — confirm segments flush correctly
- [ ] Click the active project card — confirm the adjust modal opens pre-filled with the current segment start
- [ ] Change the time to an earlier value — confirm the active segment and the preceding log entry both update correctly
- [ ] Try invalid times (future, before timer start, too early to make preceding entry negative) — confirm error alerts
- [ ] Click "Reset all logged times" — confirm prompt appears and entries are cleared
- [ ] Enable test mode while timer is stopped — confirm button turns yellow
- [ ] Start timer in test mode — confirm timer display and project totals tick at 600× speed, fictional clock appears
- [ ] Switch projects in test mode, then click active card — confirm adjust modal shows fictional time and patching works
- [ ] Stop timer, disable test mode — confirm fictional clock hides and button resets

https://claude.ai/code/session_012ER1pqj2SSn3wLyphjVQNc

---
_Generated by [Claude Code](https://claude.ai/code/session_012ER1pqj2SSn3wLyphjVQNc)_