### PR TITLE
tts v1.4: fix broken state after merge sync + remove default projects

### DIFF
--- a/tts/index.html
+++ b/tts/index.html
@@ -981,7 +981,7 @@ transition: background 0.1s;
 
 <!-- APP -->
 
-<h1>tts<span style="font-size:10px;color:#bbb;margin-left:8px;letter-spacing:0.05em;text-transform:none;font-weight:normal">v1.2</span></h1>
+<h1>tts<span style="font-size:10px;color:#bbb;margin-left:8px;letter-spacing:0.05em;text-transform:none;font-weight:normal">v1.3</span></h1>
 
 <div class="top-bar">
   <div class="timer-display" id="timerDisplay">00:00:00</div>
@@ -1174,28 +1174,43 @@ async function setupConnect() {
 // ---- GIST SYNC ----
 
 // Merge two states without data loss.
-// Entries and projects are unioned by ID.
-// Timer state: most recently changed (timerUpdatedAt) wins, so both devices
-// see whichever device last started/stopped/switched the recording.
+// Entries and projects are unioned by ID, with tombstones and a clearedAt
+// timestamp to honour intentional deletions on either device.
 function mergeStates(local, remote) {
+  // Combine tombstones from both sides so deletions propagate everywhere.
+  const delEntries  = new Set([...(local.deletedEntryIds  || []), ...(remote.deletedEntryIds  || [])]);
+  const delProjects = new Set([...(local.deletedProjectIds || []), ...(remote.deletedProjectIds || [])]);
+  const clearedAt   = Math.max(local.clearedAt || 0, remote.clearedAt || 0);
+
+  // Entries: union by ID, skip tombstoned and pre-clear entries.
   const entryById = {};
-  (remote.entries || []).forEach(function(e) { entryById[e.id] = e; });
-  (local.entries || []).forEach(function(e) { entryById[e.id] = e; });
+  (remote.entries || []).forEach(function(e) {
+    if (!delEntries.has(e.id) && e.start > clearedAt) entryById[e.id] = e;
+  });
+  (local.entries || []).forEach(function(e) {
+    if (!delEntries.has(e.id) && e.start > clearedAt) entryById[e.id] = e;
+  });
   const entries = Object.values(entryById).sort(function(a, b) { return a.start - b.start; });
 
+  // Projects: union by ID, skip tombstoned. Local wins on conflict (preserves
+  // renames, colour changes, archived status set on this device).
   const projById = {};
-  (remote.projects || []).forEach(function(p) { projById[p.id] = p; });
-  (local.projects || []).forEach(function(p) { projById[p.id] = p; });
+  (remote.projects || []).forEach(function(p) { if (!delProjects.has(p.id)) projById[p.id] = p; });
+  (local.projects  || []).forEach(function(p) { if (!delProjects.has(p.id)) projById[p.id] = p; });
   const projects = Object.values(projById).sort(function(a, b) { return a.name.localeCompare(b.name); });
 
+  // Timer: most recently changed wins.
   const useRemote = (remote.timerUpdatedAt || 0) > (local.timerUpdatedAt || 0);
   return {
     projects: projects,
     entries: entries,
-    timerRunning: useRemote ? remote.timerRunning : local.timerRunning,
-    timerStart: useRemote ? remote.timerStart : local.timerStart,
-    timerUpdatedAt: Math.max(local.timerUpdatedAt || 0, remote.timerUpdatedAt || 0) || null,
-    activeProjectId: useRemote ? remote.activeProjectId : local.activeProjectId,
+    deletedEntryIds:  Array.from(delEntries),
+    deletedProjectIds: Array.from(delProjects),
+    clearedAt: clearedAt || null,
+    timerRunning:       useRemote ? remote.timerRunning       : local.timerRunning,
+    timerStart:         useRemote ? remote.timerStart         : local.timerStart,
+    timerUpdatedAt:     Math.max(local.timerUpdatedAt || 0, remote.timerUpdatedAt || 0) || null,
+    activeProjectId:    useRemote ? remote.activeProjectId    : local.activeProjectId,
     activeSegmentStart: useRemote ? remote.activeSegmentStart : local.activeSegmentStart,
     reportMode: local.reportMode || remote.reportMode || 'week'
   };
@@ -1670,6 +1685,7 @@ function renderLog() {
 
 function deleteEntry(id) {
   state.entries = state.entries.filter(function(e) { return e.id !== id; });
+  state.deletedEntryIds = (state.deletedEntryIds || []).concat([id]);
   schedulePush();
   renderLog();
   renderReport();
@@ -1678,7 +1694,11 @@ function deleteEntry(id) {
 
 function resetAllEntries() {
   if (!confirm('Delete all logged time entries and remove archived projects? This cannot be undone.')) return;
+  state.deletedEntryIds = (state.deletedEntryIds || []).concat(state.entries.map(function(e) { return e.id; }));
   state.entries = [];
+  state.clearedAt = Date.now();
+  const archivedIds = state.projects.filter(function(p) { return p.archived; }).map(function(p) { return p.id; });
+  state.deletedProjectIds = (state.deletedProjectIds || []).concat(archivedIds);
   state.projects = state.projects.filter(function(p) { return !p.archived; });
   schedulePush();
   renderLog();
@@ -2102,6 +2122,7 @@ function archiveOrDeleteProject(id) {
     var p = state.projects.find(function(p) { return p.id === id; });
     if (p) { p.archived = true; }
   } else {
+    state.deletedProjectIds = (state.deletedProjectIds || []).concat([id]);
     state.projects = state.projects.filter(function(p) { return p.id !== id; });
   }
   schedulePush();
@@ -2379,7 +2400,9 @@ async function init() {
     btn.style.borderColor = '#ffd56b';
     document.getElementById('timerDisplay').classList.add('test');
   }
-  if (state.projects.length === 0) {
+  // Only seed defaults when there's no gist to pull from; if a gist is
+  // configured we wait for the pull so defaults don't get merged with remote.
+  if (state.projects.length === 0 && (!gistToken || !gistId)) {
     DEFAULTS.forEach(function(name, i) {
       state.projects.push({ id: Date.now() + i, name: name, color: COLORS[i % COLORS.length] });
     });
@@ -2389,6 +2412,12 @@ async function init() {
     setSyncStatus('syncing', 'Loading...');
     try {
       await pullFromGist();
+      // If the gist was empty (new setup), seed defaults now.
+      if (state.projects.length === 0) {
+        DEFAULTS.forEach(function(name, i) {
+          state.projects.push({ id: Date.now() + i, name: name, color: COLORS[i % COLORS.length] });
+        });
+      }
       setSyncStatus('synced', 'Synced');
       setTimeout(function() { setSyncStatus('', 'Ready'); }, 2000);
       renderAll();

--- a/tts/index.html
+++ b/tts/index.html
@@ -981,7 +981,7 @@ transition: background 0.1s;
 
 <!-- APP -->
 
-<h1>tts<span style="font-size:10px;color:#bbb;margin-left:8px;letter-spacing:0.05em;text-transform:none;font-weight:normal">v1.3</span></h1>
+<h1>tts<span style="font-size:10px;color:#bbb;margin-left:8px;letter-spacing:0.05em;text-transform:none;font-weight:normal">v1.4</span></h1>
 
 <div class="top-bar">
   <div class="timer-display" id="timerDisplay">00:00:00</div>
@@ -1041,7 +1041,6 @@ const COLORS = [
   '#ff9f6b','#6bfff0','#ff6bd6','#b5ff6b','#6b7fff'
 ];
 
-const DEFAULTS = ['orga','docs','meet','offs','code'];
 
 const DAY_LABELS = ['Mon','Tue','Wed','Thu','Fri','Sat','Sun'];
 
@@ -2400,24 +2399,11 @@ async function init() {
     btn.style.borderColor = '#ffd56b';
     document.getElementById('timerDisplay').classList.add('test');
   }
-  // Only seed defaults when there's no gist to pull from; if a gist is
-  // configured we wait for the pull so defaults don't get merged with remote.
-  if (state.projects.length === 0 && (!gistToken || !gistId)) {
-    DEFAULTS.forEach(function(name, i) {
-      state.projects.push({ id: Date.now() + i, name: name, color: COLORS[i % COLORS.length] });
-    });
-  }
   renderAll();
   if (gistToken && gistId) {
     setSyncStatus('syncing', 'Loading...');
     try {
       await pullFromGist();
-      // If the gist was empty (new setup), seed defaults now.
-      if (state.projects.length === 0) {
-        DEFAULTS.forEach(function(name, i) {
-          state.projects.push({ id: Date.now() + i, name: name, color: COLORS[i % COLORS.length] });
-        });
-      }
       setSyncStatus('synced', 'Synced');
       setTimeout(function() { setSyncStatus('', 'Ready'); }, 2000);
       renderAll();


### PR DESCRIPTION
## What's in here

### Fix: projects doubled, deletions/reset undone (v1.3)

The merge-based sync introduced three bugs:

**1. Projects shown twice** — defaults were seeded before the initial Gist pull, so `mergeStates()` unioned them with remote projects (different IDs, same names → duplicates). Fixed by deferring seeding until after the pull.

**2. Deleted projects reappeared** — no way to distinguish "never existed here" from "intentionally deleted". Fixed with a `deletedProjectIds` tombstone array; `archiveOrDeleteProject()` appends to it and `mergeStates()` skips tombstoned IDs.

**3. Reset undone by remote** — entries came back from the remote Gist after reset. Fixed with `deletedEntryIds` tombstones + a `clearedAt` timestamp; `mergeStates()` skips entries before `clearedAt` and any tombstoned entry ID. Both arrays sync across devices so deletions propagate within 10 s.

### Remove default projects (v1.4)

New installs now start with an empty project list instead of orga/docs/meet/offs/code.

## Test plan
- [ ] Fresh load with Gist → projects appear once, not twice
- [ ] Archive a project → stays archived after background sync
- [ ] Delete a project → doesn't reappear
- [ ] Delete a log entry → doesn't reappear
- [ ] Reset → entries gone, don't come back from the other device
- [ ] New install → empty project list

https://claude.ai/code/session_012ER1pqj2SSn3wLyphjVQNc

---
_Generated by [Claude Code](https://claude.ai/code/session_012ER1pqj2SSn3wLyphjVQNc)_