### PR TITLE
fix: idx kill ghost-tap + button label alignment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,7 +126,7 @@ Every subproject displays its version next to its title — small (`font-size:10
 | cal  | `productivity/cal/index.html` | v1.3 |
 | pom  | `productivity/pom/index.html` | v1.0 |
 | mtg  | `productivity/mtg/index.html` | v1.0 |
-| idx  | `productivity/idx/index.html` | v1.3 |
+| idx  | `productivity/idx/index.html` | v1.4 |
 | str  | `personal/str/index.html` | v1.0 |
 | crd  | `personal/crd/index.html` | v1.0 |
 | teleport-tap | `games/teleport-tap/index.html` | v1.0 |

--- a/productivity/idx/index.html
+++ b/productivity/idx/index.html
@@ -185,7 +185,7 @@ body {
 <div id="syncBar">
   <div class="left">
     <span class="name">idx</span>
-    <span class="ver">v1.3</span>
+    <span class="ver">v1.4</span>
   </div>
   <div style="display:flex;align-items:center;gap:10px;">
     <div id="syncStatus"><span class="dot" id="syncDot"></span><span id="syncText">not connected</span></div>
@@ -326,12 +326,12 @@ function render() {
     var actions;
     if (currentView === 'inbox') {
       actions =
-        '<button class="act promote" onclick="promote(' + idea.id + ')">promote</button>' +
-        '<button class="act defer"   onclick="defer('   + idea.id + ')">defer</button>'   +
+        '<button class="act promote" onclick="promote(' + idea.id + ')">DO</button>' +
+        '<button class="act defer"   onclick="defer('   + idea.id + ')">BL</button>'  +
         '<button class="act kill"    onclick="kill('    + idea.id + ')">kill</button>';
     } else if (currentView === 'deferred') {
       actions =
-        '<button class="act promote" onclick="promote(' + idea.id + ')">promote</button>' +
+        '<button class="act promote" onclick="promote(' + idea.id + ')">DO</button>' +
         '<button class="act kill"    onclick="kill('    + idea.id + ')">kill</button>';
     } else {
       actions = '<button class="act kill" onclick="kill(' + idea.id + ')">kill</button>';
@@ -379,18 +379,34 @@ function defer(id) {
 
 function kill(id) {
   var el = document.getElementById('idea-' + id);
-  if (el) {
-    el.classList.add('killing');
+  if (!el) {
+    state.ideas = state.ideas.filter(function(i) { return i.id !== id; });
+    render(); schedulePush();
+    return;
+  }
+  el.classList.add('killing');
+  setTimeout(function() {
+    // collapse height after fade so the list slides up instead of jumping
+    var h = el.offsetHeight;
+    el.style.height = h + 'px';
+    el.style.overflow = 'hidden';
+    el.offsetHeight; // force reflow
+    el.style.transition = 'height 0.15s ease, padding-top 0.15s ease, padding-bottom 0.15s ease';
+    el.style.height = '0';
+    el.style.paddingTop = '0';
+    el.style.paddingBottom = '0';
     setTimeout(function() {
       state.ideas = state.ideas.filter(function(i) { return i.id !== id; });
       render();
       schedulePush();
-    }, 170);
-  } else {
-    state.ideas = state.ideas.filter(function(i) { return i.id !== id; });
-    render();
-    schedulePush();
-  }
+      // block ghost taps on newly positioned buttons
+      var list = document.getElementById('list');
+      if (list) {
+        list.style.pointerEvents = 'none';
+        setTimeout(function() { list.style.pointerEvents = ''; }, 400);
+      }
+    }, 160);
+  }, 150);
 }
 
 function startEdit(id) {


### PR DESCRIPTION
## Summary
- Kill animation now fades the item first (150ms), then smoothly collapses its height (150ms) so the list slides up gradually instead of jumping — preventing the next kill button from teleporting under your finger
- After render, `pointer-events` on the list is locked for 400ms to absorb any stray ghost taps on mobile
- Action buttons renamed to match tab labels: **DO** (promote) and **BL** (defer)

## Test plan
- [ ] Kill an idea on mobile — next item should slide up smoothly, not jump
- [ ] Rapidly kill multiple ideas — no accidental double-kills
- [ ] DO and BL buttons move ideas to the correct tabs

---
_Generated by [Claude Code](https://claude.ai/code/session_01VZfx9eqRhRxfDkAogdg5ZR)_