### PR TITLE
fix: idx iOS input zoom

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,7 +126,7 @@ Every subproject displays its version next to its title — small (`font-size:10
 | cal  | `productivity/cal/index.html` | v1.3 |
 | pom  | `productivity/pom/index.html` | v1.0 |
 | mtg  | `productivity/mtg/index.html` | v1.0 |
-| idx  | `productivity/idx/index.html` | v1.4 |
+| idx  | `productivity/idx/index.html` | v1.5 |
 | str  | `personal/str/index.html` | v1.0 |
 | crd  | `personal/crd/index.html` | v1.0 |
 | teleport-tap | `games/teleport-tap/index.html` | v1.0 |

--- a/productivity/idx/index.html
+++ b/productivity/idx/index.html
@@ -96,7 +96,7 @@ body {
   color: #e0e0e0;
   padding: 10px 12px;
   font-family: 'Courier New', Courier, monospace;
-  font-size: 14px;
+  font-size: 16px;
   outline: none;
 }
 #captureInput:focus { border-color: #8855ff; }
@@ -167,7 +167,7 @@ body {
   color: #e0e0e0;
   padding: 3px 6px;
   font-family: 'Courier New', Courier, monospace;
-  font-size: 13px;
+  font-size: 16px;
   outline: none;
 }
 
@@ -185,7 +185,7 @@ body {
 <div id="syncBar">
   <div class="left">
     <span class="name">idx</span>
-    <span class="ver">v1.4</span>
+    <span class="ver">v1.5</span>
   </div>
   <div style="display:flex;align-items:center;gap:10px;">
     <div id="syncStatus"><span class="dot" id="syncDot"></span><span id="syncText">not connected</span></div>


### PR DESCRIPTION
## Summary
- Bumps all inputs (`#captureInput`, `.idea-edit`, modal inputs) to `font-size: 16px`
- iOS Safari auto-zooms on focus when font-size < 16px; this is the correct threshold to suppress it without touching `user-scalable`

## Test plan
- [ ] Tap the capture input on iPhone — no zoom
- [ ] Tap an inbox idea to edit — no zoom
- [ ] Open Setup modal and tap token field — no zoom

---
_Generated by [Claude Code](https://claude.ai/code/session_01VZfx9eqRhRxfDkAogdg5ZR)_