### PR TITLE
feat: idx DONE state + persistent kill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ Each tool keeps a single `state` (or `data`) object in memory. Mutations happen 
 - **cal** (`productivity/cal/`) — Calendar. Month tiles across a configurable date range. Project timelines overlaid as colored date ranges. Holiday overlays for DE, AT, US, GB, FR, CN, JP (computed via Easter algorithm + fixed dates).
 - **pom** (`productivity/pom/`) — Pomodoro. 25-min work / 5-min break cycles. Timer state persists to Gist every 60 ticks so it survives page reloads. Snarky message pool in `MESSAGES` object, randomized via `pick()`.
 - **mtg** (`productivity/mtg/`) — Meeting notes. Meetings with title, date, attendees, freeform notes, and action items. "Summarize" generates a plain-text summary locally (no AI). Cross-meeting actions view with open/done/all filter.
-- **idx** (`productivity/idx/`) — Idea inbox. Frictionless capture (one input, Enter to log). Three views: Inbox, Promoted, Deferred — each with a counter. Actions per status: inbox → promote / defer / kill; deferred → promote / kill; promoted → kill. Click an inbox item to edit it inline. Ideas never demoted once promoted. Gist-synced.
+- **idx** (`productivity/idx/`) — Idea inbox. Frictionless capture (one input, Enter to log). Three views: IN / DO / BL — each with a counter. Statuses: `inbox`, `promoted` (DO), `deferred` (BL), `done`, `killed`. Transitions: IN→DO, IN→BL, BL→DO, DO→DONE, any→killed. Done and killed ideas are hidden from UI but kept in Gist for future stats. Click an inbox item to edit it inline. Ideas never demoted once promoted. Gist-synced.
 
 ### Personal (`personal/`)
 
@@ -126,7 +126,7 @@ Every subproject displays its version next to its title — small (`font-size:10
 | cal  | `productivity/cal/index.html` | v1.3 |
 | pom  | `productivity/pom/index.html` | v1.0 |
 | mtg  | `productivity/mtg/index.html` | v1.0 |
-| idx  | `productivity/idx/index.html` | v1.5 |
+| idx  | `productivity/idx/index.html` | v1.6 |
 | str  | `personal/str/index.html` | v1.0 |
 | crd  | `personal/crd/index.html` | v1.0 |
 | teleport-tap | `games/teleport-tap/index.html` | v1.0 |

--- a/productivity/idx/index.html
+++ b/productivity/idx/index.html
@@ -158,6 +158,7 @@ body {
 .act:hover              { border-color: #555; color: #ccc; }
 .act.promote:hover      { border-color: #8855ff; color: #8855ff; }
 .act.defer:hover        { border-color: #886600; color: #ccaa00; }
+.act.done:hover         { border-color: #226644; color: #44cc88; }
 .act.kill:hover         { border-color: #882222; color: #ff5555; }
 
 .idea-edit {
@@ -185,7 +186,7 @@ body {
 <div id="syncBar">
   <div class="left">
     <span class="name">idx</span>
-    <span class="ver">v1.5</span>
+    <span class="ver">v1.6</span>
   </div>
   <div style="display:flex;align-items:center;gap:10px;">
     <div id="syncStatus"><span class="dot" id="syncDot"></span><span id="syncText">not connected</span></div>
@@ -334,7 +335,9 @@ function render() {
         '<button class="act promote" onclick="promote(' + idea.id + ')">DO</button>' +
         '<button class="act kill"    onclick="kill('    + idea.id + ')">kill</button>';
     } else {
-      actions = '<button class="act kill" onclick="kill(' + idea.id + ')">kill</button>';
+      actions =
+        '<button class="act done" onclick="done(' + idea.id + ')">DONE</button>' +
+        '<button class="act kill" onclick="kill(' + idea.id + ')">kill</button>';
     }
 
     var textAttrs = currentView === 'inbox'
@@ -377,29 +380,23 @@ function defer(id) {
   if (idea) { idea.status = 'deferred'; render(); schedulePush(); }
 }
 
-function kill(id) {
+function animateRemove(id, onComplete) {
   var el = document.getElementById('idea-' + id);
-  if (!el) {
-    state.ideas = state.ideas.filter(function(i) { return i.id !== id; });
-    render(); schedulePush();
-    return;
-  }
+  if (!el) { onComplete(); render(); schedulePush(); return; }
   el.classList.add('killing');
   setTimeout(function() {
-    // collapse height after fade so the list slides up instead of jumping
     var h = el.offsetHeight;
     el.style.height = h + 'px';
     el.style.overflow = 'hidden';
-    el.offsetHeight; // force reflow
+    el.offsetHeight;
     el.style.transition = 'height 0.15s ease, padding-top 0.15s ease, padding-bottom 0.15s ease';
     el.style.height = '0';
     el.style.paddingTop = '0';
     el.style.paddingBottom = '0';
     setTimeout(function() {
-      state.ideas = state.ideas.filter(function(i) { return i.id !== id; });
+      onComplete();
       render();
       schedulePush();
-      // block ghost taps on newly positioned buttons
       var list = document.getElementById('list');
       if (list) {
         list.style.pointerEvents = 'none';
@@ -407,6 +404,16 @@ function kill(id) {
       }
     }, 160);
   }, 150);
+}
+
+function kill(id) {
+  var idea = state.ideas.find(function(i) { return i.id === id; });
+  if (idea) animateRemove(id, function() { idea.status = 'killed'; });
+}
+
+function done(id) {
+  var idea = state.ideas.find(function(i) { return i.id === id; });
+  if (idea) animateRemove(id, function() { idea.status = 'done'; });
 }
 
 function startEdit(id) {


### PR DESCRIPTION
## Summary
- DO ideas now have a **DONE** button — fades out with the same animation as kill, but sets `status: 'done'` in the gist instead of disappearing
- Kill no longer deletes the idea from state — sets `status: 'killed'` so it persists in the gist
- Both `done` and `killed` ideas are invisible in all three tab views but survive in the gist for future stats
- Extracted shared `animateRemove(id, onComplete)` helper — kill and done reuse the same fade+collapse+ghost-tap logic

## State transitions
- IN → DO → DONE
- IN → BL → DO
- any → killed

## Test plan
- [x] Mark a DO idea as DONE — fades out, disappears from DO tab, gist still contains it with `status: "done"`
- [x] Kill an idea — fades out, gist still contains it with `status: "killed"`
- [x] Reload page — done and killed ideas do not reappear in any tab

---
_Generated by [Claude Code](https://claude.ai/code/session_01VZfx9eqRhRxfDkAogdg5ZR)_