### PR TITLE
feat: idx KILL button redesign + remove DO/DONE buttons

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,7 +126,7 @@ Every subproject displays its version next to its title — small (`font-size:10
 | cal  | `productivity/cal/index.html` | v1.3 |
 | pom  | `productivity/pom/index.html` | v1.0 |
 | mtg  | `productivity/mtg/index.html` | v1.0 |
-| idx  | `productivity/idx/index.html` | v1.7 |
+| idx  | `productivity/idx/index.html` | v1.8 |
 | str  | `personal/str/index.html` | v1.0 |
 | crd  | `personal/crd/index.html` | v1.0 |
 | teleport-tap | `games/teleport-tap/index.html` | v1.0 |

--- a/productivity/idx/index.html
+++ b/productivity/idx/index.html
@@ -179,7 +179,7 @@ body {
 .idea-text.clickable:hover { color: #fff; }
 .idea-ts { font-size: 10px; color: #777; margin-top: 5px; }
 
-.idea-actions { display: flex; gap: 5px; flex-shrink: 0; padding-top: 1px; }
+.idea-actions { display: flex; gap: 5px; flex-shrink: 0; align-self: stretch; align-items: center; }
 .act {
   background: none;
   border: 1px solid #2a2a2a;
@@ -194,6 +194,7 @@ body {
 .act.promote:hover      { border-color: #8855ff; color: #8855ff; }
 .act.defer:hover        { border-color: #886600; color: #ccaa00; }
 .act.done:hover         { border-color: #226644; color: #44cc88; }
+.act.kill               { padding: 0 8px; aspect-ratio: 1; display: flex; align-items: center; justify-content: center; }
 .act.kill:hover         { border-color: #882222; color: #ff5555; }
 
 .idea-edit {
@@ -221,7 +222,7 @@ body {
 <div id="syncBar">
   <div class="left">
     <span class="name">idx</span>
-    <span class="ver">v1.7</span>
+    <span class="ver">v1.8</span>
   </div>
   <div style="display:flex;align-items:center;gap:10px;">
     <div id="syncStatus"><span class="dot" id="syncDot"></span><span id="syncText">not connected</span></div>
@@ -363,19 +364,16 @@ function render() {
     if (currentView === 'inbox') {
       rightLabel = 'DO'; leftLabel = 'BL';
       actions =
-        '<button class="act promote" onclick="promote(' + idea.id + ')">DO</button>' +
-        '<button class="act defer"   onclick="defer('   + idea.id + ')">BL</button>'  +
-        '<button class="act kill"    onclick="kill('    + idea.id + ')">kill</button>';
+        '<button class="act defer" onclick="defer(' + idea.id + ')">BL</button>'  +
+        '<button class="act kill"  onclick="kill('  + idea.id + ')">KILL</button>';
     } else if (currentView === 'deferred') {
       rightLabel = 'DO'; leftLabel = '';
       actions =
-        '<button class="act promote" onclick="promote(' + idea.id + ')">DO</button>' +
-        '<button class="act kill"    onclick="kill('    + idea.id + ')">kill</button>';
+        '<button class="act kill" onclick="kill(' + idea.id + ')">KILL</button>';
     } else {
       rightLabel = 'DONE'; leftLabel = '';
       actions =
-        '<button class="act done" onclick="done(' + idea.id + ')">DONE</button>' +
-        '<button class="act kill" onclick="kill(' + idea.id + ')">kill</button>';
+        '<button class="act kill" onclick="kill(' + idea.id + ')">KILL</button>';
     }
 
     var textAttrs = currentView === 'inbox'


### PR DESCRIPTION
## Summary
- Removed DO button (IN and BL views) and DONE button (DO view) — swipe handles those transitions
- KILL → capitalised in all views
- KILL button is now square (`aspect-ratio: 1`, text centered), height increased to match its width
- `.idea-actions` stretches to full card height and centers the button vertically

## Test plan
- [x] Each view shows only the BL button (IN) or no action buttons (BL, DO) besides KILL
- [x] KILL button appears square and vertically centred regardless of idea text length
- [x] Swipe right/left still works for all positive transitions

---
_Generated by [Claude Code](https://claude.ai/code/session_01VZfx9eqRhRxfDkAogdg5ZR)_