### PR TITLE
idx v1.12 — brighter text to match nav card style

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,7 +126,7 @@ Every subproject displays its version next to its title — small (`font-size:10
 | cal  | `productivity/cal/index.html` | v1.3 |
 | pom  | `productivity/pom/index.html` | v1.0 |
 | mtg  | `productivity/mtg/index.html` | v1.0 |
-| idx  | `productivity/idx/index.html` | v1.11 |
+| idx  | `productivity/idx/index.html` | v1.12 |
 | str  | `personal/str/index.html` | v1.0 |
 | crd  | `personal/crd/index.html` | v1.0 |
 | teleport-tap | `games/teleport-tap/index.html` | v1.0 |

--- a/productivity/idx/index.html
+++ b/productivity/idx/index.html
@@ -52,7 +52,7 @@ body {
 .modal-overlay.active { display: flex; }
 .modal { background: #111; border: 1px solid #333; padding: 24px; width: 90%; max-width: 420px; }
 .modal h2 { font-size: 13px; color: #ccc; margin-bottom: 16px; letter-spacing: 2px; text-transform: uppercase; }
-.modal label { display: block; color: #aaa; font-size: 11px; margin-bottom: 4px; margin-top: 12px; }
+.modal label { display: block; color: #ccc; font-size: 11px; margin-bottom: 4px; margin-top: 12px; }
 .modal input {
   width: 100%; background: #1a1a1a; border: 1px solid #333; color: #e0e0e0;
   padding: 8px; font-family: 'Courier New', monospace; font-size: 16px;
@@ -75,17 +75,17 @@ body {
   font-size: 16px; outline: none;
 }
 #captureInput:focus { border-color: #8855ff; }
-#captureInput::placeholder { color: #666; }
+#captureInput::placeholder { color: #888; }
 
 /* TABS */
 #tabs { display: flex; border-bottom: 1px solid #222; margin-bottom: 16px; }
 .tab {
   background: none; border: none; border-bottom: 2px solid transparent;
-  color: #777; padding: 7px 14px; cursor: pointer;
+  color: #ccc; padding: 7px 14px; cursor: pointer;
   font-family: 'Courier New', monospace; font-size: 15px;
   letter-spacing: 0.05em; margin-bottom: -1px;
 }
-.tab:hover { color: #bbb; }
+.tab:hover { color: #e0e0e0; }
 .tab.active { color: #8855ff; border-bottom-color: #8855ff; }
 
 /* IDEAS */
@@ -114,18 +114,18 @@ body {
   position: relative; z-index: 1; will-change: transform;
 }
 .idea-body { flex: 1; min-width: 0; }
-.idea-text { color: #ddd; word-break: break-word; line-height: 1.5; font-size: 13px; }
+.idea-text { color: #e0e0e0; word-break: break-word; line-height: 1.5; font-size: 13px; }
 .idea-text.clickable { cursor: pointer; }
 .idea-text.clickable:hover { color: #fff; }
-.idea-ts { font-size: 10px; color: #777; margin-top: 5px; }
+.idea-ts { font-size: 10px; color: #ccc; margin-top: 5px; }
 
 .idea-actions { display: flex; gap: 5px; flex-shrink: 0; align-self: stretch; align-items: center; }
 .act {
-  background: none; border: 1px solid #2a2a2a; color: #888;
+  background: none; border: 1px solid #2a2a2a; color: #ccc;
   padding: 2px 8px; cursor: pointer;
   font-family: 'Courier New', monospace; font-size: 10px; letter-spacing: 0.05em;
 }
-.act:hover         { border-color: #555; color: #ccc; }
+.act:hover         { border-color: #555; color: #e0e0e0; }
 .act.kill          { padding: 0 8px; aspect-ratio: 1; display: flex; align-items: center; justify-content: center; background: #1a0606; border-color: #882222; color: #ff5555; }
 .act.kill:hover    { border-color: #cc3333; color: #ff8888; background: #2a0a0a; }
 
@@ -134,43 +134,43 @@ body {
   color: #e0e0e0; padding: 3px 6px;
   font-family: 'Courier New', Courier, monospace; font-size: 16px; outline: none;
 }
-.empty { color: #666; padding: 32px 0; text-align: center; font-size: 12px; letter-spacing: 0.1em; }
+.empty { color: #ccc; padding: 32px 0; text-align: center; font-size: 12px; letter-spacing: 0.1em; }
 
 /* ── STATS ──────────────────────────────────────────── */
 .stat-topline { display: flex; margin-bottom: 28px; }
 .stat-box { flex: 1; text-align: center; padding: 14px 6px; border: 1px solid #1e1e1e; background: #111; }
 .stat-box + .stat-box { border-left: none; }
 .stat-box-val   { font-size: 26px; line-height: 1; margin-bottom: 5px; }
-.stat-box-label { font-size: 9px; color: #555; letter-spacing: 0.15em; }
+.stat-box-label { font-size: 9px; color: #aaa; letter-spacing: 0.15em; }
 
 .stat-section { margin-bottom: 28px; }
-.stat-heading { font-size: 9px; color: #555; letter-spacing: 0.15em; margin-bottom: 12px; }
+.stat-heading { font-size: 9px; color: #aaa; letter-spacing: 0.15em; margin-bottom: 12px; }
 
 .stat-funnel-row   { display: flex; align-items: center; gap: 8px; margin-bottom: 7px; }
-.stat-funnel-label { font-size: 10px; color: #777; letter-spacing: 0.08em; width: 44px; flex-shrink: 0; text-align: right; }
+.stat-funnel-label { font-size: 10px; color: #ccc; letter-spacing: 0.08em; width: 44px; flex-shrink: 0; text-align: right; }
 .stat-funnel-wrap  { flex: 1; height: 10px; background: #1a1a1a; }
 .stat-funnel-bar   { height: 100%; }
-.stat-funnel-count { font-size: 10px; color: #555; width: 68px; flex-shrink: 0; }
-.stat-pct          { color: #444; }
+.stat-funnel-count { font-size: 10px; color: #aaa; width: 68px; flex-shrink: 0; }
+.stat-pct          { color: #888; }
 
 .stat-resolution { display: flex; gap: 28px; margin-bottom: 10px; }
 .stat-res-item   { display: flex; align-items: baseline; gap: 7px; }
 .stat-res-pct    { font-size: 32px; line-height: 1; }
-.stat-res-label  { font-size: 9px; color: #555; letter-spacing: 0.12em; }
+.stat-res-label  { font-size: 9px; color: #aaa; letter-spacing: 0.12em; }
 .stat-res-bar    { width: 100%; height: 4px; display: flex; overflow: hidden; }
 
 .stat-bars     { display: flex; align-items: flex-end; gap: 4px; }
 .stat-bar-col  { display: flex; flex-direction: column; align-items: center; flex: 1; gap: 3px; }
-.stat-bar-val  { font-size: 9px; color: #666; min-height: 12px; line-height: 12px; }
+.stat-bar-val  { font-size: 9px; color: #aaa; min-height: 12px; line-height: 12px; }
 .stat-bar-out  { width: 100%; height: 60px; background: #1a1a1a; display: flex; align-items: flex-end; }
 .stat-bar-in   { width: 100%; background: #8855ff; min-height: 0; }
-.stat-bar-date { font-size: 8px; color: #444; white-space: nowrap; }
+.stat-bar-date { font-size: 8px; color: #999; white-space: nowrap; }
 
 .stat-dow       { display: flex; gap: 4px; }
 .stat-dow-col   { flex: 1; display: flex; flex-direction: column; align-items: center; gap: 5px; }
 .stat-dow-cell  { width: 100%; aspect-ratio: 1; }
-.stat-dow-label { font-size: 8px; color: #555; letter-spacing: 0.04em; }
-.stat-dow-count { font-size: 9px; color: #666; }
+.stat-dow-label { font-size: 8px; color: #aaa; letter-spacing: 0.04em; }
+.stat-dow-count { font-size: 9px; color: #ccc; }
 </style>
 </head>
 <body>
@@ -178,7 +178,7 @@ body {
 <div id="syncBar">
   <div class="left">
     <span class="name">idx</span>
-    <span class="ver">v1.11</span>
+    <span class="ver">v1.12</span>
   </div>
   <div style="display:flex;align-items:center;gap:10px;">
     <div id="syncStatus"><span class="dot" id="syncDot"></span><span id="syncText">not connected</span></div>
@@ -204,7 +204,7 @@ body {
     <h2>sync setup</h2>
     <label>GitHub Personal Access Token (scope: gist)</label>
     <input type="password" id="inputToken" placeholder="ghp_..." autocomplete="off" />
-    <label>Gist ID <span style="color:#555">(leave blank to create new)</span></label>
+    <label>Gist ID <span style="color:#999">(leave blank to create new)</span></label>
     <input type="text" id="inputGistId" placeholder="optional" />
     <div class="modal-btns">
       <button class="mbtn" onclick="closeSetup()">cancel</button>


### PR DESCRIPTION
## Summary

- Raises all dim grey text in idx to match the `#ccc` / `#e0e0e0` palette used by the navigation card pages
- No functional changes — purely visual

## Changes

| Element | Before | After |
|---|---|---|
| Tabs (resting) | `#777` | `#ccc` |
| Tabs (hover) | `#bbb` | `#e0e0e0` |
| Idea text | `#ddd` | `#e0e0e0` |
| Timestamps | `#777` | `#ccc` |
| Action button | `#888` | `#ccc` |
| Empty state | `#666` | `#ccc` |
| Modal labels | `#aaa` | `#ccc` |
| Stat box labels / headings | `#555` | `#aaa` |
| Stat funnel labels | `#777` | `#ccc` |
| Stat funnel counts | `#555` | `#aaa` |
| Stat % (pct) | `#444` | `#888` |
| Stat res labels | `#555` | `#aaa` |
| Bar values | `#666` | `#aaa` |
| Bar dates | `#444` | `#999` |
| DoW labels | `#555` | `#aaa` |
| DoW counts | `#666` | `#ccc` |
| Placeholder | `#666` | `#888` |

## Version

`v1.11` → `v1.12`

https://claude.ai/code/session_01VZfx9eqRhRxfDkAogdg5ZR

---
_Generated by [Claude Code](https://claude.ai/code/session_01VZfx9eqRhRxfDkAogdg5ZR)_