### PR TITLE
all subprojects — prevent iOS Safari zoom on input focus

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,13 +122,13 @@ Every subproject displays its version next to its title — small (`font-size:10
 
 | Tool | Path | Version |
 |------|------|---------|
-| tts  | `productivity/tts/index.html` | v2.11 |
-| cal  | `productivity/cal/index.html` | v1.3 |
-| pom  | `productivity/pom/index.html` | v1.0 |
-| mtg  | `productivity/mtg/index.html` | v1.0 |
+| tts  | `productivity/tts/index.html` | v2.13 |
+| cal  | `productivity/cal/index.html` | v1.4 |
+| pom  | `productivity/pom/index.html` | v1.1 |
+| mtg  | `productivity/mtg/index.html` | v1.1 |
 | idx  | `productivity/idx/index.html` | v1.12 |
-| str  | `personal/str/index.html` | v1.0 |
-| crd  | `personal/crd/index.html` | v1.0 |
+| str  | `personal/str/index.html` | v1.1 |
+| crd  | `personal/crd/index.html` | v1.1 |
 | teleport-tap | `games/teleport-tap/index.html` | v1.0 |
 | mobs-magic | `games/mobs-magic/index.html` | v1.0 |
 

--- a/personal/crd/index.html
+++ b/personal/crd/index.html
@@ -116,7 +116,7 @@ textarea, input[type="url"], input[type="text"] {
   border: 1px solid var(--border);
   color: var(--text);
   font-family: 'Courier New', Courier, monospace;
-  font-size: 13px;
+  font-size: 16px;
   padding: 9px 10px;
   border-radius: 3px;
   resize: vertical;
@@ -312,7 +312,7 @@ textarea:focus, input:focus { border-color: var(--accent); }
   border: 1px solid var(--border);
   color: var(--text);
   font-family: 'Courier New', Courier, monospace;
-  font-size: 15px;
+  font-size: 16px;
   padding: 6px 8px;
   border-radius: 3px;
   outline: none;
@@ -449,7 +449,7 @@ textarea:focus, input:focus { border-color: var(--accent); }
 <body>
 
 <div class="hdr">
-  <h1>crd<span style="font-size:10px;color:#bbb;margin-left:8px;letter-spacing:0.05em;text-transform:none;font-weight:normal">v1.0</span></h1>
+  <h1>crd<span style="font-size:10px;color:#bbb;margin-left:8px;letter-spacing:0.05em;text-transform:none;font-weight:normal">v1.1</span></h1>
   <a href="../">← home</a>
   <span id="sync-dot" class="sync-dot" title="Gist sync status"></span>
   <span id="sync-lbl" class="sync-lbl"></span>
@@ -564,7 +564,7 @@ the red desert snows.
       <button class="btn"   onclick="regenerateOutput()">Regenerate</button>
       <span class="status-flash" id="copy-flash">Copied!</span>
     </div>
-    <textarea id="out-box" spellcheck="false" rows="30" style="font-size:13px;line-height:1.65;resize:vertical;background:#0a0a0a;border-color:var(--border)"></textarea>
+    <textarea id="out-box" spellcheck="false" rows="30" style="font-size:16px;line-height:1.65;resize:vertical;background:#0a0a0a;border-color:var(--border)"></textarea>
   </div>
 
   <div class="nav">

--- a/personal/str/index.html
+++ b/personal/str/index.html
@@ -125,7 +125,7 @@ width: 100%;
 background: #2a2a2a;
 border: 1px solid #2a2a2a;
 color: #f0f0f0;
-font-size: 13px;
+font-size: 16px;
 font-family: inherit;
 padding: 9px 12px;
 outline: none;
@@ -362,7 +362,7 @@ flex: 1;
 background: none;
 border: none;
 color: #f0f0f0;
-font-size: 13px;
+font-size: 16px;
 font-family: inherit;
 outline: none;
 border-bottom: 1px solid transparent;
@@ -384,7 +384,7 @@ width: 48px;
 background: #1e1e1e;
 border: 1px solid #222;
 color: #c8a26b;
-font-size: 12px;
+font-size: 16px;
 font-family: inherit;
 padding: 4px 6px;
 outline: none;
@@ -414,7 +414,7 @@ flex: 1;
 background: #1e1e1e;
 border: 1px solid #1e1e1e;
 color: #f0f0f0;
-font-size: 13px;
+font-size: 16px;
 font-family: inherit;
 padding: 8px 12px;
 outline: none;
@@ -480,7 +480,7 @@ letter-spacing: 0.05em;
 
 <!-- APP -->
 
-<h1>String Tracker<span style="font-size:10px;color:#bbb;margin-left:8px;letter-spacing:0.05em;text-transform:none;font-weight:normal">v1.0</span></h1>
+<h1>String Tracker<span style="font-size:10px;color:#bbb;margin-left:8px;letter-spacing:0.05em;text-transform:none;font-weight:normal">v1.1</span></h1>
 
 <div class="guitars-list" id="guitarsList"></div>
 

--- a/productivity/cal/index.html
+++ b/productivity/cal/index.html
@@ -116,7 +116,7 @@ width: 100%;
 background: #222;
 border: 1px solid #3a3a3a;
 color: #c8c8c8;
-font-size: 12px;
+font-size: 16px;
 font-family: inherit;
 padding: 8px 10px;
 outline: none;
@@ -248,7 +248,7 @@ background: #333;
 border: 1px solid #3d3d3d;
 color: #c8c8c8;
 font-family: inherit;
-font-size: 12px;
+font-size: 16px;
 padding: 6px 8px;
 border-radius: 4px;
 outline: none;
@@ -263,7 +263,7 @@ background: #333;
 border: 1px solid #3d3d3d;
 color: #c8c8c8;
 font-family: inherit;
-font-size: 12px;
+font-size: 16px;
 padding: 6px 8px;
 border-radius: 4px;
 outline: none;
@@ -457,7 +457,7 @@ main { padding: 20px 16px 40px; }
 </div>
 
 <header>
-  <span class="logo">Cal</span><span style="font-size:10px;color: #ccc;margin-left:6px;letter-spacing:0.05em">v1.3</span>
+  <span class="logo">Cal</span><span style="font-size:10px;color: #ccc;margin-left:6px;letter-spacing:0.05em">v1.4</span>
   <div class="ctrl-group">
     <span>From</span>
     <select id="startMonth">

--- a/productivity/mtg/index.html
+++ b/productivity/mtg/index.html
@@ -70,7 +70,7 @@ border-radius: 4px;
 .modal input {
 width: 100%; background: #2a2a2a;
 border: 1px solid #333; color: #e0e0e0;
-padding: 8px; font-family: ‘Courier New’, monospace; font-size: 13px;
+padding: 8px; font-family: ‘Courier New’, monospace; font-size: 16px;
 border-radius: 2px;
 }
 .modal input:focus { outline: none; border-color: #ccc; }
@@ -150,7 +150,7 @@ overflow-y: auto; padding: 16px; gap: 14px;
 .field-input {
 background: #111; border: 1px solid #222;
 color: #e0e0e0; padding: 8px 10px;
-font-family: ‘Courier New’, monospace; font-size: 14px;
+font-family: ‘Courier New’, monospace; font-size: 16px;
 border-radius: 2px; width: 100%;
 }
 .field-input:focus { outline: none; border-color: #ccc; }
@@ -193,7 +193,7 @@ flex-shrink: 0;
 }
 .action-item-delete:hover { color: #f44336; }
 .action-add-row { display: flex; gap: 6px; flex-wrap: wrap; }
-.action-add-row input { background: #111; border: 1px solid #222; color: #e0e0e0; padding: 7px 10px; font-family: ‘Courier New’, monospace; font-size: 13px; border-radius: 2px; }
+.action-add-row input { background: #111; border: 1px solid #222; color: #e0e0e0; padding: 7px 10px; font-family: ‘Courier New’, monospace; font-size: 16px; border-radius: 2px; }
 .action-add-row input:focus { outline: none; border-color: #ccc; }
 .action-add-row .txt { flex: 2; min-width: 140px; }
 .action-add-row .own { flex: 1; min-width: 80px; }
@@ -316,7 +316,7 @@ padding: 10px 12px; border-radius: 2px;
 
 <div id="app">
   <div id="nav">
-    <span style="font-size:10px;color:#bbb;letter-spacing:0.12em;text-transform:uppercase;padding-right:16px">mtg <span style="letter-spacing:0.05em;text-transform:none">v1.0</span></span>
+    <span style="font-size:10px;color:#bbb;letter-spacing:0.12em;text-transform:uppercase;padding-right:16px">mtg <span style="letter-spacing:0.05em;text-transform:none">v1.1</span></span>
     <button class="nav-tab active" data-view="listView">Meetings</button>
     <button class="nav-tab" data-view="actionsView">Actions</button>
     <button id="newMtgBtn">+ New</button>

--- a/productivity/pom/index.html
+++ b/productivity/pom/index.html
@@ -77,7 +77,7 @@ border-radius: 4px;
 .modal input {
 width: 100%; background: #2a2a2a;
 border: 1px solid #333; color: #e0e0e0;
-padding: 8px; font-family: ‘Courier New’, monospace; font-size: 13px;
+padding: 8px; font-family: ‘Courier New’, monospace; font-size: 16px;
 border-radius: 2px;
 }
 .modal input:focus { outline: none; border-color: #ccc; }
@@ -232,7 +232,7 @@ width: 0%;
 <!-- MAIN -->
 
 <div id="main">
-  <div style="font-size:10px;letter-spacing:0.2em;text-transform:uppercase;color:#bbb">pom<span style="letter-spacing:0.05em;text-transform:none;margin-left:6px">v1.0</span></div>
+  <div style="font-size:10px;letter-spacing:0.2em;text-transform:uppercase;color:#bbb">pom<span style="letter-spacing:0.05em;text-transform:none;margin-left:6px">v1.1</span></div>
   <div id="mode-label">work</div>
   <div id="timer">25:00</div>
   <div id="progress-bar"><div id="progress-fill"></div></div>

--- a/productivity/tts/index.html
+++ b/productivity/tts/index.html
@@ -119,7 +119,7 @@ width: 100%;
 background: #2a2a2a;
 border: 1px solid #2a2a2a;
 color: #f0f0f0;
-font-size: 13px;
+font-size: 16px;
 font-family: inherit;
 padding: 9px 12px;
 outline: none;
@@ -632,7 +632,7 @@ flex: 1;
 background: none;
 border: none;
 color: #f0f0f0;
-font-size: 13px;
+font-size: 16px;
 font-family: inherit;
 outline: none;
 border-bottom: 1px solid #7effa0;
@@ -702,7 +702,7 @@ flex: 1;
 background: #1e1e1e;
 border: 1px solid #1e1e1e;
 color: #f0f0f0;
-font-size: 13px;
+font-size: 16px;
 font-family: inherit;
 padding: 8px 12px;
 outline: none;
@@ -1038,7 +1038,7 @@ transition: background 0.1s;
 
 <!-- APP -->
 
-<h1>tts<span style="font-size:10px;color:#bbb;margin-left:8px;letter-spacing:0.05em;text-transform:none;font-weight:normal">v2.12</span></h1>
+<h1>tts<span style="font-size:10px;color:#bbb;margin-left:8px;letter-spacing:0.05em;text-transform:none;font-weight:normal">v2.13</span></h1>
 
 <div class="top-bar">
   <div class="timer-display" id="timerDisplay">00:00:00</div>


### PR DESCRIPTION
## Summary

iOS Safari auto-zooms the viewport when an input/textarea receives focus if its `font-size` is below 16px. This sets all interactive text fields to exactly `font-size: 16px` across every subproject.

## Files changed

| Tool | Inputs fixed |
|---|---|
| **tts** v2.12→v2.13 | `.modal input`, `.proj-name-input`, `.add-input` |
| **cal** v1.3→v1.4 | `.modal input`, `.form-input`, `.form-select` |
| **pom** v1.0→v1.1 | `.modal input` |
| **mtg** v1.0→v1.1 | `.modal input`, `.field-input`, `.action-add-row input` |
| **str** v1.0→v1.1 | `.modal input`, `.guitar-name-input`, `.threshold-input`, `.add-input` |
| **crd** v1.0→v1.1 | `textarea, input[type="url/text"]`, `#popup input`, `#out-box` inline style |

idx already had this fix applied in a previous PR.

https://claude.ai/code/session_01VZfx9eqRhRxfDkAogdg5ZR

---
_Generated by [Claude Code](https://claude.ai/code/session_01VZfx9eqRhRxfDkAogdg5ZR)_