### PR TITLE
feat: add FastAPI + Postgres backend and React frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,7 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Frontend
+frontend/node_modules/
+frontend/dist/

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,0 +1,19 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://localhost/endermatx")
+if DATABASE_URL.startswith("postgres://"):
+    DATABASE_URL = DATABASE_URL.replace("postgres://", "postgresql://", 1)
+
+engine = create_engine(DATABASE_URL)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,40 @@
+import os
+from pathlib import Path
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
+
+from .database import engine, Base
+from .routers import tts, cal, pom, mtg, idx, strings, crd
+
+Base.metadata.create_all(bind=engine)
+
+app = FastAPI(title="endermatx API")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+app.include_router(tts.router, prefix="/api/tts", tags=["tts"])
+app.include_router(cal.router, prefix="/api/cal", tags=["cal"])
+app.include_router(pom.router, prefix="/api/pom", tags=["pom"])
+app.include_router(mtg.router, prefix="/api/mtg", tags=["mtg"])
+app.include_router(idx.router, prefix="/api/idx", tags=["idx"])
+app.include_router(strings.router, prefix="/api/str", tags=["str"])
+app.include_router(crd.router, prefix="/api/crd", tags=["crd"])
+
+FRONTEND_DIST = Path(__file__).parent.parent / "frontend" / "dist"
+
+if FRONTEND_DIST.exists():
+    app.mount("/assets", StaticFiles(directory=FRONTEND_DIST / "assets"), name="assets")
+
+    @app.get("/{full_path:path}")
+    async def spa_fallback(full_path: str):
+        candidate = FRONTEND_DIST / full_path
+        if candidate.is_file():
+            return FileResponse(candidate)
+        return FileResponse(FRONTEND_DIST / "index.html")

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,106 @@
+from datetime import datetime
+from sqlalchemy import BigInteger, Boolean, Column, DateTime, Float, ForeignKey, Integer, String, Text
+from sqlalchemy.dialects.postgresql import JSONB
+from .database import Base
+
+
+# ── tts ───────────────────────────────────────────────────────────────────────
+
+class TtsProject(Base):
+    __tablename__ = "tts_projects"
+    id = Column(BigInteger, primary_key=True, autoincrement=True)
+    name = Column(String, nullable=False)
+    color = Column(String, nullable=False, default="#888888")
+    archived = Column(Boolean, default=False)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+
+class TtsEntry(Base):
+    __tablename__ = "tts_entries"
+    id = Column(BigInteger, primary_key=True, autoincrement=True)
+    project_id = Column(BigInteger, ForeignKey("tts_projects.id", ondelete="CASCADE"), nullable=False)
+    start_time = Column(DateTime, nullable=False)
+    end_time = Column(DateTime, nullable=True)
+
+
+# ── cal ───────────────────────────────────────────────────────────────────────
+
+class CalProject(Base):
+    __tablename__ = "cal_projects"
+    id = Column(BigInteger, primary_key=True, autoincrement=True)
+    name = Column(String, nullable=False)
+    color = Column(String, nullable=False, default="#4a9eff")
+    start_date = Column(String, nullable=False)
+    end_date = Column(String, nullable=False)
+
+
+class CalSettings(Base):
+    __tablename__ = "cal_settings"
+    id = Column(Integer, primary_key=True, default=1)
+    start_year = Column(Integer)
+    start_month = Column(Integer)
+    end_year = Column(Integer)
+    end_month = Column(Integer)
+    tile_width = Column(Integer, default=360)
+    countries = Column(JSONB, default=list)
+
+
+# ── pom ───────────────────────────────────────────────────────────────────────
+
+class PomState(Base):
+    __tablename__ = "pom_state"
+    id = Column(Integer, primary_key=True, default=1)
+    sessions = Column(JSONB, default=dict)
+    total_mins = Column(Float, default=0.0)
+    timer = Column(JSONB, nullable=True)
+
+
+# ── mtg ───────────────────────────────────────────────────────────────────────
+
+class Meeting(Base):
+    __tablename__ = "mtg_meetings"
+    id = Column(BigInteger, primary_key=True, autoincrement=True)
+    title = Column(String, nullable=False)
+    date = Column(String, default="")
+    notes = Column(Text, default="")
+    attendees = Column(JSONB, default=list)
+    actions = Column(JSONB, default=list)
+    summary = Column(Text, default="")
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+
+# ── idx ───────────────────────────────────────────────────────────────────────
+
+class Idea(Base):
+    __tablename__ = "idx_ideas"
+    id = Column(BigInteger, primary_key=True, autoincrement=True)
+    text = Column(String, nullable=False)
+    status = Column(String, default="inbox")
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow)
+
+
+# ── str ───────────────────────────────────────────────────────────────────────
+
+class Guitar(Base):
+    __tablename__ = "str_guitars"
+    id = Column(BigInteger, primary_key=True, autoincrement=True)
+    name = Column(String, nullable=False)
+    threshold_days = Column(Integer, default=30)
+    last_changed = Column(DateTime, nullable=True)
+    history = Column(JSONB, default=list)
+
+
+# ── crd ───────────────────────────────────────────────────────────────────────
+
+class CrdState(Base):
+    __tablename__ = "crd_state"
+    id = Column(Integer, primary_key=True, default=1)
+    lyrics = Column(Text, default="")
+    manual_chords = Column(Text, default="")
+    media_url = Column(String, default="")
+    chords = Column(JSONB, default=list)
+    cursor = Column(Integer, default=0)
+    word_seq = Column(Integer, default=0)
+    lines = Column(JSONB, default=list)
+    manual_output = Column(Text, nullable=True)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.115.0
+uvicorn[standard]==0.32.0
+sqlalchemy==2.0.35
+psycopg2-binary==2.9.10
+pydantic==2.9.2

--- a/backend/routers/cal.py
+++ b/backend/routers/cal.py
@@ -1,0 +1,77 @@
+from datetime import datetime
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from .. import models, schemas
+from ..database import get_db
+
+router = APIRouter()
+
+today = datetime.utcnow()
+DEFAULT_SETTINGS = {
+    "start_year": today.year,
+    "start_month": max(today.month - 3, 1),
+    "end_year": today.year + 1,
+    "end_month": today.month,
+    "tile_width": 360,
+    "countries": ["DE"],
+}
+
+
+def _get_or_create_settings(db: Session) -> models.CalSettings:
+    s = db.get(models.CalSettings, 1)
+    if not s:
+        s = models.CalSettings(id=1, **DEFAULT_SETTINGS)
+        db.add(s)
+        db.commit()
+        db.refresh(s)
+    return s
+
+
+@router.get("/projects", response_model=list[schemas.CalProjectOut])
+def list_projects(db: Session = Depends(get_db)):
+    return db.query(models.CalProject).order_by(models.CalProject.id).all()
+
+
+@router.post("/projects", response_model=schemas.CalProjectOut, status_code=201)
+def create_project(body: schemas.CalProjectCreate, db: Session = Depends(get_db)):
+    proj = models.CalProject(**body.model_dump())
+    db.add(proj)
+    db.commit()
+    db.refresh(proj)
+    return proj
+
+
+@router.put("/projects/{pid}", response_model=schemas.CalProjectOut)
+def update_project(pid: int, body: schemas.CalProjectUpdate, db: Session = Depends(get_db)):
+    proj = db.get(models.CalProject, pid)
+    if not proj:
+        raise HTTPException(404)
+    for k, v in body.model_dump(exclude_none=True).items():
+        setattr(proj, k, v)
+    db.commit()
+    db.refresh(proj)
+    return proj
+
+
+@router.delete("/projects/{pid}", status_code=204)
+def delete_project(pid: int, db: Session = Depends(get_db)):
+    proj = db.get(models.CalProject, pid)
+    if not proj:
+        raise HTTPException(404)
+    db.delete(proj)
+    db.commit()
+
+
+@router.get("/settings", response_model=schemas.CalSettingsOut)
+def get_settings(db: Session = Depends(get_db)):
+    return _get_or_create_settings(db)
+
+
+@router.put("/settings", response_model=schemas.CalSettingsOut)
+def update_settings(body: schemas.CalSettingsUpdate, db: Session = Depends(get_db)):
+    s = _get_or_create_settings(db)
+    for k, v in body.model_dump(exclude_none=True).items():
+        setattr(s, k, v)
+    db.commit()
+    db.refresh(s)
+    return s

--- a/backend/routers/crd.py
+++ b/backend/routers/crd.py
@@ -1,0 +1,32 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+from .. import models, schemas
+from ..database import get_db
+
+router = APIRouter()
+
+
+def _get_or_create(db: Session) -> models.CrdState:
+    s = db.get(models.CrdState, 1)
+    if not s:
+        s = models.CrdState(id=1, lyrics="", manual_chords="", media_url="",
+                             chords=[], cursor=0, word_seq=0, lines=[], manual_output=None)
+        db.add(s)
+        db.commit()
+        db.refresh(s)
+    return s
+
+
+@router.get("/state", response_model=schemas.CrdStateOut)
+def get_state(db: Session = Depends(get_db)):
+    return _get_or_create(db)
+
+
+@router.put("/state", response_model=schemas.CrdStateOut)
+def update_state(body: schemas.CrdStateUpdate, db: Session = Depends(get_db)):
+    s = _get_or_create(db)
+    for k, v in body.model_dump(exclude_unset=True).items():
+        setattr(s, k, v)
+    db.commit()
+    db.refresh(s)
+    return s

--- a/backend/routers/idx.py
+++ b/backend/routers/idx.py
@@ -1,0 +1,47 @@
+from datetime import datetime
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from .. import models, schemas
+from ..database import get_db
+
+router = APIRouter()
+
+VALID_STATUSES = {"inbox", "promoted", "deferred", "done", "killed"}
+
+
+@router.get("/ideas", response_model=list[schemas.IdeaOut])
+def list_ideas(db: Session = Depends(get_db)):
+    return db.query(models.Idea).order_by(models.Idea.created_at.desc()).all()
+
+
+@router.post("/ideas", response_model=schemas.IdeaOut, status_code=201)
+def create_idea(body: schemas.IdeaCreate, db: Session = Depends(get_db)):
+    idea = models.Idea(text=body.text)
+    db.add(idea)
+    db.commit()
+    db.refresh(idea)
+    return idea
+
+
+@router.put("/ideas/{iid}", response_model=schemas.IdeaOut)
+def update_idea(iid: int, body: schemas.IdeaUpdate, db: Session = Depends(get_db)):
+    idea = db.get(models.Idea, iid)
+    if not idea:
+        raise HTTPException(404)
+    if body.status and body.status not in VALID_STATUSES:
+        raise HTTPException(400, f"invalid status: {body.status}")
+    for k, v in body.model_dump(exclude_none=True).items():
+        setattr(idea, k, v)
+    idea.updated_at = datetime.utcnow()
+    db.commit()
+    db.refresh(idea)
+    return idea
+
+
+@router.delete("/ideas/{iid}", status_code=204)
+def delete_idea(iid: int, db: Session = Depends(get_db)):
+    idea = db.get(models.Idea, iid)
+    if not idea:
+        raise HTTPException(404)
+    db.delete(idea)
+    db.commit()

--- a/backend/routers/mtg.py
+++ b/backend/routers/mtg.py
@@ -1,0 +1,41 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from .. import models, schemas
+from ..database import get_db
+
+router = APIRouter()
+
+
+@router.get("/meetings", response_model=list[schemas.MeetingOut])
+def list_meetings(db: Session = Depends(get_db)):
+    return db.query(models.Meeting).order_by(models.Meeting.date.desc(), models.Meeting.created_at.desc()).all()
+
+
+@router.post("/meetings", response_model=schemas.MeetingOut, status_code=201)
+def create_meeting(body: schemas.MeetingCreate, db: Session = Depends(get_db)):
+    mtg = models.Meeting(**body.model_dump())
+    db.add(mtg)
+    db.commit()
+    db.refresh(mtg)
+    return mtg
+
+
+@router.put("/meetings/{mid}", response_model=schemas.MeetingOut)
+def update_meeting(mid: int, body: schemas.MeetingUpdate, db: Session = Depends(get_db)):
+    mtg = db.get(models.Meeting, mid)
+    if not mtg:
+        raise HTTPException(404)
+    for k, v in body.model_dump(exclude_none=True).items():
+        setattr(mtg, k, v)
+    db.commit()
+    db.refresh(mtg)
+    return mtg
+
+
+@router.delete("/meetings/{mid}", status_code=204)
+def delete_meeting(mid: int, db: Session = Depends(get_db)):
+    mtg = db.get(models.Meeting, mid)
+    if not mtg:
+        raise HTTPException(404)
+    db.delete(mtg)
+    db.commit()

--- a/backend/routers/pom.py
+++ b/backend/routers/pom.py
@@ -1,0 +1,31 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+from .. import models, schemas
+from ..database import get_db
+
+router = APIRouter()
+
+
+def _get_or_create(db: Session) -> models.PomState:
+    s = db.get(models.PomState, 1)
+    if not s:
+        s = models.PomState(id=1, sessions={}, total_mins=0.0, timer=None)
+        db.add(s)
+        db.commit()
+        db.refresh(s)
+    return s
+
+
+@router.get("/state", response_model=schemas.PomStateOut)
+def get_state(db: Session = Depends(get_db)):
+    return _get_or_create(db)
+
+
+@router.put("/state", response_model=schemas.PomStateOut)
+def update_state(body: schemas.PomStateUpdate, db: Session = Depends(get_db)):
+    s = _get_or_create(db)
+    for k, v in body.model_dump(exclude_none=True).items():
+        setattr(s, k, v)
+    db.commit()
+    db.refresh(s)
+    return s

--- a/backend/routers/strings.py
+++ b/backend/routers/strings.py
@@ -1,0 +1,72 @@
+from datetime import datetime
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from .. import models, schemas
+from ..database import get_db
+
+router = APIRouter()
+
+
+@router.get("/guitars", response_model=list[schemas.GuitarOut])
+def list_guitars(db: Session = Depends(get_db)):
+    return db.query(models.Guitar).order_by(models.Guitar.id).all()
+
+
+@router.post("/guitars", response_model=schemas.GuitarOut, status_code=201)
+def create_guitar(body: schemas.GuitarCreate, db: Session = Depends(get_db)):
+    guitar = models.Guitar(**body.model_dump(), history=[])
+    db.add(guitar)
+    db.commit()
+    db.refresh(guitar)
+    return guitar
+
+
+@router.put("/guitars/{gid}", response_model=schemas.GuitarOut)
+def update_guitar(gid: int, body: schemas.GuitarUpdate, db: Session = Depends(get_db)):
+    guitar = db.get(models.Guitar, gid)
+    if not guitar:
+        raise HTTPException(404)
+    for k, v in body.model_dump(exclude_none=True).items():
+        setattr(guitar, k, v)
+    db.commit()
+    db.refresh(guitar)
+    return guitar
+
+
+@router.delete("/guitars/{gid}", status_code=204)
+def delete_guitar(gid: int, db: Session = Depends(get_db)):
+    guitar = db.get(models.Guitar, gid)
+    if not guitar:
+        raise HTTPException(404)
+    db.delete(guitar)
+    db.commit()
+
+
+@router.post("/guitars/{gid}/change", response_model=schemas.GuitarOut)
+def record_change(gid: int, db: Session = Depends(get_db)):
+    guitar = db.get(models.Guitar, gid)
+    if not guitar:
+        raise HTTPException(404)
+    now = datetime.utcnow()
+    history = list(guitar.history or [])
+    history.append(now.isoformat())
+    guitar.history = history
+    guitar.last_changed = now
+    db.commit()
+    db.refresh(guitar)
+    return guitar
+
+
+@router.delete("/guitars/{gid}/change", response_model=schemas.GuitarOut)
+def undo_change(gid: int, db: Session = Depends(get_db)):
+    guitar = db.get(models.Guitar, gid)
+    if not guitar:
+        raise HTTPException(404)
+    history = list(guitar.history or [])
+    if history:
+        history.pop()
+    guitar.history = history
+    guitar.last_changed = datetime.fromisoformat(history[-1]) if history else None
+    db.commit()
+    db.refresh(guitar)
+    return guitar

--- a/backend/routers/tts.py
+++ b/backend/routers/tts.py
@@ -1,0 +1,79 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from .. import models, schemas
+from ..database import get_db
+
+router = APIRouter()
+
+
+@router.get("/projects", response_model=list[schemas.TtsProjectOut])
+def list_projects(db: Session = Depends(get_db)):
+    return db.query(models.TtsProject).order_by(models.TtsProject.created_at).all()
+
+
+@router.post("/projects", response_model=schemas.TtsProjectOut, status_code=201)
+def create_project(body: schemas.TtsProjectCreate, db: Session = Depends(get_db)):
+    proj = models.TtsProject(**body.model_dump())
+    db.add(proj)
+    db.commit()
+    db.refresh(proj)
+    return proj
+
+
+@router.put("/projects/{pid}", response_model=schemas.TtsProjectOut)
+def update_project(pid: int, body: schemas.TtsProjectUpdate, db: Session = Depends(get_db)):
+    proj = db.get(models.TtsProject, pid)
+    if not proj:
+        raise HTTPException(404)
+    for k, v in body.model_dump(exclude_none=True).items():
+        setattr(proj, k, v)
+    db.commit()
+    db.refresh(proj)
+    return proj
+
+
+@router.delete("/projects/{pid}", status_code=204)
+def delete_project(pid: int, db: Session = Depends(get_db)):
+    proj = db.get(models.TtsProject, pid)
+    if not proj:
+        raise HTTPException(404)
+    db.delete(proj)
+    db.commit()
+
+
+@router.get("/entries", response_model=list[schemas.TtsEntryOut])
+def list_entries(project_id: int | None = None, db: Session = Depends(get_db)):
+    q = db.query(models.TtsEntry)
+    if project_id is not None:
+        q = q.filter(models.TtsEntry.project_id == project_id)
+    return q.order_by(models.TtsEntry.start_time.desc()).all()
+
+
+@router.post("/entries", response_model=schemas.TtsEntryOut, status_code=201)
+def create_entry(body: schemas.TtsEntryCreate, db: Session = Depends(get_db)):
+    entry = models.TtsEntry(**body.model_dump())
+    db.add(entry)
+    db.commit()
+    db.refresh(entry)
+    return entry
+
+
+@router.put("/entries/{eid}", response_model=schemas.TtsEntryOut)
+def update_entry(eid: int, body: schemas.TtsEntryUpdate, db: Session = Depends(get_db)):
+    entry = db.get(models.TtsEntry, eid)
+    if not entry:
+        raise HTTPException(404)
+    for k, v in body.model_dump(exclude_none=True).items():
+        setattr(entry, k, v)
+    db.commit()
+    db.refresh(entry)
+    return entry
+
+
+@router.delete("/entries/{eid}", status_code=204)
+def delete_entry(eid: int, db: Session = Depends(get_db)):
+    entry = db.get(models.TtsEntry, eid)
+    if not entry:
+        raise HTTPException(404)
+    db.delete(entry)
+    db.commit()

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,0 +1,187 @@
+from datetime import datetime
+from typing import Any, Optional
+from pydantic import BaseModel
+
+
+# ── tts ───────────────────────────────────────────────────────────────────────
+
+class TtsProjectCreate(BaseModel):
+    name: str
+    color: str = "#888888"
+
+class TtsProjectUpdate(BaseModel):
+    name: Optional[str] = None
+    color: Optional[str] = None
+    archived: Optional[bool] = None
+
+class TtsProjectOut(BaseModel):
+    id: int
+    name: str
+    color: str
+    archived: bool
+    created_at: datetime
+    model_config = {"from_attributes": True}
+
+
+class TtsEntryCreate(BaseModel):
+    project_id: int
+    start_time: datetime
+    end_time: Optional[datetime] = None
+
+class TtsEntryUpdate(BaseModel):
+    end_time: Optional[datetime] = None
+    start_time: Optional[datetime] = None
+    project_id: Optional[int] = None
+
+class TtsEntryOut(BaseModel):
+    id: int
+    project_id: int
+    start_time: datetime
+    end_time: Optional[datetime]
+    model_config = {"from_attributes": True}
+
+
+# ── cal ───────────────────────────────────────────────────────────────────────
+
+class CalProjectCreate(BaseModel):
+    name: str
+    color: str = "#4a9eff"
+    start_date: str
+    end_date: str
+
+class CalProjectUpdate(BaseModel):
+    name: Optional[str] = None
+    color: Optional[str] = None
+    start_date: Optional[str] = None
+    end_date: Optional[str] = None
+
+class CalProjectOut(BaseModel):
+    id: int
+    name: str
+    color: str
+    start_date: str
+    end_date: str
+    model_config = {"from_attributes": True}
+
+
+class CalSettingsUpdate(BaseModel):
+    start_year: Optional[int] = None
+    start_month: Optional[int] = None
+    end_year: Optional[int] = None
+    end_month: Optional[int] = None
+    tile_width: Optional[int] = None
+    countries: Optional[list[str]] = None
+
+class CalSettingsOut(BaseModel):
+    start_year: Optional[int]
+    start_month: Optional[int]
+    end_year: Optional[int]
+    end_month: Optional[int]
+    tile_width: int
+    countries: list[str]
+    model_config = {"from_attributes": True}
+
+
+# ── pom ───────────────────────────────────────────────────────────────────────
+
+class PomStateUpdate(BaseModel):
+    sessions: Optional[dict[str, Any]] = None
+    total_mins: Optional[float] = None
+    timer: Optional[dict[str, Any]] = None
+
+class PomStateOut(BaseModel):
+    sessions: dict[str, Any]
+    total_mins: float
+    timer: Optional[dict[str, Any]]
+    model_config = {"from_attributes": True}
+
+
+# ── mtg ───────────────────────────────────────────────────────────────────────
+
+class MeetingCreate(BaseModel):
+    title: str
+    date: str = ""
+    notes: str = ""
+    attendees: list[str] = []
+    actions: list[dict[str, Any]] = []
+    summary: str = ""
+
+class MeetingUpdate(BaseModel):
+    title: Optional[str] = None
+    date: Optional[str] = None
+    notes: Optional[str] = None
+    attendees: Optional[list[str]] = None
+    actions: Optional[list[dict[str, Any]]] = None
+    summary: Optional[str] = None
+
+class MeetingOut(BaseModel):
+    id: int
+    title: str
+    date: str
+    notes: str
+    attendees: list[str]
+    actions: list[dict[str, Any]]
+    summary: str
+    created_at: datetime
+    model_config = {"from_attributes": True}
+
+
+# ── idx ───────────────────────────────────────────────────────────────────────
+
+class IdeaCreate(BaseModel):
+    text: str
+
+class IdeaUpdate(BaseModel):
+    text: Optional[str] = None
+    status: Optional[str] = None
+
+class IdeaOut(BaseModel):
+    id: int
+    text: str
+    status: str
+    created_at: datetime
+    updated_at: datetime
+    model_config = {"from_attributes": True}
+
+
+# ── str ───────────────────────────────────────────────────────────────────────
+
+class GuitarCreate(BaseModel):
+    name: str
+    threshold_days: int = 30
+
+class GuitarUpdate(BaseModel):
+    name: Optional[str] = None
+    threshold_days: Optional[int] = None
+
+class GuitarOut(BaseModel):
+    id: int
+    name: str
+    threshold_days: int
+    last_changed: Optional[datetime]
+    history: list[str]
+    model_config = {"from_attributes": True}
+
+
+# ── crd ───────────────────────────────────────────────────────────────────────
+
+class CrdStateUpdate(BaseModel):
+    lyrics: Optional[str] = None
+    manual_chords: Optional[str] = None
+    media_url: Optional[str] = None
+    chords: Optional[list[Any]] = None
+    cursor: Optional[int] = None
+    word_seq: Optional[int] = None
+    lines: Optional[list[Any]] = None
+    manual_output: Optional[str] = None
+
+class CrdStateOut(BaseModel):
+    lyrics: str
+    manual_chords: str
+    media_url: str
+    chords: list[Any]
+    cursor: int
+    word_seq: int
+    lines: list[Any]
+    manual_output: Optional[str]
+    model_config = {"from_attributes": True}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>endermatx</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "endermatx-frontend",
+  "private": true,
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.26.2"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.3.2",
+    "vite": "^5.4.8"
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,26 @@
+import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import Home from './pages/Home'
+import TimeTracker from './pages/TimeTracker'
+import Calendar from './pages/Calendar'
+import Pomodoro from './pages/Pomodoro'
+import Meetings from './pages/Meetings'
+import IdeaInbox from './pages/IdeaInbox'
+import StringTracker from './pages/StringTracker'
+import ChordAligner from './pages/ChordAligner'
+
+export default function App() {
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/tts" element={<TimeTracker />} />
+        <Route path="/cal" element={<Calendar />} />
+        <Route path="/pom" element={<Pomodoro />} />
+        <Route path="/mtg" element={<Meetings />} />
+        <Route path="/idx" element={<IdeaInbox />} />
+        <Route path="/str" element={<StringTracker />} />
+        <Route path="/crd" element={<ChordAligner />} />
+      </Routes>
+    </BrowserRouter>
+  )
+}

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,0 +1,78 @@
+const BASE = '/api'
+
+async function req(method, path, body) {
+  const opts = { method, headers: {} }
+  if (body !== undefined) {
+    opts.headers['Content-Type'] = 'application/json'
+    opts.body = JSON.stringify(body)
+  }
+  const res = await fetch(BASE + path, opts)
+  if (!res.ok) throw new Error(`${method} ${path} → ${res.status}`)
+  if (res.status === 204) return null
+  return res.json()
+}
+
+const get  = (path)        => req('GET',    path)
+const post = (path, body)  => req('POST',   path, body)
+const put  = (path, body)  => req('PUT',    path, body)
+const del  = (path)        => req('DELETE', path)
+
+// ── tts ───────────────────────────────────────────────────────
+export const tts = {
+  getProjects: ()            => get('/tts/projects'),
+  createProject: (b)         => post('/tts/projects', b),
+  updateProject: (id, b)     => put(`/tts/projects/${id}`, b),
+  deleteProject: (id)        => del(`/tts/projects/${id}`),
+  getEntries: (projectId)    => get('/tts/entries' + (projectId ? `?project_id=${projectId}` : '')),
+  createEntry: (b)           => post('/tts/entries', b),
+  updateEntry: (id, b)       => put(`/tts/entries/${id}`, b),
+  deleteEntry: (id)          => del(`/tts/entries/${id}`),
+}
+
+// ── cal ───────────────────────────────────────────────────────
+export const cal = {
+  getProjects: ()            => get('/cal/projects'),
+  createProject: (b)         => post('/cal/projects', b),
+  updateProject: (id, b)     => put(`/cal/projects/${id}`, b),
+  deleteProject: (id)        => del(`/cal/projects/${id}`),
+  getSettings: ()            => get('/cal/settings'),
+  updateSettings: (b)        => put('/cal/settings', b),
+}
+
+// ── pom ───────────────────────────────────────────────────────
+export const pom = {
+  getState: ()               => get('/pom/state'),
+  updateState: (b)           => put('/pom/state', b),
+}
+
+// ── mtg ───────────────────────────────────────────────────────
+export const mtg = {
+  getMeetings: ()            => get('/mtg/meetings'),
+  createMeeting: (b)         => post('/mtg/meetings', b),
+  updateMeeting: (id, b)     => put(`/mtg/meetings/${id}`, b),
+  deleteMeeting: (id)        => del(`/mtg/meetings/${id}`),
+}
+
+// ── idx ───────────────────────────────────────────────────────
+export const idx = {
+  getIdeas: ()               => get('/idx/ideas'),
+  createIdea: (b)            => post('/idx/ideas', b),
+  updateIdea: (id, b)        => put(`/idx/ideas/${id}`, b),
+  deleteIdea: (id)           => del(`/idx/ideas/${id}`),
+}
+
+// ── str ───────────────────────────────────────────────────────
+export const str = {
+  getGuitars: ()             => get('/str/guitars'),
+  createGuitar: (b)          => post('/str/guitars', b),
+  updateGuitar: (id, b)      => put(`/str/guitars/${id}`, b),
+  deleteGuitar: (id)         => del(`/str/guitars/${id}`),
+  recordChange: (id)         => post(`/str/guitars/${id}/change`),
+  undoChange: (id)           => del(`/str/guitars/${id}/change`),
+}
+
+// ── crd ───────────────────────────────────────────────────────
+export const crd = {
+  getState: ()               => get('/crd/state'),
+  updateState: (b)           => put('/crd/state', b),
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,169 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  background: #0d0d0d;
+  color: #e0e0e0;
+  font-family: 'Courier New', Courier, monospace;
+  min-height: 100vh;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button {
+  font-family: 'Courier New', Courier, monospace;
+  cursor: pointer;
+}
+
+input, textarea, select {
+  font-family: 'Courier New', Courier, monospace;
+}
+
+/* ── Top bar ──────────────────────────────────────────────────── */
+.topbar {
+  position: fixed;
+  top: 0; left: 0; right: 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 6px 12px;
+  background: #111;
+  border-bottom: 1px solid #222;
+  font-size: 11px;
+  color: #ccc;
+  z-index: 50;
+}
+.topbar-left { display: flex; align-items: center; gap: 8px; }
+.topbar-title { font-weight: bold; letter-spacing: 0.15em; }
+.topbar-back {
+  background: none; border: 1px solid #333; color: #888;
+  font-size: 11px; padding: 2px 8px;
+}
+.topbar-back:hover { border-color: #888; color: #ccc; }
+
+/* ── Page shell ──────────────────────────────────────────────── */
+.page {
+  margin-top: 32px;
+  padding: 20px 16px;
+  max-width: 720px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+/* ── Shared controls ─────────────────────────────────────────── */
+.btn {
+  background: none;
+  border: 1px solid #333;
+  color: #ccc;
+  padding: 5px 12px;
+  font-size: 12px;
+}
+.btn:hover { border-color: #888; color: #fff; }
+.btn-primary { border-color: #8855ff; color: #8855ff; }
+.btn-primary:hover { background: rgba(136,85,255,0.1); }
+.btn-danger { border-color: #f44336; color: #f44336; }
+.btn-danger:hover { background: rgba(244,67,54,0.1); }
+.btn-sm { padding: 2px 8px; font-size: 11px; }
+
+.input {
+  background: #1a1a1a;
+  border: 1px solid #333;
+  color: #e0e0e0;
+  padding: 8px 10px;
+  font-size: 14px;
+  width: 100%;
+  outline: none;
+}
+.input:focus { border-color: #8855ff; }
+.input::placeholder { color: #555; }
+
+.textarea {
+  background: #1a1a1a;
+  border: 1px solid #333;
+  color: #e0e0e0;
+  padding: 8px 10px;
+  font-size: 13px;
+  width: 100%;
+  resize: vertical;
+  outline: none;
+  min-height: 80px;
+}
+.textarea:focus { border-color: #8855ff; }
+
+/* ── Cards ───────────────────────────────────────────────────── */
+.card {
+  background: #111;
+  border: 1px solid #1e1e1e;
+  padding: 14px;
+  margin-bottom: 8px;
+}
+.card:hover { border-color: #2a2a2a; }
+
+/* ── Home grid ───────────────────────────────────────────────── */
+.home-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 10px;
+  margin-top: 24px;
+}
+.home-card {
+  background: #111;
+  border: 1px solid #222;
+  padding: 20px 16px;
+  display: block;
+  transition: border-color 0.15s;
+}
+.home-card:hover { border-color: #555; }
+.home-card-name { font-size: 13px; color: #e0e0e0; letter-spacing: 0.1em; }
+.home-card-desc { font-size: 11px; color: #666; margin-top: 4px; }
+
+/* ── Flex utils ──────────────────────────────────────────────── */
+.row { display: flex; align-items: center; gap: 8px; }
+.row-between { display: flex; align-items: center; justify-content: space-between; }
+.gap4 { gap: 4px; }
+.gap8 { gap: 8px; }
+.gap12 { gap: 12px; }
+.mt4  { margin-top: 4px; }
+.mt8  { margin-top: 8px; }
+.mt12 { margin-top: 12px; }
+.mt16 { margin-top: 16px; }
+.mt24 { margin-top: 24px; }
+
+/* ── Text utils ──────────────────────────────────────────────── */
+.text-sm   { font-size: 11px; }
+.text-muted { color: #666; }
+.text-accent { color: #8855ff; }
+.label { font-size: 11px; color: #888; letter-spacing: 0.05em; margin-bottom: 4px; display: block; }
+
+/* ── Section header ──────────────────────────────────────────── */
+.section-header {
+  font-size: 11px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: #555;
+  margin-bottom: 12px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid #1e1e1e;
+}
+
+/* ── Tabs ────────────────────────────────────────────────────── */
+.tabs { display: flex; border-bottom: 1px solid #222; margin-bottom: 16px; }
+.tab {
+  background: none; border: none; border-bottom: 2px solid transparent;
+  color: #888; padding: 7px 14px; font-size: 13px;
+  letter-spacing: 0.05em; margin-bottom: -1px;
+}
+.tab:hover { color: #ccc; }
+.tab.active { color: #8855ff; border-bottom-color: #8855ff; }
+
+/* ── Color dot ───────────────────────────────────────────────── */
+.color-dot {
+  width: 10px; height: 10px; border-radius: 50%;
+  display: inline-block; flex-shrink: 0;
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App.jsx'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/frontend/src/pages/Calendar.jsx
+++ b/frontend/src/pages/Calendar.jsx
@@ -1,0 +1,175 @@
+import { useState, useEffect } from 'react'
+import { Link } from 'react-router-dom'
+import { cal } from '../api'
+
+const MONTHS = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec']
+const COLORS = ['#4a9eff','#e74c3c','#2ecc71','#f1c40f','#9b59b6','#e67e22','#1abc9c','#e91e63']
+
+function daysInMonth(y, m) { return new Date(y, m + 1, 0).getDate() }
+
+function parseDate(s) { return s ? new Date(s) : null }
+
+function isInRange(y, m, d, start, end) {
+  const date = new Date(y, m, d)
+  return date >= parseDate(start) && date <= parseDate(end)
+}
+
+export default function Calendar() {
+  const [projects, setProjects] = useState([])
+  const [settings, setSettings] = useState(null)
+  const [showForm, setShowForm] = useState(false)
+  const [editId, setEditId] = useState(null)
+  const [form, setForm] = useState({ name: '', color: COLORS[0], start_date: '', end_date: '' })
+
+  useEffect(() => {
+    cal.getProjects().then(setProjects)
+    cal.getSettings().then(setSettings)
+  }, [])
+
+  function months() {
+    if (!settings) return []
+    const result = []
+    let y = settings.start_year, m = settings.start_month
+    const ey = settings.end_year, em = settings.end_month
+    while (y < ey || (y === ey && m <= em)) {
+      result.push({ y, m })
+      m++; if (m > 11) { m = 0; y++ }
+    }
+    return result
+  }
+
+  async function saveProject(e) {
+    e.preventDefault()
+    if (!form.name.trim() || !form.start_date || !form.end_date) return
+    if (editId) {
+      const p = await cal.updateProject(editId, form)
+      setProjects(ps => ps.map(x => x.id === editId ? p : x))
+    } else {
+      const p = await cal.createProject(form)
+      setProjects(ps => [...ps, p])
+    }
+    setShowForm(false)
+    setEditId(null)
+    setForm({ name: '', color: COLORS[projects.length % COLORS.length], start_date: '', end_date: '' })
+  }
+
+  async function deleteProject(id) {
+    await cal.deleteProject(id)
+    setProjects(ps => ps.filter(p => p.id !== id))
+    if (editId === id) { setEditId(null); setShowForm(false) }
+  }
+
+  function startEdit(p) {
+    setForm({ name: p.name, color: p.color, start_date: p.start_date, end_date: p.end_date })
+    setEditId(p.id)
+    setShowForm(true)
+  }
+
+  return (
+    <div>
+      <div className="topbar">
+        <div className="topbar-left">
+          <Link to="/"><button className="topbar-back btn btn-sm">←</button></Link>
+          <span className="topbar-title">cal</span>
+          <span style={{ fontSize: 10, color: '#bbb', letterSpacing: '0.05em' }}>v1.4</span>
+        </div>
+      </div>
+      <div className="page" style={{ maxWidth: 900 }}>
+        {/* Projects list */}
+        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginBottom: 16, alignItems: 'center' }}>
+          {projects.map(p => (
+            <span key={p.id} onClick={() => startEdit(p)}
+              style={{ display: 'flex', alignItems: 'center', gap: 6, background: '#111', border: '1px solid #222',
+                padding: '4px 10px', fontSize: 12, cursor: 'pointer', color: '#ccc' }}>
+              <span style={{ width: 8, height: 8, borderRadius: '50%', background: p.color }} />
+              {p.name}
+            </span>
+          ))}
+          <button className="btn btn-sm" onClick={() => { setShowForm(true); setEditId(null); setForm({ name: '', color: COLORS[projects.length % COLORS.length], start_date: '', end_date: '' }) }}>+ add</button>
+        </div>
+
+        {showForm && (
+          <form onSubmit={saveProject} className="card" style={{ marginBottom: 16 }}>
+            <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'flex-end' }}>
+              <div style={{ flex: '1 1 160px' }}>
+                <label className="label">name</label>
+                <input className="input" value={form.name} onChange={e => setForm(f => ({...f, name: e.target.value}))} placeholder="Project name" />
+              </div>
+              <div style={{ flex: '1 1 120px' }}>
+                <label className="label">start</label>
+                <input className="input" type="date" value={form.start_date} onChange={e => setForm(f => ({...f, start_date: e.target.value}))} />
+              </div>
+              <div style={{ flex: '1 1 120px' }}>
+                <label className="label">end</label>
+                <input className="input" type="date" value={form.end_date} onChange={e => setForm(f => ({...f, end_date: e.target.value}))} />
+              </div>
+              <div>
+                <label className="label">color</label>
+                <div style={{ display: 'flex', gap: 4 }}>
+                  {COLORS.map(c => (
+                    <button key={c} type="button" onClick={() => setForm(f => ({...f, color: c}))}
+                      style={{ width: 20, height: 20, background: c, border: form.color === c ? '2px solid #fff' : '2px solid transparent', borderRadius: 2 }} />
+                  ))}
+                </div>
+              </div>
+            </div>
+            <div style={{ display: 'flex', gap: 8, marginTop: 12 }}>
+              <button type="submit" className="btn btn-primary btn-sm">save</button>
+              <button type="button" className="btn btn-sm" onClick={() => { setShowForm(false); setEditId(null) }}>cancel</button>
+              {editId && <button type="button" className="btn btn-danger btn-sm" style={{ marginLeft: 'auto' }} onClick={() => deleteProject(editId)}>delete</button>}
+            </div>
+          </form>
+        )}
+
+        {/* Calendar grid */}
+        {settings && months().map(({ y, m }) => {
+          const days = daysInMonth(y, m)
+          const today = new Date()
+          const isThisMonth = today.getFullYear() === y && today.getMonth() === m
+
+          return (
+            <div key={`${y}-${m}`} style={{ marginBottom: 24 }}>
+              <div style={{ fontSize: 11, color: '#555', letterSpacing: '0.2em', marginBottom: 8 }}>
+                {MONTHS[m]} {y}
+              </div>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
+                {Array.from({ length: days }, (_, i) => {
+                  const d = i + 1
+                  const isToday = isThisMonth && today.getDate() === d
+                  const projectsOnDay = projects.filter(p => isInRange(y, m, d, p.start_date, p.end_date))
+                  return (
+                    <div key={d} style={{
+                      width: 28, height: 28,
+                      background: projectsOnDay.length > 0 ? projectsOnDay[0].color + '33' : '#111',
+                      border: isToday ? '1px solid #8855ff' : '1px solid #1a1a1a',
+                      display: 'flex', alignItems: 'center', justifyContent: 'center',
+                      fontSize: 10, color: isToday ? '#8855ff' : '#555',
+                      position: 'relative',
+                    }}>
+                      {d}
+                      {projectsOnDay.length > 1 && (
+                        <span style={{ position: 'absolute', bottom: 1, right: 1, width: 4, height: 4, borderRadius: '50%', background: projectsOnDay[1].color }} />
+                      )}
+                    </div>
+                  )
+                })}
+              </div>
+              {projects.filter(p => {
+                const start = parseDate(p.start_date)
+                const end = parseDate(p.end_date)
+                const monthStart = new Date(y, m, 1)
+                const monthEnd = new Date(y, m + 1, 0)
+                return start <= monthEnd && end >= monthStart
+              }).map(p => (
+                <div key={p.id} style={{ marginTop: 4, display: 'flex', alignItems: 'center', gap: 6, fontSize: 11, color: '#888' }}>
+                  <span style={{ width: 6, height: 6, borderRadius: '50%', background: p.color }} />
+                  {p.name}
+                </div>
+              ))}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/ChordAligner.jsx
+++ b/frontend/src/pages/ChordAligner.jsx
@@ -1,0 +1,140 @@
+import { useState, useEffect, useRef } from 'react'
+import { Link } from 'react-router-dom'
+import { crd } from '../api'
+
+function distributeChords(lyrics, chordsText) {
+  const words = lyrics.trim().split(/\s+/).filter(Boolean)
+  const chords = chordsText.trim().split(/\s+/).filter(Boolean)
+  if (!words.length || !chords.length) return []
+
+  const result = []
+  const step = words.length / chords.length
+  chords.forEach((chord, i) => {
+    const wordIdx = Math.round(i * step)
+    result.push({ chord, wordIdx: Math.min(wordIdx, words.length - 1) })
+  })
+  return result
+}
+
+function renderAligned(lyrics, chords) {
+  if (!lyrics.trim()) return ''
+  const words = lyrics.trim().split(/\s+/)
+  const chordMap = {}
+  chords.forEach(c => { chordMap[c.wordIdx] = c.chord })
+
+  const lines = []
+  let chordLine = ''
+  let lyricLine = ''
+  let col = 0
+
+  words.forEach((word, i) => {
+    const chord = chordMap[i] || ''
+    const len = Math.max(word.length, chord.length) + 1
+    chordLine += (chord + ' ').padEnd(len)
+    lyricLine += (word + ' ').padEnd(len)
+    col += len
+    if (col > 60 || i === words.length - 1) {
+      lines.push(chordLine.trimEnd())
+      lines.push(lyricLine.trimEnd())
+      lines.push('')
+      chordLine = ''
+      lyricLine = ''
+      col = 0
+    }
+  })
+  return lines.join('\n')
+}
+
+export default function ChordAligner() {
+  const [lyrics, setLyrics] = useState('')
+  const [manualChords, setManualChords] = useState('')
+  const [mediaUrl, setMediaUrl] = useState('')
+  const [aligned, setAligned] = useState('')
+  const [saved, setSaved] = useState(false)
+  const saveTimer = useRef(null)
+
+  useEffect(() => {
+    crd.getState().then(s => {
+      setLyrics(s.lyrics || '')
+      setManualChords(s.manual_chords || '')
+      setMediaUrl(s.media_url || '')
+      if (s.lines?.length) {
+        setAligned(renderAligned(s.lyrics, s.chords || []))
+      }
+    })
+  }, [])
+
+  function scheduleSave(update) {
+    clearTimeout(saveTimer.current)
+    setSaved(false)
+    saveTimer.current = setTimeout(async () => {
+      await crd.updateState(update)
+      setSaved(true)
+    }, 1500)
+  }
+
+  function handleLyricsChange(v) {
+    setLyrics(v)
+    scheduleSave({ lyrics: v })
+  }
+
+  function handleChordsChange(v) {
+    setManualChords(v)
+    scheduleSave({ manual_chords: v })
+  }
+
+  function handleUrlChange(v) {
+    setMediaUrl(v)
+    scheduleSave({ media_url: v })
+  }
+
+  function autoAlign() {
+    const chords = distributeChords(lyrics, manualChords)
+    const output = renderAligned(lyrics, chords)
+    setAligned(output)
+    scheduleSave({ chords, lines: lyrics.split('\n'), manual_chords: manualChords })
+  }
+
+  return (
+    <div>
+      <div className="topbar">
+        <div className="topbar-left">
+          <Link to="/"><button className="topbar-back btn btn-sm">←</button></Link>
+          <span className="topbar-title">crd</span>
+          <span style={{ fontSize: 10, color: '#bbb', letterSpacing: '0.05em' }}>v1.1</span>
+        </div>
+        <span style={{ fontSize: 11, color: saved ? '#4caf50' : '#555' }}>{saved ? 'saved' : '…'}</span>
+      </div>
+      <div className="page">
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }}>
+          <div>
+            <label className="label">lyrics</label>
+            <textarea className="textarea" rows={12} value={lyrics} onChange={e => handleLyricsChange(e.target.value)} placeholder="Paste lyrics here…" />
+          </div>
+          <div>
+            <label className="label">chords (space-separated)</label>
+            <textarea className="textarea" rows={4} value={manualChords} onChange={e => handleChordsChange(e.target.value)} placeholder="G G C G D G C G" />
+            <label className="label mt8">audio / video URL</label>
+            <input className="input" value={mediaUrl} onChange={e => handleUrlChange(e.target.value)} placeholder="https://…" />
+            {mediaUrl && (
+              <audio controls src={mediaUrl} style={{ marginTop: 8, width: '100%' }} />
+            )}
+          </div>
+        </div>
+
+        <div style={{ marginTop: 12 }}>
+          <button className="btn btn-primary btn-sm" onClick={autoAlign}>auto-align</button>
+        </div>
+
+        {aligned && (
+          <div style={{ marginTop: 20 }}>
+            <div className="section-header">aligned</div>
+            <pre style={{ background: '#0a0a0a', border: '1px solid #1a1a1a', padding: 16, fontSize: 13, color: '#ccc', overflowX: 'auto', whiteSpace: 'pre' }}>
+              {aligned}
+            </pre>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,0 +1,30 @@
+import { Link } from 'react-router-dom'
+
+const TOOLS = [
+  { path: '/tts', name: 'tts', desc: 'time tracker' },
+  { path: '/cal', name: 'cal', desc: 'calendar' },
+  { path: '/pom', name: 'pom', desc: 'pomodoro' },
+  { path: '/mtg', name: 'mtg', desc: 'meeting notes' },
+  { path: '/idx', name: 'idx', desc: 'idea inbox' },
+  { path: '/str', name: 'str', desc: 'string tracker' },
+  { path: '/crd', name: 'crd', desc: 'chord aligner' },
+]
+
+export default function Home() {
+  return (
+    <div style={{ padding: '40px 20px', maxWidth: 600, margin: '0 auto' }}>
+      <h1 style={{ fontSize: 28, letterSpacing: '0.15em', marginBottom: 8 }}>
+        ENDERMATX
+      </h1>
+      <p style={{ color: '#555', fontSize: 12, marginBottom: 32 }}>personal tools</p>
+      <div className="home-grid">
+        {TOOLS.map(t => (
+          <Link key={t.path} to={t.path} className="home-card">
+            <div className="home-card-name">{t.name}</div>
+            <div className="home-card-desc">{t.desc}</div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/IdeaInbox.jsx
+++ b/frontend/src/pages/IdeaInbox.jsx
@@ -1,0 +1,124 @@
+import { useState, useEffect, useRef } from 'react'
+import { Link } from 'react-router-dom'
+import { idx } from '../api'
+
+const TABS = [
+  { key: 'inbox',    label: 'IN',  status: 'inbox' },
+  { key: 'promoted', label: 'DO',  status: 'promoted' },
+  { key: 'deferred', label: 'BL',  status: 'deferred' },
+]
+
+const TRANSITIONS = {
+  inbox:    [{ label: 'DO', status: 'promoted' }, { label: 'BL', status: 'deferred' }, { label: 'kill', status: 'killed' }],
+  promoted: [{ label: 'DONE', status: 'done' }, { label: 'kill', status: 'killed' }],
+  deferred: [{ label: 'DO', status: 'promoted' }, { label: 'kill', status: 'killed' }],
+}
+
+export default function IdeaInbox() {
+  const [ideas, setIdeas] = useState([])
+  const [tab, setTab] = useState('inbox')
+  const [text, setText] = useState('')
+  const [editId, setEditId] = useState(null)
+  const [editText, setEditText] = useState('')
+  const inputRef = useRef(null)
+
+  useEffect(() => { idx.getIdeas().then(setIdeas) }, [])
+
+  async function addIdea(e) {
+    e.preventDefault()
+    if (!text.trim()) return
+    const idea = await idx.createIdea({ text: text.trim() })
+    setIdeas(is => [idea, ...is])
+    setText('')
+  }
+
+  async function transition(id, status) {
+    const idea = await idx.updateIdea(id, { status })
+    setIdeas(is => is.map(i => i.id === id ? idea : i))
+  }
+
+  async function saveEdit(id) {
+    if (!editText.trim()) return
+    const idea = await idx.updateIdea(id, { text: editText.trim() })
+    setIdeas(is => is.map(i => i.id === id ? idea : i))
+    setEditId(null)
+  }
+
+  const visible = ideas.filter(i => i.status === tab)
+  const counts = {}
+  TABS.forEach(t => { counts[t.key] = ideas.filter(i => i.status === t.status).length })
+
+  return (
+    <div>
+      <div className="topbar">
+        <div className="topbar-left">
+          <Link to="/"><button className="topbar-back btn btn-sm">←</button></Link>
+          <span className="topbar-title">idx</span>
+          <span style={{ fontSize: 10, color: '#bbb', letterSpacing: '0.05em' }}>v1.12</span>
+        </div>
+      </div>
+      <div className="page">
+        <form onSubmit={addIdea} style={{ marginBottom: 20 }}>
+          <input
+            ref={inputRef}
+            className="input"
+            style={{ borderLeft: '2px solid #8855ff' }}
+            placeholder="capture an idea…"
+            value={text}
+            onChange={e => setText(e.target.value)}
+          />
+        </form>
+
+        <div className="tabs">
+          {TABS.map(t => (
+            <button key={t.key} className={`tab${tab === t.key ? ' active' : ''}`} onClick={() => setTab(t.key)}>
+              {t.label} <span style={{ fontSize: 11, color: '#555', marginLeft: 4 }}>{counts[t.key]}</span>
+            </button>
+          ))}
+        </div>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+          {visible.length === 0 && (
+            <div style={{ color: '#444', fontSize: 13, padding: '20px 0' }}>empty</div>
+          )}
+          {visible.map(idea => (
+            <div key={idea.id} className="card" style={{ padding: '10px 12px' }}>
+              {editId === idea.id ? (
+                <div style={{ display: 'flex', gap: 8 }}>
+                  <input
+                    className="input"
+                    style={{ flex: 1 }}
+                    value={editText}
+                    onChange={e => setEditText(e.target.value)}
+                    onKeyDown={e => { if (e.key === 'Enter') saveEdit(idea.id); if (e.key === 'Escape') setEditId(null) }}
+                    autoFocus
+                  />
+                  <button className="btn btn-sm btn-primary" onClick={() => saveEdit(idea.id)}>save</button>
+                  <button className="btn btn-sm" onClick={() => setEditId(null)}>cancel</button>
+                </div>
+              ) : (
+                <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8 }}>
+                  <span
+                    style={{ flex: 1, fontSize: 14, color: '#ddd', cursor: tab === 'inbox' ? 'pointer' : 'default' }}
+                    onClick={() => { if (tab === 'inbox') { setEditId(idea.id); setEditText(idea.text) } }}
+                  >
+                    {idea.text}
+                  </span>
+                  <div style={{ display: 'flex', gap: 4, flexShrink: 0 }}>
+                    {(TRANSITIONS[tab] || []).map(tr => (
+                      <button key={tr.status} className="btn btn-sm"
+                        style={tr.status === 'killed' ? { color: '#555', borderColor: '#222' } : {}}
+                        onClick={() => transition(idea.id, tr.status)}>
+                        {tr.label}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/Meetings.jsx
+++ b/frontend/src/pages/Meetings.jsx
@@ -1,0 +1,193 @@
+import { useState, useEffect } from 'react'
+import { Link } from 'react-router-dom'
+import { mtg } from '../api'
+
+function uid() { return Date.now() + Math.random().toString(36).slice(2) }
+
+export default function Meetings() {
+  const [meetings, setMeetings] = useState([])
+  const [tab, setTab] = useState('meetings')
+  const [openId, setOpenId] = useState(null)
+  const [creating, setCreating] = useState(false)
+  const [form, setForm] = useState({ title: '', date: '', notes: '', attendees: [], actions: [], summary: '' })
+  const [newAttendee, setNewAttendee] = useState('')
+  const [newAction, setNewAction] = useState('')
+  const [actionsFilter, setActionsFilter] = useState('open')
+
+  useEffect(() => { mtg.getMeetings().then(setMeetings) }, [])
+
+  function openMeeting(m) {
+    setForm({ title: m.title, date: m.date, notes: m.notes, attendees: [...m.attendees], actions: [...m.actions], summary: m.summary })
+    setOpenId(m.id)
+    setCreating(false)
+  }
+
+  function startCreate() {
+    setForm({ title: '', date: new Date().toISOString().slice(0,10), notes: '', attendees: [], actions: [], summary: '' })
+    setOpenId(null)
+    setCreating(true)
+  }
+
+  async function save() {
+    if (!form.title.trim()) return
+    if (creating) {
+      const m = await mtg.createMeeting(form)
+      setMeetings(ms => [m, ...ms])
+    } else {
+      const m = await mtg.updateMeeting(openId, form)
+      setMeetings(ms => ms.map(x => x.id === openId ? m : x))
+    }
+    setCreating(false)
+    setOpenId(null)
+  }
+
+  async function deleteMeeting(id) {
+    await mtg.deleteMeeting(id)
+    setMeetings(ms => ms.filter(m => m.id !== id))
+    if (openId === id) setOpenId(null)
+  }
+
+  function addAttendee() {
+    if (!newAttendee.trim()) return
+    setForm(f => ({ ...f, attendees: [...f.attendees, newAttendee.trim()] }))
+    setNewAttendee('')
+  }
+
+  function removeAttendee(i) {
+    setForm(f => ({ ...f, attendees: f.attendees.filter((_, idx) => idx !== i) }))
+  }
+
+  function addAction() {
+    if (!newAction.trim()) return
+    setForm(f => ({ ...f, actions: [...f.actions, { id: uid(), text: newAction.trim(), done: false }] }))
+    setNewAction('')
+  }
+
+  function toggleAction(actionId) {
+    setForm(f => ({ ...f, actions: f.actions.map(a => a.id === actionId ? { ...a, done: !a.done } : a) }))
+  }
+
+  async function toggleSavedAction(mid, actionId) {
+    const meeting = meetings.find(m => m.id === mid)
+    if (!meeting) return
+    const actions = meeting.actions.map(a => a.id === actionId ? { ...a, done: !a.done } : a)
+    const updated = await mtg.updateMeeting(mid, { actions })
+    setMeetings(ms => ms.map(m => m.id === mid ? updated : m))
+  }
+
+  const allActions = meetings.flatMap(m =>
+    (m.actions || []).map(a => ({ ...a, meetingTitle: m.title, meetingId: m.id }))
+  )
+  const filteredActions = actionsFilter === 'all' ? allActions
+    : actionsFilter === 'open' ? allActions.filter(a => !a.done)
+    : allActions.filter(a => a.done)
+
+  const isEditing = creating || openId !== null
+
+  return (
+    <div>
+      <div className="topbar">
+        <div className="topbar-left">
+          <Link to="/"><button className="topbar-back btn btn-sm">←</button></Link>
+          <span className="topbar-title">mtg</span>
+          <span style={{ fontSize: 10, color: '#bbb', letterSpacing: '0.05em' }}>v1.1</span>
+        </div>
+      </div>
+      <div className="page">
+        <div className="tabs">
+          <button className={`tab${tab === 'meetings' ? ' active' : ''}`} onClick={() => setTab('meetings')}>Meetings</button>
+          <button className={`tab${tab === 'actions' ? ' active' : ''}`} onClick={() => setTab('actions')}>Actions</button>
+        </div>
+
+        {tab === 'meetings' && (
+          <>
+            {!isEditing && (
+              <button className="btn btn-primary btn-sm" style={{ marginBottom: 16 }} onClick={startCreate}>+ new meeting</button>
+            )}
+
+            {isEditing && (
+              <div className="card" style={{ marginBottom: 16 }}>
+                <div className="section-header">{creating ? 'new meeting' : 'edit'}</div>
+                <label className="label">title</label>
+                <input className="input" value={form.title} onChange={e => setForm(f => ({...f, title: e.target.value}))} placeholder="Meeting title" />
+                <label className="label mt8">date</label>
+                <input className="input" type="date" value={form.date} onChange={e => setForm(f => ({...f, date: e.target.value}))} />
+                <label className="label mt8">attendees</label>
+                <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginBottom: 8 }}>
+                  {form.attendees.map((a, i) => (
+                    <span key={i} style={{ background: '#1a1a1a', border: '1px solid #333', padding: '2px 8px', fontSize: 12, color: '#ccc' }}>
+                      {a} <button style={{ background: 'none', border: 'none', color: '#555', marginLeft: 4, cursor: 'pointer' }} onClick={() => removeAttendee(i)}>×</button>
+                    </span>
+                  ))}
+                </div>
+                <div style={{ display: 'flex', gap: 6 }}>
+                  <input className="input" value={newAttendee} onChange={e => setNewAttendee(e.target.value)}
+                    onKeyDown={e => e.key === 'Enter' && addAttendee()} placeholder="Add attendee" />
+                  <button className="btn btn-sm" onClick={addAttendee}>add</button>
+                </div>
+                <label className="label mt8">notes</label>
+                <textarea className="textarea" rows={4} value={form.notes} onChange={e => setForm(f => ({...f, notes: e.target.value}))} />
+                <label className="label mt8">action items</label>
+                {form.actions.map(a => (
+                  <div key={a.id} style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4 }}>
+                    <input type="checkbox" checked={a.done} onChange={() => toggleAction(a.id)} />
+                    <span style={{ fontSize: 13, color: a.done ? '#555' : '#ccc', textDecoration: a.done ? 'line-through' : 'none' }}>{a.text}</span>
+                  </div>
+                ))}
+                <div style={{ display: 'flex', gap: 6, marginTop: 8 }}>
+                  <input className="input" value={newAction} onChange={e => setNewAction(e.target.value)}
+                    onKeyDown={e => e.key === 'Enter' && addAction()} placeholder="Add action item" />
+                  <button className="btn btn-sm" onClick={addAction}>add</button>
+                </div>
+                <div style={{ display: 'flex', gap: 8, marginTop: 16 }}>
+                  <button className="btn btn-primary btn-sm" onClick={save}>save</button>
+                  <button className="btn btn-sm" onClick={() => { setCreating(false); setOpenId(null) }}>cancel</button>
+                  {!creating && <button className="btn btn-danger btn-sm" style={{ marginLeft: 'auto' }} onClick={() => deleteMeeting(openId)}>delete</button>}
+                </div>
+              </div>
+            )}
+
+            {meetings.map(m => (
+              <div key={m.id} className="card" style={{ cursor: 'pointer' }} onClick={() => openMeeting(m)}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+                  <div>
+                    <div style={{ fontSize: 14, color: '#ddd' }}>{m.title}</div>
+                    <div style={{ fontSize: 11, color: '#555', marginTop: 4 }}>
+                      {m.date && <span>{m.date}</span>}
+                      {m.attendees?.length > 0 && <span style={{ marginLeft: 10 }}>{m.attendees.join(', ')}</span>}
+                    </div>
+                  </div>
+                  {m.actions?.length > 0 && (
+                    <div style={{ fontSize: 11, color: '#555' }}>
+                      {m.actions.filter(a => !a.done).length} open / {m.actions.filter(a => a.done).length} done
+                    </div>
+                  )}
+                </div>
+              </div>
+            ))}
+          </>
+        )}
+
+        {tab === 'actions' && (
+          <>
+            <div style={{ display: 'flex', gap: 8, marginBottom: 16 }}>
+              {['open','done','all'].map(f => (
+                <button key={f} className={`btn btn-sm${actionsFilter === f ? ' btn-primary' : ''}`} onClick={() => setActionsFilter(f)}>{f}</button>
+              ))}
+            </div>
+            {filteredActions.length === 0 && <div style={{ color: '#444', fontSize: 13 }}>no actions</div>}
+            {filteredActions.map((a, i) => (
+              <div key={i} className="card" style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '8px 14px' }}>
+                <input type="checkbox" checked={a.done} onChange={() => toggleSavedAction(a.meetingId, a.id)} />
+                <div style={{ flex: 1 }}>
+                  <div style={{ fontSize: 13, color: a.done ? '#555' : '#ccc', textDecoration: a.done ? 'line-through' : 'none' }}>{a.text}</div>
+                  <div style={{ fontSize: 11, color: '#444', marginTop: 2 }}>{a.meetingTitle}</div>
+                </div>
+              </div>
+            ))}
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/Pomodoro.jsx
+++ b/frontend/src/pages/Pomodoro.jsx
@@ -1,0 +1,146 @@
+import { useState, useEffect, useRef } from 'react'
+import { Link } from 'react-router-dom'
+import { pom } from '../api'
+
+const WORK_MINS = 25
+const BREAK_MINS = 5
+
+const MESSAGES = [
+  "tick tock, chop chop",
+  "no scrolling",
+  "you said you'd focus",
+  "eyes on the prize",
+  "almost there",
+  "this is the way",
+]
+
+function pick(arr) { return arr[Math.floor(Math.random() * arr.length)] }
+
+export default function Pomodoro() {
+  const [mode, setMode] = useState('idle')   // idle | work | break
+  const [secsLeft, setSecsLeft] = useState(WORK_MINS * 60)
+  const [cycles, setCycles] = useState(0)
+  const [totalMins, setTotalMins] = useState(0)
+  const [msg, setMsg] = useState(pick(MESSAGES))
+  const intervalRef = useRef(null)
+  const saveRef = useRef(null)
+
+  useEffect(() => {
+    pom.getState().then(s => {
+      setTotalMins(s.total_mins || 0)
+      if (s.timer) {
+        const t = s.timer
+        const elapsed = Math.floor((Date.now() - (t.savedAt || Date.now())) / 1000)
+        const remaining = Math.max(0, (t.secsLeft || WORK_MINS * 60) - elapsed)
+        setMode(t.state || 'idle')
+        setSecsLeft(remaining)
+      }
+      const todayKey = new Date().toDateString()
+      setCycles((s.sessions || {})[todayKey] || 0)
+    })
+  }, [])
+
+  useEffect(() => {
+    if (mode === 'idle') {
+      clearInterval(intervalRef.current)
+      return
+    }
+    intervalRef.current = setInterval(() => {
+      setSecsLeft(s => {
+        if (s <= 1) {
+          handleTimerEnd()
+          return 0
+        }
+        return s - 1
+      })
+    }, 1000)
+    return () => clearInterval(intervalRef.current)
+  }, [mode])
+
+  function handleTimerEnd() {
+    clearInterval(intervalRef.current)
+    if (mode === 'work') {
+      const todayKey = new Date().toDateString()
+      const newCycles = cycles + 1
+      const addedMins = WORK_MINS
+      setCycles(newCycles)
+      setTotalMins(t => t + addedMins)
+      setMode('break')
+      setSecsLeft(BREAK_MINS * 60)
+      setMsg(pick(MESSAGES))
+      pom.updateState({
+        total_mins: totalMins + addedMins,
+        sessions: { [todayKey]: newCycles },
+        timer: { state: 'break', secsLeft: BREAK_MINS * 60, savedAt: Date.now() },
+      })
+    } else {
+      setMode('idle')
+      setSecsLeft(WORK_MINS * 60)
+      pom.updateState({ timer: null })
+    }
+  }
+
+  function start() {
+    setMode('work')
+    setSecsLeft(WORK_MINS * 60)
+    setMsg(pick(MESSAGES))
+    pom.updateState({ timer: { state: 'work', secsLeft: WORK_MINS * 60, savedAt: Date.now() } })
+  }
+
+  function stop() {
+    clearInterval(intervalRef.current)
+    setMode('idle')
+    setSecsLeft(WORK_MINS * 60)
+    pom.updateState({ timer: null })
+  }
+
+  const mins = Math.floor(secsLeft / 60)
+  const secs = secsLeft % 60
+  const timerStr = `${String(mins).padStart(2,'0')}:${String(secs).padStart(2,'0')}`
+
+  const modeColor = mode === 'work' ? '#e74c3c' : mode === 'break' ? '#2ecc71' : '#555'
+
+  return (
+    <div>
+      <div className="topbar">
+        <div className="topbar-left">
+          <Link to="/"><button className="topbar-back btn btn-sm">←</button></Link>
+          <span className="topbar-title">pom</span>
+          <span style={{ fontSize: 10, color: '#bbb', letterSpacing: '0.05em' }}>v1.1</span>
+        </div>
+      </div>
+      <div className="page" style={{ textAlign: 'center', paddingTop: 48 }}>
+        <div style={{ fontSize: 11, color: modeColor, letterSpacing: '0.3em', textTransform: 'uppercase', marginBottom: 16 }}>
+          {mode === 'idle' ? 'ready' : mode}
+        </div>
+
+        <div style={{ fontSize: 72, fontWeight: 'bold', color: modeColor, letterSpacing: '0.05em', marginBottom: 8 }}>
+          {timerStr}
+        </div>
+
+        {mode !== 'idle' && (
+          <div style={{ fontSize: 12, color: '#555', marginBottom: 32 }}>{msg}</div>
+        )}
+
+        <div style={{ display: 'flex', gap: 12, justifyContent: 'center', marginTop: 32 }}>
+          {mode === 'idle' ? (
+            <button className="btn btn-primary" onClick={start} style={{ padding: '8px 24px', fontSize: 13 }}>start</button>
+          ) : (
+            <button className="btn btn-danger" onClick={stop} style={{ padding: '8px 24px', fontSize: 13 }}>stop</button>
+          )}
+        </div>
+
+        <div style={{ marginTop: 64, display: 'flex', gap: 48, justifyContent: 'center' }}>
+          <div>
+            <div style={{ fontSize: 28, color: '#ccc' }}>{cycles}</div>
+            <div style={{ fontSize: 11, color: '#555', marginTop: 4 }}>today</div>
+          </div>
+          <div>
+            <div style={{ fontSize: 28, color: '#ccc' }}>{Math.floor(totalMins)}m</div>
+            <div style={{ fontSize: 11, color: '#555', marginTop: 4 }}>total</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/StringTracker.jsx
+++ b/frontend/src/pages/StringTracker.jsx
@@ -1,0 +1,129 @@
+import { useState, useEffect } from 'react'
+import { Link } from 'react-router-dom'
+import { str } from '../api'
+
+function daysSince(iso) {
+  if (!iso) return null
+  return Math.floor((Date.now() - new Date(iso)) / 86400000)
+}
+
+function statusColor(days, threshold) {
+  if (days === null) return '#f44336'
+  if (days >= threshold) return '#f44336'
+  if (days >= Math.floor(threshold * 0.75)) return '#ff9800'
+  return '#4caf50'
+}
+
+function fmtDate(iso) {
+  if (!iso) return 'never'
+  return new Date(iso).toLocaleDateString()
+}
+
+export default function StringTracker() {
+  const [guitars, setGuitars] = useState([])
+  const [adding, setAdding] = useState(false)
+  const [name, setName] = useState('')
+  const [threshold, setThreshold] = useState(30)
+  const [expandedId, setExpandedId] = useState(null)
+
+  useEffect(() => { str.getGuitars().then(setGuitars) }, [])
+
+  async function addGuitar(e) {
+    e.preventDefault()
+    if (!name.trim()) return
+    const g = await str.createGuitar({ name: name.trim(), threshold_days: Number(threshold) })
+    setGuitars(gs => [...gs, g])
+    setName('')
+    setThreshold(30)
+    setAdding(false)
+  }
+
+  async function recordChange(id) {
+    const g = await str.recordChange(id)
+    setGuitars(gs => gs.map(x => x.id === id ? g : x))
+  }
+
+  async function undoChange(id) {
+    const g = await str.undoChange(id)
+    setGuitars(gs => gs.map(x => x.id === id ? g : x))
+  }
+
+  async function deleteGuitar(id) {
+    await str.deleteGuitar(id)
+    setGuitars(gs => gs.filter(g => g.id !== id))
+    if (expandedId === id) setExpandedId(null)
+  }
+
+  return (
+    <div>
+      <div className="topbar">
+        <div className="topbar-left">
+          <Link to="/"><button className="topbar-back btn btn-sm">←</button></Link>
+          <span className="topbar-title">str</span>
+          <span style={{ fontSize: 10, color: '#bbb', letterSpacing: '0.05em' }}>v1.1</span>
+        </div>
+      </div>
+      <div className="page">
+        <div className="section-header">guitars</div>
+
+        {guitars.map(g => {
+          const days = daysSince(g.last_changed)
+          const color = statusColor(days, g.threshold_days)
+          const expanded = expandedId === g.id
+          return (
+            <div key={g.id} className="card" style={{ marginBottom: 8 }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 10, cursor: 'pointer' }} onClick={() => setExpandedId(expanded ? null : g.id)}>
+                <span style={{ width: 8, height: 8, borderRadius: '50%', background: color, flexShrink: 0 }} />
+                <span style={{ flex: 1, fontSize: 14, color: '#ddd' }}>{g.name}</span>
+                <span style={{ fontSize: 12, color: color }}>
+                  {days === null ? 'never changed' : `${days}d ago`}
+                </span>
+                <span style={{ fontSize: 11, color: '#444' }}>/{g.threshold_days}d</span>
+              </div>
+
+              {expanded && (
+                <div style={{ marginTop: 12, borderTop: '1px solid #1e1e1e', paddingTop: 12 }}>
+                  <div style={{ fontSize: 11, color: '#666', marginBottom: 8 }}>
+                    last changed: {fmtDate(g.last_changed)}
+                  </div>
+                  {g.history?.length > 0 && (
+                    <div style={{ marginBottom: 12 }}>
+                      <div className="label">change history</div>
+                      <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                        {[...g.history].reverse().slice(0, 10).map((h, i) => (
+                          <div key={i} style={{ fontSize: 12, color: '#555' }}>{fmtDate(h)}</div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                  <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+                    <button className="btn btn-sm btn-primary" onClick={() => recordChange(g.id)}>just changed</button>
+                    {g.history?.length > 0 && (
+                      <button className="btn btn-sm" onClick={() => undoChange(g.id)}>undo</button>
+                    )}
+                    <button className="btn btn-sm btn-danger" style={{ marginLeft: 'auto' }} onClick={() => deleteGuitar(g.id)}>delete</button>
+                  </div>
+                </div>
+              )}
+            </div>
+          )
+        })}
+
+        {adding ? (
+          <form onSubmit={addGuitar} className="card mt8">
+            <label className="label">guitar name</label>
+            <input className="input" value={name} onChange={e => setName(e.target.value)} placeholder="e.g. Strat" autoFocus />
+            <label className="label mt8">threshold (days)</label>
+            <input className="input" type="number" min={1} value={threshold} onChange={e => setThreshold(e.target.value)} />
+            <div style={{ display: 'flex', gap: 8, marginTop: 12 }}>
+              <button type="submit" className="btn btn-primary btn-sm">add</button>
+              <button type="button" className="btn btn-sm" onClick={() => setAdding(false)}>cancel</button>
+            </div>
+          </form>
+        ) : (
+          <button className="btn btn-sm mt8" onClick={() => setAdding(true)}>+ guitar</button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/TimeTracker.jsx
+++ b/frontend/src/pages/TimeTracker.jsx
@@ -1,0 +1,170 @@
+import { useState, useEffect, useRef } from 'react'
+import { Link } from 'react-router-dom'
+import { tts } from '../api'
+
+const COLORS = ['#e74c3c','#e67e22','#f1c40f','#2ecc71','#1abc9c','#3498db','#9b59b6','#e91e63']
+
+function fmtMs(ms) {
+  const s = Math.floor(ms / 1000)
+  const h = Math.floor(s / 3600)
+  const m = Math.floor((s % 3600) / 60)
+  const ss = s % 60
+  return h > 0
+    ? `${h}:${String(m).padStart(2,'0')}:${String(ss).padStart(2,'0')}`
+    : `${m}:${String(ss).padStart(2,'0')}`
+}
+
+function fmtDuration(start, end) {
+  const ms = (end ? new Date(end) : new Date()) - new Date(start)
+  return fmtMs(ms)
+}
+
+function fmtTime(dt) {
+  return new Date(dt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+}
+
+function todayEntries(entries) {
+  const today = new Date().toDateString()
+  return entries.filter(e => new Date(e.start_time).toDateString() === today)
+}
+
+export default function TimeTracker() {
+  const [projects, setProjects] = useState([])
+  const [entries, setEntries] = useState([])
+  const [newName, setNewName] = useState('')
+  const [newColor, setNewColor] = useState(COLORS[0])
+  const [adding, setAdding] = useState(false)
+  const [tick, setTick] = useState(0)
+  const timerRef = useRef(null)
+
+  useEffect(() => {
+    tts.getProjects().then(setProjects)
+    tts.getEntries().then(setEntries)
+  }, [])
+
+  useEffect(() => {
+    timerRef.current = setInterval(() => setTick(t => t + 1), 1000)
+    return () => clearInterval(timerRef.current)
+  }, [])
+
+  const activeEntry = entries.find(e => !e.end_time)
+  const activeProjectId = activeEntry?.project_id
+
+  async function handleProjectClick(pid) {
+    if (activeEntry) {
+      const updated = await tts.updateEntry(activeEntry.id, { end_time: new Date().toISOString() })
+      setEntries(es => es.map(e => e.id === updated.id ? updated : e))
+      if (pid === activeProjectId) return
+    }
+    const entry = await tts.createEntry({ project_id: pid, start_time: new Date().toISOString() })
+    setEntries(es => [entry, ...es])
+  }
+
+  async function addProject(e) {
+    e.preventDefault()
+    if (!newName.trim()) return
+    const proj = await tts.createProject({ name: newName.trim(), color: newColor })
+    setProjects(ps => [...ps, proj])
+    setNewName('')
+    setAdding(false)
+  }
+
+  async function archiveProject(pid) {
+    await tts.updateProject(pid, { archived: true })
+    setProjects(ps => ps.filter(p => p.id !== pid))
+    if (activeEntry?.project_id === pid) {
+      const updated = await tts.updateEntry(activeEntry.id, { end_time: new Date().toISOString() })
+      setEntries(es => es.map(e => e.id === updated.id ? updated : e))
+    }
+  }
+
+  async function deleteEntry(eid) {
+    await tts.deleteEntry(eid)
+    setEntries(es => es.filter(e => e.id !== eid))
+  }
+
+  const visibleProjects = projects.filter(p => !p.archived)
+  const today = todayEntries(entries)
+
+  const projectTotals = {}
+  entries.forEach(e => {
+    const ms = (e.end_time ? new Date(e.end_time) : new Date()) - new Date(e.start_time)
+    projectTotals[e.project_id] = (projectTotals[e.project_id] || 0) + ms
+  })
+
+  return (
+    <div>
+      <div className="topbar">
+        <div className="topbar-left">
+          <Link to="/"><button className="topbar-back btn btn-sm">←</button></Link>
+          <span className="topbar-title">tts</span>
+          <span style={{ fontSize: 10, color: '#bbb', letterSpacing: '0.05em' }}>v2.13</span>
+        </div>
+      </div>
+      <div className="page">
+        <div className="section-header">projects</div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+          {visibleProjects.map(p => (
+            <div key={p.id} className="card" style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '10px 14px' }}>
+              <span className="color-dot" style={{ background: p.color }} />
+              <button
+                onClick={() => handleProjectClick(p.id)}
+                style={{ flex: 1, background: 'none', border: 'none', color: p.id === activeProjectId ? p.color : '#ccc', textAlign: 'left', fontSize: 14, padding: 0 }}
+              >
+                {p.name}
+                {p.id === activeProjectId && activeEntry && (
+                  <span style={{ marginLeft: 10, fontSize: 12, color: p.color }}>
+                    {fmtMs(Date.now() - new Date(activeEntry.start_time))}
+                  </span>
+                )}
+              </button>
+              {projectTotals[p.id] && (
+                <span style={{ fontSize: 11, color: '#555' }}>{fmtMs(projectTotals[p.id])}</span>
+              )}
+              <button className="btn btn-sm" style={{ color: '#444', borderColor: '#222' }} onClick={() => archiveProject(p.id)}>×</button>
+            </div>
+          ))}
+        </div>
+
+        {adding ? (
+          <form onSubmit={addProject} className="card mt8" style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+            <input className="input" style={{ flex: 1 }} placeholder="project name" value={newName} onChange={e => setNewName(e.target.value)} autoFocus />
+            <div style={{ display: 'flex', gap: 4 }}>
+              {COLORS.map(c => (
+                <button key={c} type="button" onClick={() => setNewColor(c)}
+                  style={{ width: 18, height: 18, background: c, border: newColor === c ? '2px solid #fff' : '2px solid transparent', borderRadius: 2 }} />
+              ))}
+            </div>
+            <button type="submit" className="btn btn-primary btn-sm">add</button>
+            <button type="button" className="btn btn-sm" onClick={() => setAdding(false)}>cancel</button>
+          </form>
+        ) : (
+          <button className="btn btn-sm mt8" onClick={() => setAdding(true)}>+ project</button>
+        )}
+
+        {today.length > 0 && (
+          <>
+            <div className="section-header mt24">today</div>
+            {today.map(e => {
+              const proj = projects.find(p => p.id === e.project_id)
+              return (
+                <div key={e.id} className="card" style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '8px 14px' }}>
+                  <span className="color-dot" style={{ background: proj?.color || '#555' }} />
+                  <span style={{ flex: 1, fontSize: 13, color: '#ccc' }}>{proj?.name || '—'}</span>
+                  <span style={{ fontSize: 12, color: '#666' }}>{fmtTime(e.start_time)}</span>
+                  <span style={{ fontSize: 12, color: '#555', minWidth: 60, textAlign: 'right' }}>
+                    {fmtDuration(e.start_time, e.end_time)}
+                    {!e.end_time && <span style={{ color: '#ff9800' }}> ●</span>}
+                  </span>
+                  {e.end_time && (
+                    <button className="btn btn-sm" style={{ color: '#333', borderColor: '#1e1e1e' }} onClick={() => deleteEntry(e.id)}>×</button>
+                  )}
+                </div>
+              )
+            })}
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:8000',
+    },
+  },
+})

--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,5 @@
+[build]
+buildCommand = "pip install -r backend/requirements.txt && npm --prefix frontend install && npm --prefix frontend run build"
+
+[deploy]
+startCommand = "uvicorn backend.main:app --host 0.0.0.0 --port ${PORT:-8000}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+-r backend/requirements.txt


### PR DESCRIPTION
- backend/: FastAPI app with SQLAlchemy models and CRUD routers for all 7 tools (tts, cal, pom, mtg, idx, str, crd); DATABASE_URL from env; tables auto-created on startup
- frontend/: Vite + React 18 SPA with React Router; full page components for every tool; CSS matching the existing dark monospace aesthetic; API client proxying /api to FastAPI
- railway.toml: single-service build (pip install + npm build) and uvicorn start command
- FastAPI serves the React build as a SPA fallback so both run on one Railway service

https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw