### PR TITLE
fix: inline deps in root requirements.txt for Railway install phase

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,5 @@
--r backend/requirements.txt
+fastapi==0.115.0
+uvicorn[standard]==0.32.0
+sqlalchemy==2.0.35
+psycopg2-binary==2.9.10
+pydantic==2.9.2


### PR DESCRIPTION
Railway copies requirements.txt before the app directory, so using
-r backend/requirements.txt fails. Duplicate the deps directly here.

https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw