### PR TITLE
fix: remove StaticFiles assets mount that crashes on startup

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
-from fastapi.staticfiles import StaticFiles
 
 from .database import engine, Base
 from .routers import tts, cal, pom, mtg, idx, strings, crd
@@ -29,12 +28,13 @@ app.include_router(crd.router, prefix="/api/crd", tags=["crd"])
 
 FRONTEND_DIST = Path(__file__).parent.parent / "frontend" / "dist"
 
-if FRONTEND_DIST.exists():
-    app.mount("/assets", StaticFiles(directory=FRONTEND_DIST / "assets"), name="assets")
-
-    @app.get("/{full_path:path}")
-    async def spa_fallback(full_path: str):
+@app.get("/{full_path:path}")
+async def spa_fallback(full_path: str):
+    if FRONTEND_DIST.exists():
         candidate = FRONTEND_DIST / full_path
-        if candidate.is_file():
+        if full_path and candidate.is_file():
             return FileResponse(candidate)
-        return FileResponse(FRONTEND_DIST / "index.html")
+        index = FRONTEND_DIST / "index.html"
+        if index.exists():
+            return FileResponse(index)
+    return {"status": "api running"}


### PR DESCRIPTION
StaticFiles raises RuntimeError if its directory doesn't exist, which
kills the process before any request is served. Replace with a simple
catch-all route that checks paths at request time instead.

https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw