### PR TITLE
fix: move DB init to lifespan, fix port, add health + root routes

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,7 @@
-import os
+import logging
+from contextlib import asynccontextmanager
 from pathlib import Path
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
@@ -7,9 +9,20 @@ from fastapi.responses import FileResponse
 from .database import engine, Base
 from .routers import tts, cal, pom, mtg, idx, strings, crd
 
-Base.metadata.create_all(bind=engine)
+logger = logging.getLogger(__name__)
 
-app = FastAPI(title="endermatx API")
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    try:
+        Base.metadata.create_all(bind=engine)
+        logger.info("DB tables ready")
+    except Exception as exc:
+        logger.error("DB init failed: %s", exc)
+    yield
+
+
+app = FastAPI(title="endermatx API", lifespan=lifespan)
 
 app.add_middleware(
     CORSMiddleware,
@@ -28,13 +41,26 @@ app.include_router(crd.router, prefix="/api/crd", tags=["crd"])
 
 FRONTEND_DIST = Path(__file__).parent.parent / "frontend" / "dist"
 
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}
+
+
+@app.get("/")
+async def root():
+    index = FRONTEND_DIST / "index.html"
+    if index.exists():
+        return FileResponse(index)
+    return {"status": "api running"}
+
+
 @app.get("/{full_path:path}")
 async def spa_fallback(full_path: str):
-    if FRONTEND_DIST.exists():
-        candidate = FRONTEND_DIST / full_path
-        if full_path and candidate.is_file():
-            return FileResponse(candidate)
-        index = FRONTEND_DIST / "index.html"
-        if index.exists():
-            return FileResponse(index)
+    candidate = FRONTEND_DIST / full_path
+    if full_path and candidate.is_file():
+        return FileResponse(candidate)
+    index = FRONTEND_DIST / "index.html"
+    if index.exists():
+        return FileResponse(index)
     return {"status": "api running"}

--- a/railway.toml
+++ b/railway.toml
@@ -2,4 +2,4 @@
 buildCommand = "pip install -r backend/requirements.txt && npm --prefix frontend install && npm --prefix frontend run build"
 
 [deploy]
-startCommand = "uvicorn backend.main:app --host 0.0.0.0 --port ${PORT:-8000}"
+startCommand = "uvicorn backend.main:app --host 0.0.0.0 --port $PORT"


### PR DESCRIPTION
- Base.metadata.create_all was running at module import time; a slow or
  failed DB connection would hang/crash uvicorn before it could serve any
  request. Moved to an async lifespan event with error handling so a DB
  hiccup no longer kills the process.
- ${PORT:-8000} shell fallback syntax may not expand in Railway's runner;
  simplified to $PORT (Railway always provides it).
- Added explicit GET / route so the root path is never ambiguous.
- Added GET /health for Railway health checks.

https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw