### PR TITLE
restore landing page: enderman animation, category nav, games serving

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
 
 from .database import engine, Base
 from .routers import tts, cal, pom, mtg, idx, strings, crd
@@ -40,6 +41,10 @@ app.include_router(strings.router, prefix="/api/str", tags=["str"])
 app.include_router(crd.router, prefix="/api/crd", tags=["crd"])
 
 FRONTEND_DIST = Path(__file__).parent.parent / "frontend" / "dist"
+GAMES_DIR = Path(__file__).parent.parent / "games"
+
+if GAMES_DIR.exists():
+    app.mount("/games", StaticFiles(directory=GAMES_DIR, html=True), name="games")
 
 
 @app.get("/health")

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,8 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import Home from './pages/Home'
+import Productivity from './pages/Productivity'
+import Personal from './pages/Personal'
+import Games from './pages/Games'
 import TimeTracker from './pages/TimeTracker'
 import Calendar from './pages/Calendar'
 import Pomodoro from './pages/Pomodoro'
@@ -13,6 +16,9 @@ export default function App() {
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<Home />} />
+        <Route path="/productivity" element={<Productivity />} />
+        <Route path="/personal" element={<Personal />} />
+        <Route path="/games" element={<Games />} />
         <Route path="/tts" element={<TimeTracker />} />
         <Route path="/cal" element={<Calendar />} />
         <Route path="/pom" element={<Pomodoro />} />

--- a/frontend/src/components/Enderman.jsx
+++ b/frontend/src/components/Enderman.jsx
@@ -1,0 +1,176 @@
+import { useEffect, useRef } from 'react'
+
+const ENDER_W = 14
+const ENDER_H = 70
+const PARTICLE_COLORS = ['#cc00ee', '#dd44ff', '#9900bb', '#ee88ff', '#aa00dd']
+
+export default function Enderman({ headerRef }) {
+  const endermanRef = useRef(null)
+  const flipRef = useRef(null)
+
+  useEffect(() => {
+    const enderman = endermanRef.current
+    const flip = flipRef.current
+    if (!enderman || !flip) return
+
+    let x = 20
+    let dir = 1
+    let teleporting = false
+    let last = null
+    let sinceLastTport = 0
+    let nextTport = randomInterval()
+    let currentSpeed = 30
+    let targetSpeed = 30
+    let sinceSpeedChange = 0
+    let nextSpeedChange = randomSpeedInterval()
+    let rafId = null
+
+    function randomInterval() { return 2800 + Math.random() * 2400 }
+    function randomSpeedInterval() { return 600 + Math.random() * 1400 }
+    function randomTargetSpeed() {
+      const r = Math.random()
+      if (r < 0.2) return 0
+      if (r < 0.5) return 18 + Math.random() * 14
+      if (r < 0.85) return 45 + Math.random() * 25
+      return 90 + Math.random() * 40
+    }
+
+    function positionV() {
+      if (headerRef?.current) {
+        const rect = headerRef.current.getBoundingClientRect()
+        const top = rect.top + rect.height / 2 - ENDER_H / 2
+        enderman.style.top = Math.max(8, top) + 'px'
+      } else {
+        enderman.style.top = (window.innerHeight / 2 - ENDER_H / 2) + 'px'
+      }
+    }
+
+    function spawnParticles(px, py, count) {
+      for (let i = 0; i < count; i++) {
+        const p = document.createElement('div')
+        const size = 2 + Math.random() * 2.5
+        const col = PARTICLE_COLORS[Math.floor(Math.random() * PARTICLE_COLORS.length)]
+        p.style.cssText = `position:fixed;border-radius:50%;pointer-events:none;z-index:6;width:${size}px;height:${size}px;background:${col};box-shadow:0 0 4px ${col};`
+        document.body.appendChild(p)
+
+        const angle = Math.random() * Math.PI * 2
+        const dist = 18 + Math.random() * 55
+        const vx = Math.cos(angle) * dist
+        const vy = Math.sin(angle) * dist
+        const maxLife = 420 + Math.random() * 320
+        let t0 = null
+
+        function frame(ts) {
+          if (!t0) t0 = ts
+          const t = (ts - t0) / maxLife
+          if (t >= 1) { p.remove(); return }
+          const e = 1 - (1 - t) * (1 - t)
+          p.style.left = (px + vx * e) + 'px'
+          p.style.top = (py + vy * e - 28 * t) + 'px'
+          p.style.opacity = (1 - t).toFixed(3)
+          requestAnimationFrame(frame)
+        }
+        requestAnimationFrame(frame)
+      }
+    }
+
+    function enderPos() {
+      return {
+        px: x + ENDER_W / 2,
+        py: parseFloat(enderman.style.top || 0) + ENDER_H / 2,
+      }
+    }
+
+    function teleport() {
+      teleporting = true
+      const from = enderPos()
+      spawnParticles(from.px, from.py, 14)
+      enderman.style.opacity = '0'
+      setTimeout(() => {
+        const maxX = window.innerWidth - ENDER_W
+        x = Math.random() * maxX
+        dir = Math.random() > 0.5 ? 1 : -1
+        enderman.style.transform = `translateX(${x}px)`
+        flip.style.transform = dir === -1 ? 'scaleX(-1)' : 'scaleX(1)'
+        enderman.style.opacity = '1'
+        const to = enderPos()
+        spawnParticles(to.px, to.py, 14)
+        teleporting = false
+        sinceLastTport = 0
+        nextTport = randomInterval()
+      }, 200)
+    }
+
+    function step(dt) {
+      if (teleporting) return
+      sinceLastTport += dt
+      sinceSpeedChange += dt
+
+      if (sinceSpeedChange >= nextSpeedChange) {
+        targetSpeed = randomTargetSpeed()
+        nextSpeedChange = randomSpeedInterval()
+        sinceSpeedChange = 0
+      }
+
+      currentSpeed += (targetSpeed - currentSpeed) * Math.min(1, dt / 180)
+
+      x += dir * currentSpeed * (dt / 1000)
+      const maxX = window.innerWidth - ENDER_W
+      if (x >= maxX) { x = maxX; dir = -1; flip.style.transform = 'scaleX(-1)' }
+      if (x <= 0) { x = 0; dir = 1; flip.style.transform = 'scaleX(1)' }
+      enderman.style.transform = `translateX(${x}px)`
+
+      const walkDur = currentSpeed < 5 ? '9999s' : (1.4 - Math.min(currentSpeed, 130) / 130 * 0.9) + 's'
+      enderman.querySelectorAll('.ender-arm, .ender-leg, .ender-figure').forEach(el => {
+        el.style.animationDuration = walkDur
+      })
+
+      if (sinceLastTport >= nextTport) teleport()
+    }
+
+    function loop(ts) {
+      if (last !== null) step(ts - last)
+      last = ts
+      rafId = requestAnimationFrame(loop)
+    }
+
+    positionV()
+    enderman.style.transform = `translateX(${x}px)`
+
+    function onResize() {
+      positionV()
+      x = Math.min(x, window.innerWidth - ENDER_W)
+    }
+    window.addEventListener('resize', onResize)
+    rafId = requestAnimationFrame(loop)
+
+    return () => {
+      cancelAnimationFrame(rafId)
+      window.removeEventListener('resize', onResize)
+    }
+  }, [])
+
+  return (
+    <div ref={endermanRef} style={{ position: 'fixed', top: 0, left: 0, zIndex: 5, pointerEvents: 'none' }}>
+      <div ref={flipRef}>
+        <div className="ender-figure">
+          <div className="ender-head">
+            <div className="ender-eye left"></div>
+            <div className="ender-eye right"></div>
+          </div>
+          <div className="ender-body-wrap">
+            <div className="ender-arm left"></div>
+            <div className="ender-column">
+              <div className="ender-torso"></div>
+              <div className="ender-legs">
+                <div className="ender-leg left"></div>
+                <div className="ender-leg right"></div>
+              </div>
+            </div>
+            <div className="ender-arm right"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -167,3 +167,186 @@ input, textarea, select {
   width: 10px; height: 10px; border-radius: 50%;
   display: inline-block; flex-shrink: 0;
 }
+
+/* ── Landing / category pages ────────────────────────────────── */
+.landing-page {
+  background: #2a2a2a;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 20px;
+}
+
+.landing-header {
+  text-align: center;
+  margin-bottom: 60px;
+}
+
+.landing-title {
+  font-size: 2rem;
+  font-weight: normal;
+  letter-spacing: 0.15em;
+  color: #ffffff;
+  text-transform: uppercase;
+  line-height: 1.15;
+}
+
+.landing-sub {
+  margin-top: 8px;
+  font-size: 0.75rem;
+  color: #ccc;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+}
+
+.landing-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 300px;
+}
+
+.nav-card {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  text-decoration: none;
+  padding: 12px 16px;
+  border: 1px solid #2a2a2a;
+  border-left: 2px solid #6600aa;
+  background: #1e1e1e;
+  color: #e0e0e0;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.nav-card:hover {
+  border-color: #ccc;
+  border-left-color: #9900cc;
+  background: #222;
+}
+
+.nav-card-label {
+  font-size: 0.65rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: #ccc;
+  width: 28px;
+  flex-shrink: 0;
+}
+
+.nav-card-name {
+  font-size: 1rem;
+  font-weight: normal;
+  letter-spacing: 0.05em;
+  color: #ffffff;
+  flex: 1;
+  margin-left: 16px;
+}
+
+.nav-card-arrow {
+  font-size: 0.7rem;
+  color: #ccc;
+}
+
+/* ── Enderman ────────────────────────────────────────────────── */
+.ender-figure {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  animation: ender-bob 0.7s ease-in-out infinite;
+}
+
+.ender-head {
+  width: 11px;
+  height: 11px;
+  background: linear-gradient(150deg, #1e1e1e 0%, #0c0c0c 100%);
+  border-radius: 2px;
+  position: relative;
+  box-shadow: 0 1px 5px rgba(0,0,0,0.9);
+  flex-shrink: 0;
+}
+
+.ender-eye {
+  position: absolute;
+  width: 2px;
+  height: 4px;
+  background: #cc00ee;
+  top: 3px;
+  border-radius: 1px;
+  box-shadow: 0 0 4px #cc00ee, 0 0 8px #9900bb;
+}
+.ender-eye.left  { left: 1px; }
+.ender-eye.right { right: 1px; }
+
+.ender-body-wrap {
+  display: flex;
+  align-items: flex-start;
+  margin-top: 1px;
+}
+
+.ender-column {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.ender-torso {
+  width: 8px;
+  height: 14px;
+  background: linear-gradient(160deg, #2a2a2a 0%, #1a1a1a 40%, #111 100%);
+  border-left: 1px solid #333;
+  border-right: 1px solid #333;
+  box-shadow: inset 1px 0 0 rgba(255,255,255,0.04);
+}
+
+.ender-arm {
+  width: 2px;
+  height: 28px;
+  background: linear-gradient(180deg, #151515, #0a0a0a);
+  border-radius: 1px;
+  transform-origin: top center;
+}
+.ender-arm.left  { animation: ender-arm-l 1.1s ease-in-out infinite; }
+.ender-arm.right { animation: ender-arm-r 0.9s ease-in-out infinite; }
+
+.ender-legs {
+  display: flex;
+  gap: 1px;
+}
+
+.ender-leg {
+  width: 2px;
+  height: 30px;
+  background: linear-gradient(180deg, #111, #080808);
+  border-radius: 1px;
+  transform-origin: top center;
+}
+.ender-leg.left  { animation: ender-leg-l 0.7s ease-in-out infinite; }
+.ender-leg.right { animation: ender-leg-r 0.7s ease-in-out infinite; }
+
+@keyframes ender-bob {
+  0%, 100% { transform: translateY(0); }
+  50%       { transform: translateY(-2px); }
+}
+@keyframes ender-arm-l {
+  0%   { transform: rotate(-5deg); }
+  40%  { transform: rotate(7deg); }
+  70%  { transform: rotate(2deg); }
+  100% { transform: rotate(-5deg); }
+}
+@keyframes ender-arm-r {
+  0%   { transform: rotate(3deg); }
+  30%  { transform: rotate(-6deg); }
+  65%  { transform: rotate(4deg); }
+  100% { transform: rotate(3deg); }
+}
+@keyframes ender-leg-l {
+  0%, 100% { transform: rotate(-10deg); }
+  50%       { transform: rotate(10deg); }
+}
+@keyframes ender-leg-r {
+  0%, 100% { transform: rotate(10deg); }
+  50%       { transform: rotate(-10deg); }
+}

--- a/frontend/src/pages/Games.jsx
+++ b/frontend/src/pages/Games.jsx
@@ -1,0 +1,32 @@
+import { Link } from 'react-router-dom'
+import Enderman from '../components/Enderman'
+
+const GAMES = [
+  { href: '/games/teleport-tap/', label: '01', name: 'teleport-tap' },
+  { href: '/games/mobs-magic/', label: '02', name: 'mobs-magic' },
+]
+
+export default function Games() {
+  return (
+    <div className="landing-page">
+      <Enderman />
+      <header className="landing-header">
+        <h1 className="landing-title">GAM<br />ES</h1>
+        <p className="landing-sub">games</p>
+      </header>
+      <nav className="landing-grid">
+        <Link to="/" className="nav-card">
+          <div className="nav-card-label">←</div>
+          <div className="nav-card-name">back</div>
+        </Link>
+        {GAMES.map(g => (
+          <a key={g.href} href={g.href} className="nav-card">
+            <div className="nav-card-label">{g.label}</div>
+            <div className="nav-card-name">{g.name}</div>
+            <div className="nav-card-arrow">→</div>
+          </a>
+        ))}
+      </nav>
+    </div>
+  )
+}

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,30 +1,34 @@
+import { useRef } from 'react'
 import { Link } from 'react-router-dom'
-
-const TOOLS = [
-  { path: '/tts', name: 'tts', desc: 'time tracker' },
-  { path: '/cal', name: 'cal', desc: 'calendar' },
-  { path: '/pom', name: 'pom', desc: 'pomodoro' },
-  { path: '/mtg', name: 'mtg', desc: 'meeting notes' },
-  { path: '/idx', name: 'idx', desc: 'idea inbox' },
-  { path: '/str', name: 'str', desc: 'string tracker' },
-  { path: '/crd', name: 'crd', desc: 'chord aligner' },
-]
+import Enderman from '../components/Enderman'
 
 export default function Home() {
+  const headerRef = useRef(null)
+
   return (
-    <div style={{ padding: '40px 20px', maxWidth: 600, margin: '0 auto' }}>
-      <h1 style={{ fontSize: 28, letterSpacing: '0.15em', marginBottom: 8 }}>
-        ENDERMATX
-      </h1>
-      <p style={{ color: '#555', fontSize: 12, marginBottom: 32 }}>personal tools</p>
-      <div className="home-grid">
-        {TOOLS.map(t => (
-          <Link key={t.path} to={t.path} className="home-card">
-            <div className="home-card-name">{t.name}</div>
-            <div className="home-card-desc">{t.desc}</div>
-          </Link>
-        ))}
-      </div>
+    <div className="landing-page">
+      <Enderman headerRef={headerRef} />
+      <header className="landing-header" ref={headerRef}>
+        <h1 className="landing-title">END<br />ERM<br />ATX</h1>
+        <p className="landing-sub">tools</p>
+      </header>
+      <nav className="landing-grid">
+        <Link to="/productivity" className="nav-card">
+          <div className="nav-card-label">01</div>
+          <div className="nav-card-name">productivity</div>
+          <div className="nav-card-arrow">→</div>
+        </Link>
+        <Link to="/personal" className="nav-card">
+          <div className="nav-card-label">02</div>
+          <div className="nav-card-name">personal</div>
+          <div className="nav-card-arrow">→</div>
+        </Link>
+        <Link to="/games" className="nav-card">
+          <div className="nav-card-label">03</div>
+          <div className="nav-card-name">games</div>
+          <div className="nav-card-arrow">→</div>
+        </Link>
+      </nav>
     </div>
   )
 }

--- a/frontend/src/pages/Personal.jsx
+++ b/frontend/src/pages/Personal.jsx
@@ -1,0 +1,32 @@
+import { Link } from 'react-router-dom'
+import Enderman from '../components/Enderman'
+
+const TOOLS = [
+  { path: '/str', label: '01', name: 'str', desc: 'string tracker' },
+  { path: '/crd', label: '02', name: 'crd', desc: 'chord aligner' },
+]
+
+export default function Personal() {
+  return (
+    <div className="landing-page">
+      <Enderman />
+      <header className="landing-header">
+        <h1 className="landing-title">PER<br />SON<br />AL</h1>
+        <p className="landing-sub">personal</p>
+      </header>
+      <nav className="landing-grid">
+        <Link to="/" className="nav-card">
+          <div className="nav-card-label">←</div>
+          <div className="nav-card-name">back</div>
+        </Link>
+        {TOOLS.map(t => (
+          <Link key={t.path} to={t.path} className="nav-card">
+            <div className="nav-card-label">{t.label}</div>
+            <div className="nav-card-name">{t.name}</div>
+            <div className="nav-card-arrow">→</div>
+          </Link>
+        ))}
+      </nav>
+    </div>
+  )
+}

--- a/frontend/src/pages/Productivity.jsx
+++ b/frontend/src/pages/Productivity.jsx
@@ -1,0 +1,35 @@
+import { Link } from 'react-router-dom'
+import Enderman from '../components/Enderman'
+
+const TOOLS = [
+  { path: '/tts', label: '01', name: 'tts', desc: 'time tracker' },
+  { path: '/cal', label: '02', name: 'cal', desc: 'calendar' },
+  { path: '/pom', label: '03', name: 'pom', desc: 'pomodoro' },
+  { path: '/mtg', label: '04', name: 'mtg', desc: 'meeting notes' },
+  { path: '/idx', label: '05', name: 'idx', desc: 'idea inbox' },
+]
+
+export default function Productivity() {
+  return (
+    <div className="landing-page">
+      <Enderman />
+      <header className="landing-header">
+        <h1 className="landing-title">PRO<br />DUC<br />TVT</h1>
+        <p className="landing-sub">productivity</p>
+      </header>
+      <nav className="landing-grid">
+        <Link to="/" className="nav-card">
+          <div className="nav-card-label">←</div>
+          <div className="nav-card-name">back</div>
+        </Link>
+        {TOOLS.map(t => (
+          <Link key={t.path} to={t.path} className="nav-card">
+            <div className="nav-card-label">{t.label}</div>
+            <div className="nav-card-name">{t.name}</div>
+            <div className="nav-card-arrow">→</div>
+          </Link>
+        ))}
+      </nav>
+    </div>
+  )
+}


### PR DESCRIPTION
- Rebuild Home.jsx with END/ERM/ATX stacked title, three category cards
  (productivity, personal, games), and #2a2a2a background
- Add Enderman React component porting the full vanilla JS animation:
  requestAnimationFrame loop, variable speed, teleport with purple particles
- Add Productivity.jsx, Personal.jsx, Games.jsx category pages with
  back navigation and tool/game cards matching original site structure
- Add enderman CSS keyframes and landing page styles to index.css
- Add /productivity, /personal, /games routes to App.jsx
- Mount games/ directory as StaticFiles in FastAPI so teleport-tap
  and mobs-magic are accessible at /games/<name>/

https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw