### PR TITLE
fix landing header to consistent top position across all pages

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -175,8 +175,7 @@ input, textarea, select {
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
-  padding: 40px 20px;
+  padding: 100px 20px 60px;
 }
 
 .landing-header {


### PR DESCRIPTION
Remove justify-content: center so the END/ERM/ATX title always sits
at the same vertical position regardless of how many cards are below.

https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw