### PR TITLE
align enderman vertically with the END/ERM/ATX title

### DIFF
--- a/frontend/src/components/Enderman.jsx
+++ b/frontend/src/components/Enderman.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react'
 
 const ENDER_W = 14
-const ENDER_TOP = 8
+const ENDER_TOP = 120
 const PARTICLE_COLORS = ['#cc00ee', '#dd44ff', '#9900bb', '#ee88ff', '#aa00dd']
 
 export default function Enderman() {


### PR DESCRIPTION
Title starts at 100px (landing-page padding-top), is ~110px tall,
center at ~155px. Enderman is 70px tall, so top: 120px centers it
on the title so it walks across in front of the text.

https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw