### PR TITLE
fix: mobile zoom, tts big timer, idx swipe gestures and stats

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <title>endermatx</title>
   </head>
   <body>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -349,3 +349,86 @@ input, textarea, select {
   0%, 100% { transform: rotate(10deg); }
   50%       { transform: rotate(-10deg); }
 }
+
+/* ── IDX swipe cards ─────────────────────────────────────────── */
+.idea-wrap {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid #1e1e1e;
+  transition: opacity 0.15s ease, transform 0.15s ease;
+}
+.idea-wrap:hover { border-color: #2a2a2a; }
+.idea-wrap.killing { opacity: 0; transform: translateX(10px); pointer-events: none; }
+
+.swipe-bg {
+  position: absolute; top: 0; bottom: 0;
+  display: flex; align-items: center;
+  font-size: 11px; letter-spacing: 0.12em;
+  pointer-events: none; opacity: 0;
+}
+.swipe-right { left: 0; right: 35%; background: #110822; color: #8855ff; padding-left: 16px; }
+.swipe-left  { left: 35%; right: 0; background: #131100; color: #ccaa00; padding-right: 16px; justify-content: flex-end; }
+.swipe-left.kill-swipe { background: #1a0606; color: #ff5555; }
+
+.idea-card {
+  background: #111; padding: 10px 12px;
+  display: flex; align-items: flex-start; gap: 10px;
+  position: relative; z-index: 1; will-change: transform;
+}
+.idea-body { flex: 1; min-width: 0; }
+.idea-text { color: #e0e0e0; word-break: break-word; line-height: 1.5; font-size: 13px; }
+.idea-text.clickable { cursor: pointer; }
+.idea-text.clickable:hover { color: #fff; }
+
+.idea-actions { display: flex; gap: 5px; flex-shrink: 0; align-self: stretch; align-items: center; }
+.act {
+  background: none; border: 1px solid #2a2a2a; color: #ccc;
+  padding: 2px 8px; cursor: pointer; font-size: 10px; letter-spacing: 0.05em;
+}
+.act:hover { border-color: #555; color: #e0e0e0; }
+.act.kill {
+  padding: 0 8px; aspect-ratio: 1; display: flex; align-items: center;
+  justify-content: center; background: #1a0606; border-color: #882222; color: #ff5555;
+}
+.act.kill:hover { border-color: #cc3333; color: #ff8888; background: #2a0a0a; }
+
+.idea-edit {
+  width: 100%; background: #0d0d0d; border: 1px solid #8855ff;
+  color: #e0e0e0; padding: 3px 6px; font-size: 16px; outline: none;
+}
+
+/* ── IDX stats ───────────────────────────────────────────────── */
+.stat-topline { display: flex; margin-bottom: 28px; }
+.stat-box { flex: 1; text-align: center; padding: 14px 6px; border: 1px solid #1e1e1e; background: #111; }
+.stat-box + .stat-box { border-left: none; }
+.stat-box-val   { font-size: 26px; line-height: 1; margin-bottom: 5px; }
+.stat-box-label { font-size: 9px; color: #aaa; letter-spacing: 0.15em; }
+
+.stat-section { margin-bottom: 28px; }
+.stat-heading { font-size: 9px; color: #aaa; letter-spacing: 0.15em; margin-bottom: 12px; }
+
+.stat-funnel-row   { display: flex; align-items: center; gap: 8px; margin-bottom: 7px; }
+.stat-funnel-label { font-size: 10px; color: #ccc; letter-spacing: 0.08em; width: 44px; flex-shrink: 0; text-align: right; }
+.stat-funnel-wrap  { flex: 1; height: 10px; background: #1a1a1a; }
+.stat-funnel-bar   { height: 100%; }
+.stat-funnel-count { font-size: 10px; color: #aaa; width: 68px; flex-shrink: 0; }
+.stat-pct          { color: #888; }
+
+.stat-resolution { display: flex; gap: 28px; margin-bottom: 10px; }
+.stat-res-item   { display: flex; align-items: baseline; gap: 7px; }
+.stat-res-pct    { font-size: 32px; line-height: 1; }
+.stat-res-label  { font-size: 9px; color: #aaa; letter-spacing: 0.12em; }
+.stat-res-bar    { width: 100%; height: 4px; display: flex; overflow: hidden; }
+
+.stat-bars     { display: flex; align-items: flex-end; gap: 4px; }
+.stat-bar-col  { display: flex; flex-direction: column; align-items: center; flex: 1; gap: 3px; }
+.stat-bar-val  { font-size: 9px; color: #aaa; min-height: 12px; line-height: 12px; }
+.stat-bar-out  { width: 100%; height: 60px; background: #1a1a1a; display: flex; align-items: flex-end; }
+.stat-bar-in   { width: 100%; background: #8855ff; min-height: 0; }
+.stat-bar-date { font-size: 8px; color: #999; white-space: nowrap; }
+
+.stat-dow       { display: flex; gap: 4px; }
+.stat-dow-col   { flex: 1; display: flex; flex-direction: column; align-items: center; gap: 5px; }
+.stat-dow-cell  { width: 100%; aspect-ratio: 1; }
+.stat-dow-label { font-size: 8px; color: #aaa; letter-spacing: 0.04em; }
+.stat-dow-count { font-size: 9px; color: #ccc; }

--- a/frontend/src/pages/IdeaInbox.jsx
+++ b/frontend/src/pages/IdeaInbox.jsx
@@ -6,23 +6,311 @@ const TABS = [
   { key: 'inbox',    label: 'IN',  status: 'inbox' },
   { key: 'promoted', label: 'DO',  status: 'promoted' },
   { key: 'deferred', label: 'BL',  status: 'deferred' },
+  { key: 'stats',    label: 'ST',  status: null },
 ]
 
-const TRANSITIONS = {
-  inbox:    [{ label: 'DO', status: 'promoted' }, { label: 'BL', status: 'deferred' }, { label: 'kill', status: 'killed' }],
-  promoted: [{ label: 'DONE', status: 'done' }, { label: 'kill', status: 'killed' }],
-  deferred: [{ label: 'DO', status: 'promoted' }, { label: 'kill', status: 'killed' }],
+function IdeaCard({ idea, tab, onTransition, onUpdate, editId, setEditId }) {
+  const wrapRef = useRef(null)
+  const cardRef = useRef(null)
+  const stateRef = useRef({ tab, onTransition, ideaId: idea.id })
+  const [editText, setEditText] = useState(idea.text)
+
+  useEffect(() => {
+    stateRef.current = { tab, onTransition, ideaId: idea.id }
+  })
+
+  useEffect(() => {
+    const wrap = wrapRef.current
+    const card = cardRef.current
+    if (!wrap || !card) return
+
+    const SWIPE_THRESHOLD = 72
+    let startX, startY, direction
+
+    function getRightLeft() {
+      const t = stateRef.current.tab
+      if (t === 'inbox')    return { right: 'promoted', left: 'deferred' }
+      if (t === 'deferred') return { right: 'promoted', left: 'killed' }
+      return { right: 'done', left: 'killed' }
+    }
+
+    function collapseAndComplete(status) {
+      const h = wrap.offsetHeight
+      wrap.style.height = h + 'px'
+      wrap.style.overflow = 'hidden'
+      wrap.offsetHeight // force reflow
+      wrap.style.transition = 'height 0.15s ease'
+      wrap.style.height = '0'
+      setTimeout(() => stateRef.current.onTransition(stateRef.current.ideaId, status), 160)
+    }
+
+    function handleTouchStart(e) {
+      startX = e.touches[0].clientX
+      startY = e.touches[0].clientY
+      direction = null
+      card.style.transition = 'none'
+    }
+
+    function handleTouchMove(e) {
+      const dx = e.touches[0].clientX - startX
+      const dy = e.touches[0].clientY - startY
+      if (!direction) {
+        if (Math.abs(dx) > Math.abs(dy) && Math.abs(dx) > 6) direction = 'h'
+        else if (Math.abs(dy) > Math.abs(dx) && Math.abs(dy) > 6) direction = 'v'
+        else return
+      }
+      if (direction !== 'h') return
+      e.preventDefault()
+      card.style.transform = `translateX(${dx}px)`
+      const bgRight = wrap.querySelector('.swipe-right')
+      const bgLeft  = wrap.querySelector('.swipe-left')
+      const progress = Math.min(Math.abs(dx) / SWIPE_THRESHOLD, 1)
+      if (bgRight) bgRight.style.opacity = dx > 0 ? progress : 0
+      if (bgLeft)  bgLeft.style.opacity  = dx < 0 ? progress : 0
+    }
+
+    function handleTouchEnd(e) {
+      if (direction !== 'h') return
+      const dx = e.changedTouches[0].clientX - startX
+      const bgRight = wrap.querySelector('.swipe-right')
+      const bgLeft  = wrap.querySelector('.swipe-left')
+      if (bgRight) bgRight.style.opacity = 0
+      if (bgLeft)  bgLeft.style.opacity  = 0
+
+      if (dx > SWIPE_THRESHOLD) {
+        card.style.transition = 'transform 0.2s ease'
+        card.style.transform  = 'translateX(110%)'
+        setTimeout(() => collapseAndComplete(getRightLeft().right), 200)
+      } else if (dx < -SWIPE_THRESHOLD) {
+        card.style.transition = 'transform 0.2s ease'
+        card.style.transform  = 'translateX(-110%)'
+        setTimeout(() => collapseAndComplete(getRightLeft().left), 200)
+      } else {
+        card.style.transition = 'transform 0.25s ease'
+        card.style.transform  = 'translateX(0)'
+      }
+    }
+
+    wrap.addEventListener('touchstart', handleTouchStart, { passive: true })
+    wrap.addEventListener('touchmove',  handleTouchMove,  { passive: false })
+    wrap.addEventListener('touchend',   handleTouchEnd,   { passive: true })
+
+    return () => {
+      wrap.removeEventListener('touchstart', handleTouchStart)
+      wrap.removeEventListener('touchmove',  handleTouchMove)
+      wrap.removeEventListener('touchend',   handleTouchEnd)
+    }
+  }, [idea.id])
+
+  function handleKill() {
+    const wrap = wrapRef.current
+    if (wrap) {
+      wrap.style.transition = 'opacity 0.15s ease, transform 0.15s ease'
+      wrap.style.opacity = '0'
+      wrap.style.transform = 'translateX(10px)'
+    }
+    setTimeout(() => {
+      const h = wrap?.offsetHeight || 0
+      if (wrap) {
+        wrap.style.height = h + 'px'
+        wrap.style.overflow = 'hidden'
+        wrap.offsetHeight
+        wrap.style.transition = 'height 0.15s ease'
+        wrap.style.height = '0'
+      }
+      setTimeout(() => onTransition(idea.id, 'killed'), 160)
+    }, 150)
+  }
+
+  async function saveEdit() {
+    const trimmed = editText.trim()
+    setEditId(null)
+    if (!trimmed || trimmed === idea.text) return
+    try {
+      const updated = await idx.updateIdea(idea.id, { text: trimmed })
+      onUpdate(updated)
+    } catch (_) {}
+  }
+
+  const leftKill = tab !== 'inbox'
+  const rightLabel = tab === 'promoted' ? 'DONE' : 'DO'
+  const leftLabel  = leftKill ? 'KILL' : 'BL'
+  const isEditing  = editId === idea.id
+
+  return (
+    <div className="idea-wrap" ref={wrapRef}>
+      <div className="swipe-bg swipe-right">{rightLabel}</div>
+      <div className={`swipe-bg swipe-left${leftKill ? ' kill-swipe' : ''}`}>{leftLabel}</div>
+      <div className="idea-card" ref={cardRef}>
+        <div className="idea-body">
+          {isEditing ? (
+            <input
+              className="idea-edit"
+              value={editText}
+              onChange={e => setEditText(e.target.value)}
+              onKeyDown={e => {
+                if (e.key === 'Enter')  { e.preventDefault(); saveEdit() }
+                if (e.key === 'Escape') { setEditId(null); setEditText(idea.text) }
+              }}
+              onBlur={saveEdit}
+              autoFocus
+            />
+          ) : (
+            <div
+              className={`idea-text${tab === 'inbox' ? ' clickable' : ''}`}
+              onClick={() => { if (tab === 'inbox') { setEditText(idea.text); setEditId(idea.id) } }}
+            >
+              {idea.text}
+            </div>
+          )}
+        </div>
+        {tab === 'inbox' && !isEditing && (
+          <div className="idea-actions">
+            <button className="act kill" onClick={handleKill}>KILL</button>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function Stats({ ideas }) {
+  const total      = ideas.length
+  const inCount    = ideas.filter(i => i.status === 'inbox').length
+  const doCount    = ideas.filter(i => i.status === 'promoted').length
+  const blCount    = ideas.filter(i => i.status === 'deferred').length
+  const doneCount  = ideas.filter(i => i.status === 'done').length
+  const killedCount = ideas.filter(i => i.status === 'killed').length
+
+  if (total === 0) return (
+    <div style={{ color: '#444', fontSize: 13, padding: '32px 0', textAlign: 'center', letterSpacing: '0.1em' }}>no data yet</div>
+  )
+
+  const resolved   = doneCount + killedCount
+  const doneRate   = resolved > 0 ? Math.round(doneCount   / resolved * 100) : 0
+  const killedRate = resolved > 0 ? Math.round(killedCount / resolved * 100) : 0
+
+  const now = new Date()
+  const dow = (now.getDay() + 6) % 7
+  const curWeekStart = new Date(now)
+  curWeekStart.setHours(0, 0, 0, 0)
+  curWeekStart.setDate(curWeekStart.getDate() - dow)
+
+  const weeks = []
+  for (let w = 7; w >= 0; w--) {
+    const ws = new Date(curWeekStart)
+    ws.setDate(curWeekStart.getDate() - w * 7)
+    const we = new Date(ws)
+    we.setDate(ws.getDate() + 7)
+    const wStart = ws.getTime()
+    const wEnd   = we.getTime()
+    const cnt = ideas.filter(i => {
+      const ts = new Date(i.created_at).getTime()
+      return ts >= wStart && ts < wEnd
+    }).length
+    weeks.push({ cnt, lbl: `${ws.getMonth() + 1}/${ws.getDate()}` })
+  }
+  const maxW = Math.max(...weeks.map(w => w.cnt)) || 1
+
+  const dayCounts = [0, 0, 0, 0, 0, 0, 0]
+  ideas.forEach(i => { dayCounts[(new Date(i.created_at).getDay() + 6) % 7]++ })
+  const maxD = Math.max(...dayCounts) || 1
+  const dayLabels = ['MO','TU','WE','TH','FR','SA','SU']
+
+  function FunnelRow({ label, count, color }) {
+    const pct  = Math.round(count / total * 100)
+    const barW = count > 0 ? Math.max(pct, 1) : 0
+    return (
+      <div className="stat-funnel-row">
+        <div className="stat-funnel-label">{label}</div>
+        <div className="stat-funnel-wrap">
+          <div className="stat-funnel-bar" style={{ width: `${barW}%`, background: color }} />
+        </div>
+        <div className="stat-funnel-count">{count} <span className="stat-pct">({pct}%)</span></div>
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      <div className="stat-topline">
+        <div className="stat-box"><div className="stat-box-val" style={{ color: '#aaa' }}>{total}</div><div className="stat-box-label">TOTAL</div></div>
+        <div className="stat-box"><div className="stat-box-val" style={{ color: '#8855ff' }}>{doCount}</div><div className="stat-box-label">DO</div></div>
+        <div className="stat-box"><div className="stat-box-val" style={{ color: '#44cc88' }}>{doneCount}</div><div className="stat-box-label">DONE</div></div>
+        <div className="stat-box"><div className="stat-box-val" style={{ color: '#ff5555' }}>{killedCount}</div><div className="stat-box-label">KILLED</div></div>
+      </div>
+
+      <div className="stat-section">
+        <div className="stat-heading">FATE OF ALL IDEAS</div>
+        <FunnelRow label="DONE"   count={doneCount}   color="#44cc88" />
+        <FunnelRow label="DO"     count={doCount}     color="#8855ff" />
+        <FunnelRow label="BL"     count={blCount}     color="#ccaa00" />
+        <FunnelRow label="IN"     count={inCount}     color="#888888" />
+        <FunnelRow label="KILLED" count={killedCount} color="#ff5555" />
+      </div>
+
+      {resolved > 0 && (
+        <div className="stat-section">
+          <div className="stat-heading">RESOLUTION OF CLOSED IDEAS</div>
+          <div className="stat-resolution">
+            <div className="stat-res-item">
+              <span className="stat-res-pct" style={{ color: '#44cc88' }}>{doneRate}%</span>
+              <span className="stat-res-label">DONE</span>
+            </div>
+            <div className="stat-res-item">
+              <span className="stat-res-pct" style={{ color: '#ff5555' }}>{killedRate}%</span>
+              <span className="stat-res-label">KILLED</span>
+            </div>
+          </div>
+          <div className="stat-res-bar">
+            <div style={{ flex: doneRate,   background: '#44cc88' }} />
+            <div style={{ flex: killedRate, background: '#ff5555' }} />
+          </div>
+        </div>
+      )}
+
+      <div className="stat-section">
+        <div className="stat-heading">CAPTURES BY WEEK (last 8)</div>
+        <div className="stat-bars">
+          {weeks.map((w, i) => {
+            const barH = w.cnt > 0 ? Math.max(Math.round((w.cnt / maxW) * 60), 3) : 0
+            return (
+              <div key={i} className="stat-bar-col">
+                <div className="stat-bar-val">{w.cnt || ''}</div>
+                <div className="stat-bar-out"><div className="stat-bar-in" style={{ height: barH }} /></div>
+                <div className="stat-bar-date">{w.lbl}</div>
+              </div>
+            )
+          })}
+        </div>
+      </div>
+
+      <div className="stat-section">
+        <div className="stat-heading">CAPTURE BY DAY OF WEEK</div>
+        <div className="stat-dow">
+          {dayLabels.map((lbl, i) => {
+            const alpha = (0.08 + (dayCounts[i] / maxD) * 0.92).toFixed(2)
+            return (
+              <div key={lbl} className="stat-dow-col">
+                <div className="stat-dow-cell" style={{ background: `rgba(136,85,255,${alpha})` }} />
+                <div className="stat-dow-label">{lbl}</div>
+                <div className="stat-dow-count">{dayCounts[i]}</div>
+              </div>
+            )
+          })}
+        </div>
+      </div>
+    </div>
+  )
 }
 
 export default function IdeaInbox() {
-  const [ideas, setIdeas] = useState([])
-  const [tab, setTab] = useState('inbox')
-  const [text, setText] = useState('')
+  const [ideas, setIdeas]   = useState([])
+  const [tab, setTab]       = useState('inbox')
+  const [text, setText]     = useState('')
   const [editId, setEditId] = useState(null)
-  const [editText, setEditText] = useState('')
-  const inputRef = useRef(null)
 
-  useEffect(() => { idx.getIdeas().then(setIdeas) }, [])
+  useEffect(() => { idx.getIdeas().then(setIdeas).catch(() => {}) }, [])
 
   async function addIdea(e) {
     e.preventDefault()
@@ -37,22 +325,25 @@ export default function IdeaInbox() {
     setIdeas(is => is.map(i => i.id === id ? idea : i))
   }
 
-  async function saveEdit(id) {
-    if (!editText.trim()) return
-    const idea = await idx.updateIdea(id, { text: editText.trim() })
-    setIdeas(is => is.map(i => i.id === id ? idea : i))
-    setEditId(null)
+  function onUpdate(updated) {
+    setIdeas(is => is.map(i => i.id === updated.id ? updated : i))
   }
 
-  const visible = ideas.filter(i => i.status === tab)
+  const visible = ideas.filter(i => {
+    const t = TABS.find(t => t.key === tab)
+    return t?.status && i.status === t.status
+  })
+
   const counts = {}
-  TABS.forEach(t => { counts[t.key] = ideas.filter(i => i.status === t.status).length })
+  TABS.forEach(t => {
+    if (t.status) counts[t.key] = ideas.filter(i => i.status === t.status).length
+  })
 
   return (
     <div>
       <div className="topbar">
         <div className="topbar-left">
-          <Link to="/"><button className="topbar-back btn btn-sm">←</button></Link>
+          <Link to="/productivity"><button className="topbar-back btn btn-sm">←</button></Link>
           <span className="topbar-title">idx</span>
           <span style={{ fontSize: 10, color: '#bbb', letterSpacing: '0.05em' }}>v3.0</span>
         </div>
@@ -60,7 +351,6 @@ export default function IdeaInbox() {
       <div className="page">
         <form onSubmit={addIdea} style={{ marginBottom: 20 }}>
           <input
-            ref={inputRef}
             className="input"
             style={{ borderLeft: '2px solid #8855ff' }}
             placeholder="capture an idea…"
@@ -72,52 +362,32 @@ export default function IdeaInbox() {
         <div className="tabs">
           {TABS.map(t => (
             <button key={t.key} className={`tab${tab === t.key ? ' active' : ''}`} onClick={() => setTab(t.key)}>
-              {t.label} <span style={{ fontSize: 11, color: '#555', marginLeft: 4 }}>{counts[t.key]}</span>
+              {t.label}
+              {t.status && <span style={{ fontSize: 11, color: '#555', marginLeft: 4 }}>{counts[t.key]}</span>}
             </button>
           ))}
         </div>
 
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-          {visible.length === 0 && (
-            <div style={{ color: '#444', fontSize: 13, padding: '20px 0' }}>empty</div>
-          )}
-          {visible.map(idea => (
-            <div key={idea.id} className="card" style={{ padding: '10px 12px' }}>
-              {editId === idea.id ? (
-                <div style={{ display: 'flex', gap: 8 }}>
-                  <input
-                    className="input"
-                    style={{ flex: 1 }}
-                    value={editText}
-                    onChange={e => setEditText(e.target.value)}
-                    onKeyDown={e => { if (e.key === 'Enter') saveEdit(idea.id); if (e.key === 'Escape') setEditId(null) }}
-                    autoFocus
-                  />
-                  <button className="btn btn-sm btn-primary" onClick={() => saveEdit(idea.id)}>save</button>
-                  <button className="btn btn-sm" onClick={() => setEditId(null)}>cancel</button>
-                </div>
-              ) : (
-                <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8 }}>
-                  <span
-                    style={{ flex: 1, fontSize: 14, color: '#ddd', cursor: tab === 'inbox' ? 'pointer' : 'default' }}
-                    onClick={() => { if (tab === 'inbox') { setEditId(idea.id); setEditText(idea.text) } }}
-                  >
-                    {idea.text}
-                  </span>
-                  <div style={{ display: 'flex', gap: 4, flexShrink: 0 }}>
-                    {(TRANSITIONS[tab] || []).map(tr => (
-                      <button key={tr.status} className="btn btn-sm"
-                        style={tr.status === 'killed' ? { color: '#555', borderColor: '#222' } : {}}
-                        onClick={() => transition(idea.id, tr.status)}>
-                        {tr.label}
-                      </button>
-                    ))}
-                  </div>
-                </div>
-              )}
-            </div>
-          ))}
-        </div>
+        {tab === 'stats' ? (
+          <Stats ideas={ideas} />
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+            {visible.length === 0 && (
+              <div style={{ color: '#444', fontSize: 13, padding: '20px 0', textAlign: 'center', letterSpacing: '0.05em' }}>empty</div>
+            )}
+            {visible.map(idea => (
+              <IdeaCard
+                key={idea.id}
+                idea={idea}
+                tab={tab}
+                onTransition={transition}
+                onUpdate={onUpdate}
+                editId={editId}
+                setEditId={setEditId}
+              />
+            ))}
+          </div>
+        )}
       </div>
     </div>
   )

--- a/frontend/src/pages/TimeTracker.jsx
+++ b/frontend/src/pages/TimeTracker.jsx
@@ -52,6 +52,7 @@ export default function TimeTracker() {
 
   const activeEntry = entries.find(e => !e.end_time)
   const activeProjectId = activeEntry?.project_id
+  const activeProject = projects.find(p => p.id === activeProjectId)
 
   async function handleProjectClick(pid) {
     try {
@@ -115,6 +116,10 @@ export default function TimeTracker() {
     projectTotals[e.project_id] = (projectTotals[e.project_id] || 0) + ms
   })
 
+  const activeDuration = activeEntry
+    ? Date.now() - new Date(activeEntry.start_time)
+    : null
+
   return (
     <div>
       <div className="topbar">
@@ -130,6 +135,23 @@ export default function TimeTracker() {
             {error} <button style={{ float: 'right', background: 'none', border: 'none', color: '#f44336', cursor: 'pointer' }} onClick={() => setError(null)}>×</button>
           </div>
         )}
+
+        <div style={{ textAlign: 'center', marginBottom: 24 }}>
+          <div style={{
+            fontSize: 'clamp(36px, 10vw, 64px)',
+            fontWeight: 700,
+            letterSpacing: '-0.02em',
+            fontVariantNumeric: 'tabular-nums',
+            lineHeight: 1,
+            color: activeEntry ? (activeProject?.color || '#f0f0f0') : '#333',
+            transition: 'color 0.3s',
+          }}>
+            {activeDuration != null ? fmtMs(activeDuration) : '0:00:00'}
+          </div>
+          <div style={{ fontSize: 11, color: activeProject?.color || '#555', marginTop: 6, letterSpacing: '0.1em', minHeight: 16 }}>
+            {activeProject ? activeProject.name : '—'}
+          </div>
+        </div>
 
         <div className="section-header">projects</div>
         <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>


### PR DESCRIPTION
- Prevent iOS Safari auto-zoom: add maximum-scale=1.0,user-scalable=no to viewport meta
- TTS: restore large elapsed-time counter above project list, colored to match active project
- IDX: replace button-based transitions with touch swipe gestures (right→promote, left→defer/kill); KILL button kept only on IN tab
- IDX: add ST stats tab with top-line counts, fate funnel, resolution %, weekly captures, and day-of-week heatmap
- IDX: fix back button target to /productivity

https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw