### PR TITLE
feat(tts): full rework — global timer, project cards, smart delete, a…

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -350,6 +350,227 @@ input, textarea, select {
   50%       { transform: rotate(-10deg); }
 }
 
+/* ── TTS time tracker ────────────────────────────────────────── */
+.tts-global {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 8px;
+}
+
+.tts-timer {
+  font-size: clamp(36px, 10vw, 64px);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+  transition: color 0.3s;
+  flex: 1;
+}
+
+.tts-toggle {
+  padding: 10px 22px;
+  border: 1px solid #333;
+  background: #1a1a1a;
+  font-size: 10px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  transition: all 0.15s;
+  color: #bbb;
+}
+.tts-start:hover { border-color: #7effa0; color: #7effa0; background: #0d1a10; }
+.tts-stop  { border-color: #ff6b6b; color: #ff6b6b; background: #1a0e0e; }
+.tts-stop:hover { background: #220e0e; }
+
+.tts-active-bar {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 11px;
+  margin-bottom: 20px;
+  min-height: 16px;
+}
+
+.tts-pulse {
+  width: 6px; height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  animation: tts-pulse 1.4s ease-in-out infinite;
+}
+@keyframes tts-pulse {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.25; }
+}
+
+.tts-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.tts-card {
+  position: relative;
+  background: #111;
+  border: 1px solid #1e1e1e;
+  padding: 14px 12px 12px;
+  text-align: left;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  min-height: 120px;
+  transition: border-color 0.15s, background 0.15s;
+  overflow: hidden;
+}
+.tts-card:hover   { border-color: #333; background: #151515; }
+.tts-card-on      { border-color: #2a2a2a !important; background: #131313 !important; }
+
+.tts-card-stripe {
+  position: absolute;
+  top: 0; left: 0;
+  width: 3px; height: 100%;
+}
+
+.tts-card-name {
+  font-size: 13px;
+  padding-left: 8px;
+  margin-bottom: 10px;
+  line-height: 1.3;
+  word-break: break-word;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.tts-now-badge {
+  font-size: 8px;
+  letter-spacing: 0.15em;
+  color: #7effa0;
+}
+
+.tts-card-rows {
+  padding-left: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-top: auto;
+}
+
+.tts-card-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.tts-row-lbl {
+  font-size: 9px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #444;
+}
+
+.tts-row-val {
+  font-size: 11px;
+  color: #666;
+  font-variant-numeric: tabular-nums;
+}
+
+.tts-mgmt-list { display: flex; flex-direction: column; gap: 4px; }
+
+.tts-mgmt-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 0;
+  border-bottom: 1px solid #181818;
+}
+
+.tts-mgmt-name {
+  flex: 1;
+  background: none;
+  border: none;
+  color: #ccc;
+  font-size: 13px;
+  text-align: left;
+  padding: 0;
+  cursor: pointer;
+}
+.tts-mgmt-name:hover { color: #fff; }
+
+.tts-del-btn { color: #444 !important; border-color: #1e1e1e !important; font-size: 14px !important; }
+.tts-del-btn:hover { color: #ff6b6b !important; border-color: #882222 !important; }
+
+/* ── Shared modal overlay ────────────────────────────────────── */
+.tts-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.85);
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+}
+
+.tts-modal {
+  background: #111;
+  border: 1px solid #2a2a2a;
+  width: 100%;
+  max-width: 420px;
+}
+
+.tts-modal-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 16px;
+  border-bottom: 1px solid #1e1e1e;
+  font-size: 11px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: #bbb;
+}
+
+.tts-modal-x {
+  background: none;
+  border: none;
+  color: #555;
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 2px;
+}
+.tts-modal-x:hover { color: #ccc; }
+
+.tts-modal-body {
+  padding: 16px;
+}
+
+.tts-modal-label {
+  display: block;
+  font-size: 10px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: #888;
+  margin-bottom: 6px;
+}
+
+.tts-modal-hint {
+  font-size: 10px;
+  color: #555;
+  margin-top: 8px;
+  line-height: 1.5;
+}
+
+.tts-modal-foot {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  padding: 12px 16px;
+  border-top: 1px solid #1e1e1e;
+}
+
 /* ── IDX swipe cards ─────────────────────────────────────────── */
 .idea-wrap {
   position: relative;

--- a/frontend/src/pages/TimeTracker.jsx
+++ b/frontend/src/pages/TimeTracker.jsx
@@ -1,43 +1,147 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import { tts } from '../api'
 
-const COLORS = ['#e74c3c','#e67e22','#f1c40f','#2ecc71','#1abc9c','#3498db','#9b59b6','#e91e63']
+const COLORS = [
+  '#7effa0','#ff6b6b','#6bb5ff','#ffd56b','#d06bff',
+  '#ff9f6b','#6bfff0','#ff6bd6','#b5ff6b','#6b7fff',
+]
 
 function fmtMs(ms) {
+  if (ms <= 0) ms = 0
   const s = Math.floor(ms / 1000)
   const h = Math.floor(s / 3600)
   const m = Math.floor((s % 3600) / 60)
   const ss = s % 60
-  return h > 0
-    ? `${h}:${String(m).padStart(2,'0')}:${String(ss).padStart(2,'0')}`
-    : `${m}:${String(ss).padStart(2,'0')}`
+  return `${h}:${String(m).padStart(2,'0')}:${String(ss).padStart(2,'0')}`
 }
 
-function fmtDuration(start, end) {
-  const ms = (end ? new Date(end) : new Date()) - new Date(start)
-  return fmtMs(ms)
+function fmtMsStat(ms) {
+  return ms > 1000 ? fmtMs(ms) : '—'
 }
 
-function fmtTime(dt) {
-  return new Date(dt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+function isToday(dt) {
+  return new Date(dt).toDateString() === new Date().toDateString()
 }
 
-function todayEntries(entries) {
-  const today = new Date().toDateString()
-  return entries.filter(e => new Date(e.start_time).toDateString() === today)
+// ── Modals ─────────────────────────────────────────────────────────────────────
+
+function Modal({ title, onClose, children }) {
+  return (
+    <div className="tts-overlay" onClick={e => { if (e.target === e.currentTarget) onClose() }}>
+      <div className="tts-modal">
+        <div className="tts-modal-head">
+          <span>{title}</span>
+          <button className="tts-modal-x" onClick={onClose}>×</button>
+        </div>
+        {children}
+      </div>
+    </div>
+  )
 }
+
+function AdjustStartModal({ entry, prevEntry, isFirst, onApply, onClose }) {
+  const toLocalTime = dt => {
+    const d = new Date(dt)
+    return `${String(d.getHours()).padStart(2,'0')}:${String(d.getMinutes()).padStart(2,'0')}`
+  }
+  const [time, setTime] = useState(entry ? toLocalTime(entry.start_time) : '00:00')
+
+  function apply() {
+    const base = new Date()
+    const [hh, mm] = time.split(':').map(Number)
+    base.setHours(hh, mm, 0, 0)
+    if (isNaN(base.getTime())) return
+    onApply(base.toISOString())
+  }
+
+  return (
+    <Modal title="adjust start time" onClose={onClose}>
+      <div className="tts-modal-body">
+        <label className="tts-modal-label">start time</label>
+        <input
+          className="input"
+          type="time"
+          value={time}
+          onChange={e => setTime(e.target.value)}
+          onKeyDown={e => { if (e.key === 'Enter') apply() }}
+          autoFocus
+        />
+        {prevEntry && (
+          <div className="tts-modal-hint">previous entry end time will be adjusted to match</div>
+        )}
+        {isFirst && (
+          <div className="tts-modal-hint">global timer start will also be adjusted</div>
+        )}
+      </div>
+      <div className="tts-modal-foot">
+        <button className="btn" onClick={onClose}>cancel</button>
+        <button className="btn btn-primary" onClick={apply}>apply</button>
+      </div>
+    </Modal>
+  )
+}
+
+function ProjectModal({ project, onSave, onClose }) {
+  const [name, setName]   = useState(project?.name  || '')
+  const [color, setColor] = useState(project?.color || COLORS[0])
+
+  function submit() {
+    const trimmed = name.trim()
+    if (!trimmed) return
+    onSave({ name: trimmed, color })
+  }
+
+  return (
+    <Modal title={project?.id ? 'edit project' : 'new project'} onClose={onClose}>
+      <div className="tts-modal-body">
+        <label className="tts-modal-label">name</label>
+        <input
+          className="input"
+          placeholder="project name"
+          value={name}
+          onChange={e => setName(e.target.value)}
+          onKeyDown={e => { if (e.key === 'Enter') submit() }}
+          autoFocus
+        />
+        <label className="tts-modal-label" style={{ marginTop: 14 }}>color</label>
+        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginTop: 6 }}>
+          {COLORS.map(c => (
+            <button
+              key={c}
+              type="button"
+              onClick={() => setColor(c)}
+              style={{
+                width: 22, height: 22, background: c, border: 'none', borderRadius: '50%',
+                cursor: 'pointer',
+                outline: color === c ? '2px solid #fff' : '2px solid transparent',
+                outlineOffset: 2,
+              }}
+            />
+          ))}
+        </div>
+      </div>
+      <div className="tts-modal-foot">
+        <button className="btn" onClick={onClose}>cancel</button>
+        <button className="btn btn-primary" onClick={submit} disabled={!name.trim()}>save</button>
+      </div>
+    </Modal>
+  )
+}
+
+// ── Main ───────────────────────────────────────────────────────────────────────
 
 export default function TimeTracker() {
   const [projects, setProjects] = useState([])
-  const [entries, setEntries] = useState([])
-  const [newName, setNewName] = useState('')
-  const [newColor, setNewColor] = useState(COLORS[0])
-  const [adding, setAdding] = useState(false)
-  const [saving, setSaving] = useState(false)
+  const [entries,  setEntries]  = useState([])
+  const [globalStart, setGlobalStart] = useState(() => {
+    const s = localStorage.getItem('tts_global_start')
+    return s ? new Date(s) : null
+  })
+  const [, setTick]       = useState(0)
+  const [adjustModal, setAdjustModal]   = useState(null)
+  const [projectModal, setProjectModal] = useState(null)
   const [error, setError] = useState(null)
-  const [tick, setTick] = useState(0)
-  const timerRef = useRef(null)
 
   useEffect(() => {
     Promise.all([tts.getProjects(), tts.getEntries()])
@@ -46,79 +150,167 @@ export default function TimeTracker() {
   }, [])
 
   useEffect(() => {
-    timerRef.current = setInterval(() => setTick(t => t + 1), 1000)
-    return () => clearInterval(timerRef.current)
+    const id = setInterval(() => setTick(t => t + 1), 1000)
+    return () => clearInterval(id)
   }, [])
 
-  const activeEntry = entries.find(e => !e.end_time)
-  const activeProjectId = activeEntry?.project_id
-  const activeProject = projects.find(p => p.id === activeProjectId)
+  // If page reloads mid-session, restore globalStart from the earliest today entry
+  useEffect(() => {
+    if (!localStorage.getItem('tts_global_start') && entries.some(e => !e.end_time)) {
+      const todayEs = entries.filter(e => isToday(e.start_time))
+      if (todayEs.length > 0) {
+        const earliest = todayEs.reduce((a, b) =>
+          new Date(a.start_time) < new Date(b.start_time) ? a : b
+        )
+        const s = new Date(earliest.start_time)
+        setGlobalStart(s)
+        localStorage.setItem('tts_global_start', s.toISOString())
+      }
+    }
+  }, [entries])
 
-  async function handleProjectClick(pid) {
+  const activeEntry     = entries.find(e => !e.end_time)
+  const activeProjectId = activeEntry?.project_id
+
+  // ── Global timer controls ──────────────────────────────────────────────────
+
+  function startGlobal() {
+    const now = new Date()
+    setGlobalStart(now)
+    localStorage.setItem('tts_global_start', now.toISOString())
+  }
+
+  async function stopGlobal() {
+    if (activeEntry) {
+      try {
+        const updated = await tts.updateEntry(activeEntry.id, { end_time: new Date().toISOString() })
+        setEntries(es => es.map(e => e.id === updated.id ? updated : e))
+      } catch (err) { setError(err.message) }
+    }
+    setGlobalStart(null)
+    localStorage.removeItem('tts_global_start')
+  }
+
+  // ── Project card click ─────────────────────────────────────────────────────
+
+  async function handleCardClick(pid) {
+    // Auto-start global timer if not running
+    if (!globalStart) startGlobal()
+
+    if (pid === activeProjectId) {
+      // Open adjust-start modal
+      const todayEs = entries
+        .filter(e => isToday(e.start_time))
+        .sort((a, b) => new Date(a.start_time) - new Date(b.start_time))
+      const idx = todayEs.findIndex(e => e.id === activeEntry.id)
+      setAdjustModal({
+        entry:     activeEntry,
+        prevEntry: idx > 0 ? todayEs[idx - 1] : null,
+        isFirst:   idx === 0,
+      })
+      return
+    }
+
+    const now = new Date().toISOString()
     try {
       if (activeEntry) {
-        const updated = await tts.updateEntry(activeEntry.id, { end_time: new Date().toISOString() })
-        setEntries(es => es.map(e => e.id === updated.id ? updated : e))
-        if (pid === activeProjectId) return
+        const stopped = await tts.updateEntry(activeEntry.id, { end_time: now })
+        setEntries(es => es.map(e => e.id === stopped.id ? stopped : e))
       }
-      const entry = await tts.createEntry({ project_id: pid, start_time: new Date().toISOString() })
+      const entry = await tts.createEntry({ project_id: pid, start_time: now })
       setEntries(es => [entry, ...es])
-    } catch (err) {
-      setError(err.message)
-    }
+    } catch (err) { setError(err.message) }
   }
 
-  async function addProject(e) {
-    e.preventDefault()
-    if (!newName.trim()) return
-    setSaving(true)
-    setError(null)
-    try {
-      const proj = await tts.createProject({ name: newName.trim(), color: newColor })
-      setProjects(ps => [...ps, proj])
-      setNewName('')
-      setAdding(false)
-    } catch (err) {
-      setError(err.message)
-    } finally {
-      setSaving(false)
-    }
-  }
+  // ── Adjust start time ──────────────────────────────────────────────────────
 
-  async function archiveProject(pid) {
+  async function applyAdjust(newStartIso) {
+    const { entry, prevEntry, isFirst } = adjustModal
     try {
-      await tts.updateProject(pid, { archived: true })
-      setProjects(ps => ps.filter(p => p.id !== pid))
-      if (activeEntry?.project_id === pid) {
-        const updated = await tts.updateEntry(activeEntry.id, { end_time: new Date().toISOString() })
-        setEntries(es => es.map(e => e.id === updated.id ? updated : e))
+      const updated = await tts.updateEntry(entry.id, { start_time: newStartIso })
+      setEntries(es => es.map(e => e.id === updated.id ? updated : e))
+      if (prevEntry) {
+        const prevUpd = await tts.updateEntry(prevEntry.id, { end_time: newStartIso })
+        setEntries(es => es.map(e => e.id === prevUpd.id ? prevUpd : e))
       }
-    } catch (err) {
-      setError(err.message)
-    }
+      if (isFirst) {
+        const s = new Date(newStartIso)
+        setGlobalStart(s)
+        localStorage.setItem('tts_global_start', newStartIso)
+      }
+    } catch (err) { setError(err.message) }
+    setAdjustModal(null)
   }
 
-  async function deleteEntry(eid) {
+  // ── Project management ─────────────────────────────────────────────────────
+
+  async function saveProject({ name, color }) {
     try {
-      await tts.deleteEntry(eid)
-      setEntries(es => es.filter(e => e.id !== eid))
-    } catch (err) {
-      setError(err.message)
-    }
+      if (projectModal?.id) {
+        const upd = await tts.updateProject(projectModal.id, { name, color })
+        setProjects(ps => ps.map(p => p.id === upd.id ? upd : p))
+      } else {
+        const proj = await tts.createProject({ name, color })
+        setProjects(ps => [...ps, proj])
+      }
+    } catch (err) { setError(err.message) }
+    setProjectModal(null)
   }
 
-  const visibleProjects = projects.filter(p => !p.archived)
-  const today = todayEntries(entries)
+  async function deleteOrArchive(pid) {
+    const hasEntries = entries.some(e => e.project_id === pid)
+    try {
+      if (hasEntries) {
+        const upd = await tts.updateProject(pid, { archived: true })
+        setProjects(ps => ps.map(p => p.id === upd.id ? upd : p))
+        if (pid === activeProjectId && activeEntry) {
+          const stopped = await tts.updateEntry(activeEntry.id, { end_time: new Date().toISOString() })
+          setEntries(es => es.map(e => e.id === stopped.id ? stopped : e))
+        }
+      } else {
+        await tts.deleteProject(pid)
+        setProjects(ps => ps.filter(p => p.id !== pid))
+      }
+    } catch (err) { setError(err.message) }
+  }
 
-  const projectTotals = {}
-  entries.forEach(e => {
-    const ms = (e.end_time ? new Date(e.end_time) : new Date()) - new Date(e.start_time)
-    projectTotals[e.project_id] = (projectTotals[e.project_id] || 0) + ms
-  })
+  async function reactivate(pid) {
+    try {
+      const upd = await tts.updateProject(pid, { archived: false })
+      setProjects(ps => ps.map(p => p.id === upd.id ? upd : p))
+    } catch (err) { setError(err.message) }
+  }
 
-  const activeDuration = activeEntry
-    ? Date.now() - new Date(activeEntry.start_time)
-    : null
+  // ── Stats helpers ──────────────────────────────────────────────────────────
+
+  function projectStats(pid) {
+    const all   = entries.filter(e => e.project_id === pid)
+    const today = all.filter(e => isToday(e.start_time))
+    const now   = Date.now()
+
+    const sessionMs = activeEntry?.project_id === pid
+      ? now - new Date(activeEntry.start_time)
+      : 0
+
+    const todayMs = today.reduce((acc, e) => {
+      const end = e.end_time ? new Date(e.end_time) : new Date()
+      return acc + Math.max(0, end - new Date(e.start_time))
+    }, 0)
+
+    const totalMs = all.reduce((acc, e) => {
+      const end = e.end_time ? new Date(e.end_time) : new Date()
+      return acc + Math.max(0, end - new Date(e.start_time))
+    }, 0)
+
+    return { sessionMs, todayMs, totalMs }
+  }
+
+  // ── Render ─────────────────────────────────────────────────────────────────
+
+  const activeProjects   = projects.filter(p => !p.archived)
+  const archivedProjects = projects.filter(p =>  p.archived)
+  const globalElapsed    = globalStart ? Date.now() - globalStart.getTime() : 0
+  const activeProject    = projects.find(p => p.id === activeProjectId)
 
   return (
     <div>
@@ -126,96 +318,136 @@ export default function TimeTracker() {
         <div className="topbar-left">
           <Link to="/productivity"><button className="topbar-back btn btn-sm">←</button></Link>
           <span className="topbar-title">tts</span>
-          <span style={{ fontSize: 10, color: '#bbb', letterSpacing: '0.05em' }}>v3.0</span>
+          <span style={{ fontSize: 10, color: '#bbb', letterSpacing: '0.05em' }}>v3.1</span>
         </div>
       </div>
+
       <div className="page">
         {error && (
-          <div style={{ background: '#2a0000', border: '1px solid #f44336', color: '#f44336', fontSize: 12, padding: '8px 12px', marginBottom: 12 }}>
-            {error} <button style={{ float: 'right', background: 'none', border: 'none', color: '#f44336', cursor: 'pointer' }} onClick={() => setError(null)}>×</button>
+          <div style={{ background: '#2a0000', border: '1px solid #f44336', color: '#f44336', fontSize: 12, padding: '8px 12px', marginBottom: 16 }}>
+            {error}
+            <button style={{ float: 'right', background: 'none', border: 'none', color: '#f44336', cursor: 'pointer' }} onClick={() => setError(null)}>×</button>
           </div>
         )}
 
-        <div style={{ textAlign: 'center', marginBottom: 24 }}>
-          <div style={{
-            fontSize: 'clamp(36px, 10vw, 64px)',
-            fontWeight: 700,
-            letterSpacing: '-0.02em',
-            fontVariantNumeric: 'tabular-nums',
-            lineHeight: 1,
-            color: activeEntry ? (activeProject?.color || '#f0f0f0') : '#333',
-            transition: 'color 0.3s',
-          }}>
-            {activeDuration != null ? fmtMs(activeDuration) : '0:00:00'}
+        {/* ── Global timer ── */}
+        <div className="tts-global">
+          <div className="tts-timer" style={{ color: globalStart ? '#f0f0f0' : '#2a2a2a' }}>
+            {fmtMs(globalElapsed)}
           </div>
-          <div style={{ fontSize: 11, color: activeProject?.color || '#555', marginTop: 6, letterSpacing: '0.1em', minHeight: 16 }}>
-            {activeProject ? activeProject.name : '—'}
-          </div>
+          <button
+            className={`tts-toggle ${globalStart ? 'tts-stop' : 'tts-start'}`}
+            onClick={globalStart ? stopGlobal : startGlobal}
+          >
+            {globalStart ? 'STOP' : 'START'}
+          </button>
         </div>
 
-        <div className="section-header">projects</div>
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-          {visibleProjects.map(p => (
-            <div key={p.id} className="card" style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '10px 14px' }}>
+        {activeProject && (
+          <div className="tts-active-bar">
+            <span className="tts-pulse" style={{ background: activeProject.color }} />
+            <span style={{ color: activeProject.color, fontSize: 11, letterSpacing: '0.1em' }}>
+              {activeProject.name}
+            </span>
+          </div>
+        )}
+
+        {/* ── Project cards ── */}
+        {activeProjects.length > 0 && (
+          <div className="tts-cards">
+            {activeProjects.map(p => {
+              const isActive = p.id === activeProjectId
+              const { sessionMs, todayMs, totalMs } = projectStats(p.id)
+              return (
+                <button
+                  key={p.id}
+                  className={`tts-card${isActive ? ' tts-card-on' : ''}`}
+                  onClick={() => handleCardClick(p.id)}
+                >
+                  <div className="tts-card-stripe" style={{ background: p.color }} />
+                  <div className="tts-card-name" style={{ color: isActive ? p.color : '#f0f0f0' }}>
+                    {p.name}
+                    {isActive && <span className="tts-now-badge">NOW</span>}
+                  </div>
+                  <div className="tts-card-rows">
+                    <div className="tts-card-row">
+                      <span className="tts-row-lbl">session</span>
+                      <span className="tts-row-val" style={{ color: isActive ? p.color : '#666' }}>
+                        {fmtMsStat(sessionMs)}
+                      </span>
+                    </div>
+                    <div className="tts-card-row">
+                      <span className="tts-row-lbl">today</span>
+                      <span className="tts-row-val">{fmtMsStat(todayMs)}</span>
+                    </div>
+                    <div className="tts-card-row">
+                      <span className="tts-row-lbl">total</span>
+                      <span className="tts-row-val">{fmtMsStat(totalMs)}</span>
+                    </div>
+                  </div>
+                </button>
+              )
+            })}
+          </div>
+        )}
+
+        {/* ── Project management ── */}
+        <div className="section-header mt24">projects</div>
+        <div className="tts-mgmt-list">
+          {activeProjects.map(p => (
+            <div key={p.id} className="tts-mgmt-row">
               <span className="color-dot" style={{ background: p.color }} />
-              <button
-                onClick={() => handleProjectClick(p.id)}
-                style={{ flex: 1, background: 'none', border: 'none', color: p.id === activeProjectId ? p.color : '#ccc', textAlign: 'left', fontSize: 14, padding: 0 }}
-              >
+              <button className="tts-mgmt-name" onClick={() => setProjectModal(p)}>
                 {p.name}
-                {p.id === activeProjectId && activeEntry && (
-                  <span style={{ marginLeft: 10, fontSize: 12, color: p.color }}>
-                    {fmtMs(Date.now() - new Date(activeEntry.start_time))}
-                  </span>
-                )}
               </button>
-              {projectTotals[p.id] && (
-                <span style={{ fontSize: 11, color: '#555' }}>{fmtMs(projectTotals[p.id])}</span>
-              )}
-              <button className="btn btn-sm" style={{ color: '#444', borderColor: '#222' }} onClick={() => archiveProject(p.id)}>×</button>
+              <button
+                className="btn btn-sm tts-del-btn"
+                onClick={() => deleteOrArchive(p.id)}
+                title={entries.some(e => e.project_id === p.id) ? 'archive' : 'delete'}
+              >
+                −
+              </button>
             </div>
           ))}
         </div>
+        <button className="btn btn-sm mt8" onClick={() => setProjectModal({})}>+ add project</button>
 
-        {adding ? (
-          <form onSubmit={addProject} className="card mt8" style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
-            <input className="input" style={{ flex: 1, minWidth: 120 }} placeholder="project name" value={newName} onChange={e => setNewName(e.target.value)} autoFocus />
-            <div style={{ display: 'flex', gap: 4 }}>
-              {COLORS.map(c => (
-                <button key={c} type="button" onClick={() => setNewColor(c)}
-                  style={{ width: 18, height: 18, background: c, border: newColor === c ? '2px solid #fff' : '2px solid transparent', borderRadius: 2 }} />
+        {archivedProjects.length > 0 && (
+          <>
+            <div className="section-header mt24" style={{ color: '#2a2a2a' }}>archived</div>
+            <div className="tts-mgmt-list">
+              {archivedProjects.map(p => (
+                <div key={p.id} className="tts-mgmt-row" style={{ opacity: 0.4 }}>
+                  <span className="color-dot" style={{ background: p.color }} />
+                  <span className="tts-mgmt-name" style={{ color: '#666', cursor: 'default' }}>
+                    {p.name}
+                  </span>
+                  <button className="btn btn-sm" onClick={() => reactivate(p.id)} title="reactivate">
+                    +
+                  </button>
+                </div>
               ))}
             </div>
-            <button type="submit" className="btn btn-primary btn-sm" disabled={saving}>{saving ? '…' : 'add'}</button>
-            <button type="button" className="btn btn-sm" onClick={() => { setAdding(false); setError(null) }}>cancel</button>
-          </form>
-        ) : (
-          <button className="btn btn-sm mt8" onClick={() => setAdding(true)}>+ project</button>
-        )}
-
-        {today.length > 0 && (
-          <>
-            <div className="section-header mt24">today</div>
-            {today.map(e => {
-              const proj = projects.find(p => p.id === e.project_id)
-              return (
-                <div key={e.id} className="card" style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '8px 14px' }}>
-                  <span className="color-dot" style={{ background: proj?.color || '#555' }} />
-                  <span style={{ flex: 1, fontSize: 13, color: '#ccc' }}>{proj?.name || '—'}</span>
-                  <span style={{ fontSize: 12, color: '#666' }}>{fmtTime(e.start_time)}</span>
-                  <span style={{ fontSize: 12, color: '#555', minWidth: 60, textAlign: 'right' }}>
-                    {fmtDuration(e.start_time, e.end_time)}
-                    {!e.end_time && <span style={{ color: '#ff9800' }}> ●</span>}
-                  </span>
-                  {e.end_time && (
-                    <button className="btn btn-sm" style={{ color: '#333', borderColor: '#1e1e1e' }} onClick={() => deleteEntry(e.id)}>×</button>
-                  )}
-                </div>
-              )
-            })}
           </>
         )}
       </div>
+
+      {adjustModal && (
+        <AdjustStartModal
+          entry={adjustModal.entry}
+          prevEntry={adjustModal.prevEntry}
+          isFirst={adjustModal.isFirst}
+          onApply={applyAdjust}
+          onClose={() => setAdjustModal(null)}
+        />
+      )}
+      {projectModal !== null && (
+        <ProjectModal
+          project={projectModal}
+          onSave={saveProject}
+          onClose={() => setProjectModal(null)}
+        />
+      )}
     </div>
   )
 }


### PR DESCRIPTION
…djust modal

- Global counter (h:mm:ss) at top with START/STOP toggle; auto-starts when clicking a project card
- Project cards show project name + session/today/total time, all live-updating every second
- Click a different project → stops current entry, starts new one
- Click the active project → opens adjust-start-time modal; adjusting it also shifts the previous entry's end_time; if it's the first entry of the session it also shifts the global timer start
- Global timer state persisted in localStorage across page reloads; restored from earliest today entry if localStorage is missing
- Project management section: click project name to rename, − button to delete (hard-delete if no entries, archive if has entries)
- Archived projects appear dimmed in separate section with + reactivate button
- New modal component reused for both adjust-time and project-form dialogs
- Bump TTS to v3.1

https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw