### PR TITLE
fix(tts): add 1h misfire grace window to EOD scheduler job

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -60,7 +60,11 @@ async def lifespan(app: FastAPI):
         logger.error("DB init failed after 5 attempts — running without DB")
 
     scheduler = AsyncIOScheduler()
-    scheduler.add_job(_close_open_tts_entries, CronTrigger(hour=23, minute=0))
+    scheduler.add_job(
+        _close_open_tts_entries,
+        CronTrigger(hour=23, minute=0),
+        misfire_grace_time=3600,  # run immediately on startup if missed within the last hour
+    )
     scheduler.start()
     logger.info("EOD scheduler started — TTS entries will auto-close at 23:00")
 


### PR DESCRIPTION
If a deploy happens within an hour of 23:00 and the job is missed, APScheduler will fire it immediately when the new process starts up.

https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw