### PR TITLE
feat(landing): show deployment time with Railway link in footer (fixe…

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,8 +1,11 @@
 import asyncio
 import logging
+import os
 from contextlib import asynccontextmanager
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
+
+_startup_time = datetime.now(timezone.utc)
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
@@ -114,6 +117,21 @@ if GAMES_DIR.exists():
 @app.get("/health")
 async def health():
     return JSONResponse({"status": "ok", "db": db_ready})
+
+
+@app.get("/api/info")
+async def info():
+    project_id  = os.environ.get("RAILWAY_PROJECT_ID", "")
+    service_id  = os.environ.get("RAILWAY_SERVICE_ID", "")
+    deploy_url  = None
+    if project_id and service_id:
+        deploy_url = f"https://railway.com/project/{project_id}/service/{service_id}"
+    elif project_id:
+        deploy_url = f"https://railway.com/project/{project_id}"
+    return JSONResponse({
+        "started_at": _startup_time.isoformat(),
+        "deploy_url": deploy_url,
+    })
 
 
 @app.get("/")

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -207,6 +207,18 @@ input, textarea, select {
   width: 300px;
 }
 
+.landing-footer {
+  margin-top: 40px;
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  color: #555;
+}
+.landing-footer a {
+  color: #555;
+  text-decoration: none;
+}
+.landing-footer a:hover { color: #999; }
+
 .nav-card {
   display: flex;
   flex-direction: row;

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,7 +1,26 @@
+import { useState, useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import Enderman from '../components/Enderman'
 
+function fmtDeployTime(iso) {
+  const d = new Date(iso)
+  const pad = n => String(n).padStart(2, '0')
+  return `${pad(d.getDate())}.${pad(d.getMonth() + 1)}.${d.getFullYear()} ${pad(d.getHours())}:${pad(d.getMinutes())}`
+}
+
 export default function Home() {
+  const [deployInfo, setDeployInfo] = useState(null)
+
+  useEffect(() => {
+    fetch('/api/info')
+      .then(r => r.json())
+      .then(setDeployInfo)
+      .catch(() => {})
+  }, [])
+
+  const label = deployInfo?.started_at ? `deployed ${fmtDeployTime(deployInfo.started_at)}` : null
+  const url   = deployInfo?.deploy_url
+
   return (
     <div className="landing-page">
       <Enderman />
@@ -26,6 +45,14 @@ export default function Home() {
           <div className="nav-card-arrow">→</div>
         </Link>
       </nav>
+      {label && (
+        <footer className="landing-footer">
+          {url
+            ? <a href={url} target="_blank" rel="noopener noreferrer">{label}</a>
+            : <span>{label}</span>
+          }
+        </footer>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
…s #85)

Backend: record _startup_time at import time (UTC-aware). New GET /api/info endpoint returns started_at (ISO 8601 with Z) and deploy_url constructed from RAILWAY_PROJECT_ID + RAILWAY_SERVICE_ID env vars (null when running locally).

Frontend: Home.jsx fetches /api/info on mount and renders a footer below the nav grid showing "deployed DD.MM.YYYY HH:MM" in local time. If deploy_url is present the label is a link opening in a new tab. Footer is hidden until the fetch resolves.

https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw