### PR TITLE
feat: bake git hash into version badges + landing footer

### DIFF
--- a/frontend/src/components/VersionBadge.jsx
+++ b/frontend/src/components/VersionBadge.jsx
@@ -1,0 +1,12 @@
+export default function VersionBadge({ version }) {
+  return (
+    <span style={{ fontSize: 10, color: '#bbb', letterSpacing: '0.05em' }}>
+      {version}-<a
+        href={`https://github.com/matmaxx2317/endermatx/commit/${__GIT_HASH_FULL__}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        style={{ color: 'inherit', textDecoration: 'none' }}
+      >{__GIT_HASH__}</a>
+    </span>
+  )
+}

--- a/frontend/src/pages/Calendar.jsx
+++ b/frontend/src/pages/Calendar.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import { cal } from '../api'
+import VersionBadge from '../components/VersionBadge'
 
 const MONTHS = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec']
 const COLORS = ['#4a9eff','#e74c3c','#2ecc71','#f1c40f','#9b59b6','#e67e22','#1abc9c','#e91e63']
@@ -71,7 +72,7 @@ export default function Calendar() {
         <div className="topbar-left">
           <Link to="/"><button className="topbar-back btn btn-sm">←</button></Link>
           <span className="topbar-title">cal</span>
-          <span style={{ fontSize: 10, color: '#bbb', letterSpacing: '0.05em' }}>v3.0</span>
+          <VersionBadge version="v3.0" />
         </div>
       </div>
       <div className="page" style={{ maxWidth: 900 }}>

--- a/frontend/src/pages/ChordAligner.jsx
+++ b/frontend/src/pages/ChordAligner.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { Link } from 'react-router-dom'
 import { crd } from '../api'
+import VersionBadge from '../components/VersionBadge'
 
 function distributeChords(lyrics, chordsText) {
   const words = lyrics.trim().split(/\s+/).filter(Boolean)
@@ -101,7 +102,7 @@ export default function ChordAligner() {
         <div className="topbar-left">
           <Link to="/"><button className="topbar-back btn btn-sm">←</button></Link>
           <span className="topbar-title">crd</span>
-          <span style={{ fontSize: 10, color: '#bbb', letterSpacing: '0.05em' }}>v3.0</span>
+          <VersionBadge version="v3.0" />
         </div>
         <span style={{ fontSize: 11, color: saved ? '#4caf50' : '#555' }}>{saved ? 'saved' : '…'}</span>
       </div>

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -5,7 +5,7 @@ import Enderman from '../components/Enderman'
 function fmtDeployTime(iso) {
   const d = new Date(iso)
   const pad = n => String(n).padStart(2, '0')
-  return `${pad(d.getDate())}.${pad(d.getMonth() + 1)}.${d.getFullYear()} ${pad(d.getHours())}:${pad(d.getMinutes())}`
+  return `deployed ${pad(d.getDate())}.${pad(d.getMonth() + 1)}.${d.getFullYear()} ${pad(d.getHours())}:${pad(d.getMinutes())}`
 }
 
 export default function Home() {
@@ -18,8 +18,8 @@ export default function Home() {
       .catch(() => {})
   }, [])
 
-  const label = deployInfo?.started_at ? `deployed ${fmtDeployTime(deployInfo.started_at)}` : null
-  const url   = deployInfo?.deploy_url
+  const deployLabel = deployInfo?.started_at ? fmtDeployTime(deployInfo.started_at) : null
+  const deployUrl   = deployInfo?.deploy_url
 
   return (
     <div className="landing-page">
@@ -45,14 +45,24 @@ export default function Home() {
           <div className="nav-card-arrow">→</div>
         </Link>
       </nav>
-      {label && (
-        <footer className="landing-footer">
-          {url
-            ? <a href={url} target="_blank" rel="noopener noreferrer">{label}</a>
-            : <span>{label}</span>
-          }
-        </footer>
-      )}
+      <footer className="landing-footer">
+        <span>
+          v{__APP_VERSION__}-<a
+            href={`https://github.com/matmaxx2317/endermatx/commit/${__GIT_HASH_FULL__}`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >{__GIT_HASH__}</a>
+        </span>
+        {deployLabel && (
+          <>
+            <span> · </span>
+            {deployUrl
+              ? <a href={deployUrl} target="_blank" rel="noopener noreferrer">{deployLabel}</a>
+              : <span>{deployLabel}</span>
+            }
+          </>
+        )}
+      </footer>
     </div>
   )
 }

--- a/frontend/src/pages/IdeaInbox.jsx
+++ b/frontend/src/pages/IdeaInbox.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { Link } from 'react-router-dom'
 import { idx } from '../api'
+import VersionBadge from '../components/VersionBadge'
 
 const TABS = [
   { key: 'inbox',    label: 'IN',  status: 'inbox' },
@@ -345,7 +346,7 @@ export default function IdeaInbox() {
         <div className="topbar-left">
           <Link to="/productivity"><button className="topbar-back btn btn-sm">←</button></Link>
           <span className="topbar-title">idx</span>
-          <span style={{ fontSize: 10, color: '#bbb', letterSpacing: '0.05em' }}>v3.0</span>
+          <VersionBadge version="v3.0" />
         </div>
       </div>
       <div className="page">

--- a/frontend/src/pages/Meetings.jsx
+++ b/frontend/src/pages/Meetings.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import { mtg } from '../api'
+import VersionBadge from '../components/VersionBadge'
 
 function uid() { return Date.now() + Math.random().toString(36).slice(2) }
 
@@ -90,7 +91,7 @@ export default function Meetings() {
         <div className="topbar-left">
           <Link to="/"><button className="topbar-back btn btn-sm">←</button></Link>
           <span className="topbar-title">mtg</span>
-          <span style={{ fontSize: 10, color: '#bbb', letterSpacing: '0.05em' }}>v3.0</span>
+          <VersionBadge version="v3.0" />
         </div>
       </div>
       <div className="page">

--- a/frontend/src/pages/Pomodoro.jsx
+++ b/frontend/src/pages/Pomodoro.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { Link } from 'react-router-dom'
 import { pom } from '../api'
+import VersionBadge from '../components/VersionBadge'
 
 const WORK_MINS = 25
 const BREAK_MINS = 5
@@ -106,7 +107,7 @@ export default function Pomodoro() {
         <div className="topbar-left">
           <Link to="/"><button className="topbar-back btn btn-sm">←</button></Link>
           <span className="topbar-title">pom</span>
-          <span style={{ fontSize: 10, color: '#bbb', letterSpacing: '0.05em' }}>v3.0</span>
+          <VersionBadge version="v3.0" />
         </div>
       </div>
       <div className="page" style={{ textAlign: 'center', paddingTop: 48 }}>

--- a/frontend/src/pages/StringTracker.jsx
+++ b/frontend/src/pages/StringTracker.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import { str } from '../api'
+import VersionBadge from '../components/VersionBadge'
 
 function daysSince(iso) {
   if (!iso) return null
@@ -60,7 +61,7 @@ export default function StringTracker() {
         <div className="topbar-left">
           <Link to="/"><button className="topbar-back btn btn-sm">←</button></Link>
           <span className="topbar-title">str</span>
-          <span style={{ fontSize: 10, color: '#bbb', letterSpacing: '0.05em' }}>v3.0</span>
+          <VersionBadge version="v3.0" />
         </div>
       </div>
       <div className="page">

--- a/frontend/src/pages/TimeTracker.jsx
+++ b/frontend/src/pages/TimeTracker.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { Link } from 'react-router-dom'
 import { tts } from '../api'
+import VersionBadge from '../components/VersionBadge'
 
 const COLORS = [
   '#7effa0','#ff6b6b','#6bb5ff','#ffd56b','#d06bff',
@@ -784,7 +785,7 @@ export default function TimeTracker() {
         <div className="topbar-left">
           <Link to="/productivity"><button className="topbar-back btn btn-sm">←</button></Link>
           <span className="topbar-title">tts</span>
-          <span style={{ fontSize: 10, color: '#bbb', letterSpacing: '0.05em' }}>v3.8</span>
+          <VersionBadge version="v3.8" />
         </div>
       </div>
 

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,8 +1,24 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { execSync } from 'child_process'
+import { readFileSync } from 'fs'
+
+let gitHash = 'unknown'
+let gitHashFull = 'unknown'
+try {
+  gitHash     = execSync('git rev-parse --short HEAD').toString().trim()
+  gitHashFull = execSync('git rev-parse HEAD').toString().trim()
+} catch {}
+
+const { version } = JSON.parse(readFileSync('./package.json', 'utf8'))
 
 export default defineConfig({
   plugins: [react()],
+  define: {
+    __GIT_HASH__:      JSON.stringify(gitHash),
+    __GIT_HASH_FULL__: JSON.stringify(gitHashFull),
+    __APP_VERSION__:   JSON.stringify(version),
+  },
   server: {
     proxy: {
       '/api': 'http://localhost:8000',


### PR DESCRIPTION
Adds the deployed commit hash to every version label across the app.

**How it works:**
- `vite.config.js` runs `git rev-parse --short HEAD` (and full) at build time and injects `__GIT_HASH__`, `__GIT_HASH_FULL__`, `__APP_VERSION__` as Vite `define` constants — baked into the JS bundle, zero runtime cost
- New `VersionBadge` component renders `vX.Y-<hash>` where the hash is a link to `github.com/matmaxx2317/endermatx/commit/<full-sha>`
- All 7 tools (tts, cal, pom, mtg, idx, str, crd) use `<VersionBadge version="vX.Y" />`

**Landing page footer:**
- Always visible (was previously hidden until API responded)
- Shows `v1.0.0-<hash>` (clickable → GitHub commit) · `deployed DD.MM.YYYY HH:MM` (clickable → Railway, once `/api/info` responds)

https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw

---
_Generated by [Claude Code](https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw)_