### PR TITLE
fix: resolve git hash on Railway + use 2-digit app version

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -3,14 +3,23 @@ import react from '@vitejs/plugin-react'
 import { execSync } from 'child_process'
 import { readFileSync } from 'fs'
 
-let gitHash = 'unknown'
-let gitHashFull = 'unknown'
+let gitHash = ''
+let gitHashFull = ''
 try {
   gitHash     = execSync('git rev-parse --short HEAD').toString().trim()
   gitHashFull = execSync('git rev-parse HEAD').toString().trim()
 } catch {}
 
-const { version } = JSON.parse(readFileSync('./package.json', 'utf8'))
+// Fallback to Railway's build-time env var when .git is unavailable
+if (!gitHash && process.env.RAILWAY_GIT_COMMIT_SHA) {
+  gitHashFull = process.env.RAILWAY_GIT_COMMIT_SHA
+  gitHash     = gitHashFull.slice(0, 7)
+}
+if (!gitHash) gitHash = 'unknown'
+if (!gitHashFull) gitHashFull = 'unknown'
+
+const { version: semver } = JSON.parse(readFileSync('./package.json', 'utf8'))
+const version = semver.split('.').slice(0, 2).join('.')  // "1.0" from "1.0.0"
 
 export default defineConfig({
   plugins: [react()],


### PR DESCRIPTION
- Fall back to RAILWAY_GIT_COMMIT_SHA when .git dir unavailable at build
- Trim package.json semver to x.y for display (1.0.0 → 1.0)

https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw