### PR TITLE
style(tts): push all text colors towards white

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <title>endermatx</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,6 +11,20 @@ import IdeaInbox from './pages/IdeaInbox'
 import StringTracker from './pages/StringTracker'
 import ChordAligner from './pages/ChordAligner'
 
+function VersionFooter() {
+  return (
+    <div className="version-footer">
+      <a
+        href={`https://github.com/matmaxx2317/endermatx/commit/${__GIT_HASH_FULL__}`}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        v{__APP_VERSION__}-{__GIT_HASH__}
+      </a>
+    </div>
+  )
+}
+
 export default function App() {
   return (
     <BrowserRouter>
@@ -27,6 +41,7 @@ export default function App() {
         <Route path="/str" element={<StringTracker />} />
         <Route path="/crd" element={<ChordAligner />} />
       </Routes>
+      <VersionFooter />
     </BrowserRouter>
   )
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -389,7 +389,7 @@ input, textarea, select {
   text-transform: uppercase;
   white-space: nowrap;
   transition: all 0.15s;
-  color: #bbb;
+  color: #ddd;
 }
 .tts-start:hover { border-color: #7effa0; color: #7effa0; background: #0d1a10; }
 .tts-stop  { border-color: #ff6b6b; color: #ff6b6b; background: #1a0e0e; }
@@ -480,12 +480,12 @@ input, textarea, select {
   font-size: 9px;
   letter-spacing: 0.1em;
   text-transform: uppercase;
-  color: #666;
+  color: #999;
 }
 
 .tts-row-val {
   font-size: 11px;
-  color: #888;
+  color: #bbb;
   font-variant-numeric: tabular-nums;
 }
 
@@ -503,7 +503,7 @@ input, textarea, select {
   flex: 1;
   background: none;
   border: none;
-  color: #ccc;
+  color: #e0e0e0;
   font-size: 13px;
   text-align: left;
   padding: 0;
@@ -542,19 +542,19 @@ input, textarea, select {
   font-size: 11px;
   letter-spacing: 0.2em;
   text-transform: uppercase;
-  color: #bbb;
+  color: #ddd;
 }
 
 .tts-modal-x {
   background: none;
   border: none;
-  color: #555;
+  color: #888;
   font-size: 18px;
   line-height: 1;
   cursor: pointer;
   padding: 0 2px;
 }
-.tts-modal-x:hover { color: #ccc; }
+.tts-modal-x:hover { color: #e0e0e0; }
 
 .tts-modal-body {
   padding: 16px;
@@ -565,13 +565,13 @@ input, textarea, select {
   font-size: 10px;
   letter-spacing: 0.15em;
   text-transform: uppercase;
-  color: #888;
+  color: #bbb;
   margin-bottom: 6px;
 }
 
 .tts-modal-hint {
   font-size: 10px;
-  color: #555;
+  color: #888;
   margin-top: 8px;
   line-height: 1.5;
 }
@@ -594,8 +594,8 @@ input, textarea, select {
 .tts-log-dot { width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0; }
 .tts-log-info { flex: 1; display: flex; gap: 8px; align-items: baseline; min-width: 0; }
 .tts-log-project { color: #e0e0e0; letter-spacing: 0.04em; }
-.tts-log-meta { color: #777; font-size: 10px; }
-.tts-log-dur { color: #aaa; font-size: 10px; letter-spacing: 0.04em; flex-shrink: 0; }
+.tts-log-meta { color: #aaa; font-size: 10px; }
+.tts-log-dur { color: #ccc; font-size: 10px; letter-spacing: 0.04em; flex-shrink: 0; }
 .tts-log-live .tts-log-dur { color: #7effa0; }
 .tts-log-del {
   background: none; border: none; color: #2a2a2a; font-size: 14px;
@@ -608,7 +608,7 @@ input, textarea, select {
   display: flex; align-items: center; gap: 10px; margin-bottom: 8px;
 }
 .tts-week-cw {
-  flex: 1; text-align: center; font-size: 11px; color: #888; letter-spacing: 0.1em;
+  flex: 1; text-align: center; font-size: 11px; color: #bbb; letter-spacing: 0.1em;
 }
 .tts-week-wrap { overflow-x: auto; margin-bottom: 4px; }
 .tts-week-table {
@@ -618,27 +618,27 @@ input, textarea, select {
   padding: 5px 6px; text-align: right; border-bottom: 1px solid #1a1a1a;
 }
 .tts-wk-proj-col { width: 90px; }
-.tts-wk-day-col  { color: #888; font-weight: normal; letter-spacing: 0.05em; }
+.tts-wk-day-col  { color: #bbb; font-weight: normal; letter-spacing: 0.05em; }
 .tts-wk-today    { color: #7effa0 !important; }
-.tts-wk-date     { display: block; font-size: 9px; color: #555; margin-top: 2px; }
+.tts-wk-date     { display: block; font-size: 9px; color: #888; margin-top: 2px; }
 .tts-wk-today .tts-wk-date { color: #3a7a3a; }
-.tts-wk-total-col { color: #666; font-weight: normal; letter-spacing: 0.05em; }
+.tts-wk-total-col { color: #999; font-weight: normal; letter-spacing: 0.05em; }
 .tts-wk-label {
-  text-align: left; color: #777; font-size: 10px; white-space: nowrap; overflow: hidden;
+  text-align: left; color: #aaa; font-size: 10px; white-space: nowrap; overflow: hidden;
   text-overflow: ellipsis; max-width: 90px;
 }
-.tts-wk-bounds-label { color: #555; font-size: 9px; }
-.tts-wk-bounds-cell  { font-size: 9px; color: #666; text-align: center; line-height: 1.5; }
+.tts-wk-bounds-label { color: #888; font-size: 9px; }
+.tts-wk-bounds-cell  { font-size: 9px; color: #999; text-align: center; line-height: 1.5; }
 .tts-wk-dot {
   display: inline-block; width: 6px; height: 6px; border-radius: 50%;
   margin-right: 5px; vertical-align: middle; flex-shrink: 0;
 }
-.tts-wk-cell       { color: #aaa; }
-.tts-wk-empty      { color: #333; }
-.tts-wk-row-total  { color: #ccc; border-left: 1px solid #1e1e1e; }
+.tts-wk-cell       { color: #ccc; }
+.tts-wk-empty      { color: #666; }
+.tts-wk-row-total  { color: #e0e0e0; border-left: 1px solid #1e1e1e; }
 .tts-wk-total-cell { }
 .tts-wk-total-row td {
-  border-top: 1px solid #2a2a2a; color: #ccc; font-size: 10px;
+  border-top: 1px solid #2a2a2a; color: #e0e0e0; font-size: 10px;
 }
 
 /* ── IDX swipe cards ─────────────────────────────────────────── */
@@ -731,13 +731,13 @@ input, textarea, select {
   font-size: 9px;
   letter-spacing: 0.2em;
   text-transform: uppercase;
-  color: #555;
+  color: #888;
   margin-bottom: 10px;
 }
 
 .tts-stat-empty {
   font-size: 11px;
-  color: #333;
+  color: #666;
   text-align: center;
   padding: 14px 0;
   letter-spacing: 0.08em;
@@ -763,7 +763,7 @@ input, textarea, select {
 
 .tts-stat-vbar-val {
   font-size: 9px;
-  color: #888;
+  color: #bbb;
   margin-bottom: 3px;
   white-space: nowrap;
   min-height: 12px;
@@ -782,7 +782,7 @@ input, textarea, select {
 
 .tts-stat-vbar-name {
   font-size: 8px;
-  color: #555;
+  color: #888;
   margin-top: 4px;
   max-width: 100%;
   overflow: hidden;
@@ -804,11 +804,11 @@ input, textarea, select {
   width: 40px;
   flex-shrink: 0;
   font-size: 10px;
-  color: #777;
+  color: #aaa;
   line-height: 1.3;
 }
 
-.tts-stat-stack-date { display: block; font-size: 8px; color: #444; }
+.tts-stat-stack-date { display: block; font-size: 8px; color: #777; }
 
 .tts-stat-stack-track {
   flex: 1;
@@ -822,7 +822,7 @@ input, textarea, select {
   width: 36px;
   flex-shrink: 0;
   font-size: 9px;
-  color: #666;
+  color: #999;
   text-align: right;
 }
 
@@ -841,14 +841,14 @@ input, textarea, select {
 
 .tts-stat-heat-dhd {
   font-size: 9px;
-  color: #555;
+  color: #888;
   font-weight: normal;
   letter-spacing: 0.05em;
 }
 
 .tts-stat-heat-proj {
   text-align: left;
-  color: #777;
+  color: #aaa;
   font-size: 10px;
   white-space: nowrap;
   overflow: hidden;
@@ -856,4 +856,4 @@ input, textarea, select {
   max-width: 80px;
 }
 
-.tts-stat-heat-cell { font-size: 9px; color: #ccc; }
+.tts-stat-heat-cell { font-size: 9px; color: #e0e0e0; }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -5,9 +5,9 @@
 }
 
 body {
-  background: #0d0d0d;
-  color: #e0e0e0;
-  font-family: 'Courier New', Courier, monospace;
+  background: #07091a;
+  color: #eef2ff;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
   min-height: 100vh;
 }
 
@@ -17,12 +17,12 @@ a {
 }
 
 button {
-  font-family: 'Courier New', Courier, monospace;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
   cursor: pointer;
 }
 
 input, textarea, select {
-  font-family: 'Courier New', Courier, monospace;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
 }
 
 /* ── Top bar ──────────────────────────────────────────────────── */
@@ -32,25 +32,25 @@ input, textarea, select {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 6px 12px;
-  background: #111;
-  border-bottom: 1px solid #222;
+  padding: 8px 14px;
+  background: #070914;
+  border-bottom: 1px solid #1a2840;
   font-size: 11px;
-  color: #ccc;
+  color: #9ab0d0;
   z-index: 50;
 }
 .topbar-left { display: flex; align-items: center; gap: 8px; }
-.topbar-title { font-weight: bold; letter-spacing: 0.15em; }
+.topbar-title { font-weight: 600; letter-spacing: 0.12em; color: #eef2ff; }
 .topbar-back {
-  background: none; border: 1px solid #333; color: #888;
+  background: none; border: 1px solid #1a2840; color: #5d7592;
   font-size: 11px; padding: 2px 8px;
 }
-.topbar-back:hover { border-color: #888; color: #ccc; }
+.topbar-back:hover { border-color: #2a3d5c; color: #9ab0d0; }
 
 /* ── Page shell ──────────────────────────────────────────────── */
 .page {
   margin-top: 32px;
-  padding: 20px 16px;
+  padding: 20px 16px 52px;
   max-width: 720px;
   margin-left: auto;
   margin-right: auto;
@@ -59,34 +59,34 @@ input, textarea, select {
 /* ── Shared controls ─────────────────────────────────────────── */
 .btn {
   background: none;
-  border: 1px solid #333;
-  color: #ccc;
+  border: 1px solid #1a2840;
+  color: #9ab0d0;
   padding: 5px 12px;
   font-size: 12px;
 }
-.btn:hover { border-color: #888; color: #fff; }
-.btn-primary { border-color: #8855ff; color: #8855ff; }
-.btn-primary:hover { background: rgba(136,85,255,0.1); }
+.btn:hover { border-color: #2a3d5c; color: #eef2ff; }
+.btn-primary { border-color: #4d6fa0; color: #7a9fd4; }
+.btn-primary:hover { background: rgba(122,159,212,0.08); }
 .btn-danger { border-color: #f44336; color: #f44336; }
 .btn-danger:hover { background: rgba(244,67,54,0.1); }
 .btn-sm { padding: 2px 8px; font-size: 11px; }
 
 .input {
-  background: #1a1a1a;
-  border: 1px solid #333;
-  color: #e0e0e0;
+  background: #0d1221;
+  border: 1px solid #1a2840;
+  color: #eef2ff;
   padding: 8px 10px;
   font-size: 14px;
   width: 100%;
   outline: none;
 }
-.input:focus { border-color: #8855ff; }
-.input::placeholder { color: #555; }
+.input:focus { border-color: #4d6fa0; }
+.input::placeholder { color: #374d66; }
 
 .textarea {
-  background: #1a1a1a;
-  border: 1px solid #333;
-  color: #e0e0e0;
+  background: #0d1221;
+  border: 1px solid #1a2840;
+  color: #eef2ff;
   padding: 8px 10px;
   font-size: 13px;
   width: 100%;
@@ -94,16 +94,16 @@ input, textarea, select {
   outline: none;
   min-height: 80px;
 }
-.textarea:focus { border-color: #8855ff; }
+.textarea:focus { border-color: #4d6fa0; }
 
 /* ── Cards ───────────────────────────────────────────────────── */
 .card {
-  background: #111;
-  border: 1px solid #1e1e1e;
+  background: #0d1221;
+  border: 1px solid #1a2840;
   padding: 14px;
   margin-bottom: 8px;
 }
-.card:hover { border-color: #2a2a2a; }
+.card:hover { border-color: #2a3d5c; }
 
 /* ── Home grid ───────────────────────────────────────────────── */
 .home-grid {
@@ -113,15 +113,15 @@ input, textarea, select {
   margin-top: 24px;
 }
 .home-card {
-  background: #111;
-  border: 1px solid #222;
+  background: #0d1221;
+  border: 1px solid #1a2840;
   padding: 20px 16px;
   display: block;
   transition: border-color 0.15s;
 }
-.home-card:hover { border-color: #555; }
-.home-card-name { font-size: 13px; color: #e0e0e0; letter-spacing: 0.1em; }
-.home-card-desc { font-size: 11px; color: #666; margin-top: 4px; }
+.home-card:hover { border-color: #2a3d5c; }
+.home-card-name { font-size: 13px; color: #eef2ff; letter-spacing: 0.06em; }
+.home-card-desc { font-size: 11px; color: #5d7592; margin-top: 4px; }
 
 /* ── Flex utils ──────────────────────────────────────────────── */
 .row { display: flex; align-items: center; gap: 8px; }
@@ -137,29 +137,29 @@ input, textarea, select {
 
 /* ── Text utils ──────────────────────────────────────────────── */
 .text-sm   { font-size: 11px; }
-.text-muted { color: #666; }
+.text-muted { color: #5d7592; }
 .text-accent { color: #8855ff; }
-.label { font-size: 11px; color: #888; letter-spacing: 0.05em; margin-bottom: 4px; display: block; }
+.label { font-size: 11px; color: #9ab0d0; letter-spacing: 0.04em; margin-bottom: 4px; display: block; }
 
 /* ── Section header ──────────────────────────────────────────── */
 .section-header {
   font-size: 11px;
-  letter-spacing: 0.2em;
+  letter-spacing: 0.15em;
   text-transform: uppercase;
-  color: #777;
+  color: #5d7592;
   margin-bottom: 12px;
   padding-bottom: 6px;
-  border-bottom: 1px solid #1e1e1e;
+  border-bottom: 1px solid #1a2840;
 }
 
 /* ── Tabs ────────────────────────────────────────────────────── */
-.tabs { display: flex; border-bottom: 1px solid #222; margin-bottom: 16px; }
+.tabs { display: flex; border-bottom: 1px solid #1a2840; margin-bottom: 16px; }
 .tab {
   background: none; border: none; border-bottom: 2px solid transparent;
-  color: #888; padding: 7px 14px; font-size: 13px;
-  letter-spacing: 0.05em; margin-bottom: -1px;
+  color: #5d7592; padding: 7px 14px; font-size: 13px;
+  letter-spacing: 0.04em; margin-bottom: -1px;
 }
-.tab:hover { color: #ccc; }
+.tab:hover { color: #9ab0d0; }
 .tab.active { color: #8855ff; border-bottom-color: #8855ff; }
 
 /* ── Color dot ───────────────────────────────────────────────── */
@@ -170,96 +170,121 @@ input, textarea, select {
 
 /* ── Landing / category pages ────────────────────────────────── */
 .landing-page {
-  background: #2a2a2a;
+  background: #07091a;
   min-height: 100vh;
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 100px 20px 60px;
+  padding: 80px 20px 64px;
 }
 
 .landing-header {
   text-align: center;
-  margin-bottom: 60px;
+  margin-bottom: 40px;
 }
 
+.landing-crumb {
+  display: block;
+  font-size: 0.65rem;
+  color: #374d66;
+  letter-spacing: 0.12em;
+  margin-bottom: 8px;
+  text-decoration: none;
+}
+.landing-crumb:hover { color: #9ab0d0; }
+
 .landing-title {
-  font-size: 2rem;
-  font-weight: normal;
-  letter-spacing: 0.15em;
-  color: #ffffff;
-  text-transform: uppercase;
-  line-height: 1.15;
+  font-size: 1.25rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  color: #eef2ff;
+  text-transform: lowercase;
+  line-height: 1.2;
 }
 
 .landing-sub {
-  margin-top: 8px;
-  font-size: 0.75rem;
-  color: #ccc;
-  letter-spacing: 0.2em;
-  text-transform: uppercase;
+  margin-top: 6px;
+  font-size: 0.7rem;
+  color: #374d66;
+  letter-spacing: 0.12em;
 }
 
 .landing-grid {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 6px;
   width: 300px;
 }
 
-.landing-footer {
-  margin-top: 40px;
+.landing-deploy {
+  margin-top: 32px;
   font-size: 10px;
-  letter-spacing: 0.1em;
-  color: #555;
+  letter-spacing: 0.08em;
+  color: #374d66;
 }
-.landing-footer a {
-  color: #555;
+.landing-deploy a {
+  color: #374d66;
   text-decoration: none;
 }
-.landing-footer a:hover { color: #999; }
+.landing-deploy a:hover { color: #9ab0d0; }
 
 .nav-card {
   display: flex;
   flex-direction: row;
   align-items: center;
   text-decoration: none;
-  padding: 12px 16px;
-  border: 1px solid #2a2a2a;
-  border-left: 2px solid #6600aa;
-  background: #1e1e1e;
-  color: #e0e0e0;
+  padding: 13px 16px;
+  border: 1px solid #1a2840;
+  background: #0d1221;
+  color: #eef2ff;
   transition: border-color 0.15s, background 0.15s;
+  gap: 14px;
 }
 
 .nav-card:hover {
-  border-color: #ccc;
-  border-left-color: #9900cc;
-  background: #222;
+  border-color: #2a3d5c;
+  background: #111828;
 }
 
 .nav-card-label {
-  font-size: 0.65rem;
-  letter-spacing: 0.2em;
-  text-transform: uppercase;
-  color: #ccc;
-  width: 28px;
+  font-size: 0.6rem;
+  letter-spacing: 0.15em;
+  color: #374d66;
+  width: 22px;
   flex-shrink: 0;
 }
 
 .nav-card-name {
-  font-size: 1rem;
-  font-weight: normal;
-  letter-spacing: 0.05em;
-  color: #ffffff;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: #eef2ff;
   flex: 1;
-  margin-left: 16px;
 }
 
 .nav-card-arrow {
   font-size: 0.7rem;
-  color: #ccc;
+  color: #374d66;
 }
+
+/* ── Fixed version footer ────────────────────────────────────── */
+.version-footer {
+  position: fixed;
+  bottom: 0; left: 0; right: 0;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #070914;
+  border-top: 1px solid #1a2840;
+  z-index: 40;
+}
+.version-footer a {
+  font-size: 10px;
+  color: #374d66;
+  text-decoration: none;
+  letter-spacing: 0.08em;
+}
+.version-footer a:hover { color: #9ab0d0; }
 
 /* ── Enderman ────────────────────────────────────────────────── */
 .ender-figure {
@@ -382,8 +407,8 @@ input, textarea, select {
 
 .tts-toggle {
   padding: 10px 22px;
-  border: 1px solid #333;
-  background: #1a1a1a;
+  border: 1px solid #1a2840;
+  background: #0d1221;
   font-size: 10px;
   letter-spacing: 0.2em;
   text-transform: uppercase;
@@ -424,8 +449,8 @@ input, textarea, select {
 
 .tts-card {
   position: relative;
-  background: #111;
-  border: 1px solid #1e1e1e;
+  background: #0d1221;
+  border: 1px solid #1a2840;
   padding: 14px 12px 12px;
   text-align: left;
   cursor: pointer;
@@ -435,8 +460,8 @@ input, textarea, select {
   transition: border-color 0.15s, background 0.15s;
   overflow: hidden;
 }
-.tts-card:hover   { border-color: #333; background: #151515; }
-.tts-card-on      { background: #131313; } /* border-color set via inline style from project color */
+.tts-card:hover   { border-color: #2a3d5c; background: #111828; }
+.tts-card-on      { background: #0a1020; } /* border-color set via inline style from project color */
 .tts-card-on .tts-card-stripe { display: none; } /* full 4-side border replaces the stripe when active */
 
 .tts-card-stripe {
@@ -496,7 +521,7 @@ input, textarea, select {
   align-items: center;
   gap: 10px;
   padding: 6px 0;
-  border-bottom: 1px solid #181818;
+  border-bottom: 1px solid #111828;
 }
 
 .tts-mgmt-name {
@@ -518,7 +543,7 @@ input, textarea, select {
 .tts-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0,0,0,0.85);
+  background: rgba(4,6,18,0.9);
   z-index: 100;
   display: flex;
   align-items: center;
@@ -527,8 +552,8 @@ input, textarea, select {
 }
 
 .tts-modal {
-  background: #111;
-  border: 1px solid #2a2a2a;
+  background: #0d1221;
+  border: 1px solid #1a2840;
   width: 100%;
   max-width: 420px;
 }
@@ -538,7 +563,7 @@ input, textarea, select {
   justify-content: space-between;
   align-items: center;
   padding: 12px 16px;
-  border-bottom: 1px solid #1e1e1e;
+  border-bottom: 1px solid #1a2840;
   font-size: 11px;
   letter-spacing: 0.2em;
   text-transform: uppercase;
@@ -581,16 +606,16 @@ input, textarea, select {
   gap: 8px;
   justify-content: flex-end;
   padding: 12px 16px;
-  border-top: 1px solid #1e1e1e;
+  border-top: 1px solid #1a2840;
 }
 
 /* ── TTS Today's Log ─────────────────────────────────────────── */
 .tts-log { display: flex; flex-direction: column; gap: 1px; }
 .tts-log-entry {
   display: flex; align-items: center; gap: 8px;
-  padding: 7px 10px; background: #111; border: 1px solid #1e1e1e; font-size: 11px;
+  padding: 7px 10px; background: #0d1221; border: 1px solid #1a2840; font-size: 11px;
 }
-.tts-log-live { border-color: #1e3a1e; background: #0e1a0e; }
+.tts-log-live { border-color: #0d2a18; background: #071810; }
 .tts-log-dot { width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0; }
 .tts-log-info { flex: 1; display: flex; gap: 8px; align-items: baseline; min-width: 0; }
 .tts-log-project { color: #e0e0e0; letter-spacing: 0.04em; }
@@ -615,7 +640,7 @@ input, textarea, select {
   width: 100%; border-collapse: collapse; font-size: 10px;
 }
 .tts-week-table th, .tts-week-table td {
-  padding: 5px 6px; text-align: right; border-bottom: 1px solid #1a1a1a;
+  padding: 5px 6px; text-align: right; border-bottom: 1px solid #111828;
 }
 .tts-wk-proj-col { width: 90px; }
 .tts-wk-day-col  { color: #bbb; font-weight: normal; letter-spacing: 0.05em; }
@@ -635,10 +660,10 @@ input, textarea, select {
 }
 .tts-wk-cell       { color: #ccc; }
 .tts-wk-empty      { color: #666; }
-.tts-wk-row-total  { color: #e0e0e0; border-left: 1px solid #1e1e1e; }
+.tts-wk-row-total  { color: #e0e0e0; border-left: 1px solid #1a2840; }
 .tts-wk-total-cell { }
 .tts-wk-total-row td {
-  border-top: 1px solid #2a2a2a; color: #e0e0e0; font-size: 10px;
+  border-top: 1px solid #1a2840; color: #e0e0e0; font-size: 10px;
 }
 
 /* ── IDX swipe cards ─────────────────────────────────────────── */
@@ -752,6 +777,7 @@ input, textarea, select {
   padding-bottom: 4px;
 }
 
+
 .tts-stat-vbar-col {
   display: flex;
   flex-direction: column;
@@ -773,7 +799,7 @@ input, textarea, select {
 .tts-stat-vbar-track {
   width: 100%;
   height: 80px;
-  background: #191919;
+  background: #111828;
   display: flex;
   align-items: flex-end;
 }
@@ -813,7 +839,7 @@ input, textarea, select {
 .tts-stat-stack-track {
   flex: 1;
   height: 16px;
-  background: #141414;
+  background: #111828;
 }
 
 .tts-stat-stack-bar { height: 100%; display: flex; min-width: 0; }

--- a/frontend/src/pages/Calendar.jsx
+++ b/frontend/src/pages/Calendar.jsx
@@ -1,7 +1,6 @@
 import { useState, useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import { cal } from '../api'
-import VersionBadge from '../components/VersionBadge'
 
 const MONTHS = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec']
 const COLORS = ['#4a9eff','#e74c3c','#2ecc71','#f1c40f','#9b59b6','#e67e22','#1abc9c','#e91e63']
@@ -72,7 +71,6 @@ export default function Calendar() {
         <div className="topbar-left">
           <Link to="/"><button className="topbar-back btn btn-sm">←</button></Link>
           <span className="topbar-title">cal</span>
-          <VersionBadge version="v3.0" />
         </div>
       </div>
       <div className="page" style={{ maxWidth: 900 }}>

--- a/frontend/src/pages/ChordAligner.jsx
+++ b/frontend/src/pages/ChordAligner.jsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
 import { Link } from 'react-router-dom'
 import { crd } from '../api'
-import VersionBadge from '../components/VersionBadge'
 
 function distributeChords(lyrics, chordsText) {
   const words = lyrics.trim().split(/\s+/).filter(Boolean)
@@ -102,7 +101,6 @@ export default function ChordAligner() {
         <div className="topbar-left">
           <Link to="/"><button className="topbar-back btn btn-sm">←</button></Link>
           <span className="topbar-title">crd</span>
-          <VersionBadge version="v3.0" />
         </div>
         <span style={{ fontSize: 11, color: saved ? '#4caf50' : '#555' }}>{saved ? 'saved' : '…'}</span>
       </div>

--- a/frontend/src/pages/Games.jsx
+++ b/frontend/src/pages/Games.jsx
@@ -1,24 +1,18 @@
 import { Link } from 'react-router-dom'
-import Enderman from '../components/Enderman'
 
 const GAMES = [
   { href: '/games/teleport-tap/', label: '01', name: 'teleport-tap' },
-  { href: '/games/mobs-magic/', label: '02', name: 'mobs-magic' },
+  { href: '/games/mobs-magic/',   label: '02', name: 'mobs-magic' },
 ]
 
 export default function Games() {
   return (
     <div className="landing-page">
-      <Enderman />
       <header className="landing-header">
-        <h1 className="landing-title">END<br />ERM<br />ATX</h1>
-        <p className="landing-sub">tools</p>
+        <Link to="/" className="landing-crumb">endermatx</Link>
+        <h1 className="landing-title">games</h1>
       </header>
       <nav className="landing-grid">
-        <Link to="/" className="nav-card">
-          <div className="nav-card-label">←</div>
-          <div className="nav-card-name">back</div>
-        </Link>
         {GAMES.map(g => (
           <a key={g.href} href={g.href} className="nav-card">
             <div className="nav-card-label">{g.label}</div>

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,12 +1,17 @@
 import { useState, useEffect } from 'react'
 import { Link } from 'react-router-dom'
-import Enderman from '../components/Enderman'
 
 function fmtDeployTime(iso) {
   const d = new Date(iso)
   const pad = n => String(n).padStart(2, '0')
   return `deployed ${pad(d.getDate())}.${pad(d.getMonth() + 1)}.${d.getFullYear()} ${pad(d.getHours())}:${pad(d.getMinutes())}`
 }
+
+const CATEGORIES = [
+  { to: '/productivity', label: '01', name: 'productivity' },
+  { to: '/personal',    label: '02', name: 'personal' },
+  { to: '/games',       label: '03', name: 'games' },
+]
 
 export default function Home() {
   const [deployInfo, setDeployInfo] = useState(null)
@@ -23,46 +28,27 @@ export default function Home() {
 
   return (
     <div className="landing-page">
-      <Enderman />
       <header className="landing-header">
-        <h1 className="landing-title">END<br />ERM<br />ATX</h1>
-        <p className="landing-sub">tools</p>
+        <h1 className="landing-title">endermatx</h1>
+        <p className="landing-sub">productivity · personal · games</p>
       </header>
       <nav className="landing-grid">
-        <Link to="/productivity" className="nav-card">
-          <div className="nav-card-label">01</div>
-          <div className="nav-card-name">productivity</div>
-          <div className="nav-card-arrow">→</div>
-        </Link>
-        <Link to="/personal" className="nav-card">
-          <div className="nav-card-label">02</div>
-          <div className="nav-card-name">personal</div>
-          <div className="nav-card-arrow">→</div>
-        </Link>
-        <Link to="/games" className="nav-card">
-          <div className="nav-card-label">03</div>
-          <div className="nav-card-name">games</div>
-          <div className="nav-card-arrow">→</div>
-        </Link>
+        {CATEGORIES.map(c => (
+          <Link key={c.to} to={c.to} className="nav-card">
+            <div className="nav-card-label">{c.label}</div>
+            <div className="nav-card-name">{c.name}</div>
+            <div className="nav-card-arrow">→</div>
+          </Link>
+        ))}
       </nav>
-      <footer className="landing-footer">
-        <span>
-          v{__APP_VERSION__}-<a
-            href={`https://github.com/matmaxx2317/endermatx/commit/${__GIT_HASH_FULL__}`}
-            target="_blank"
-            rel="noopener noreferrer"
-          >{__GIT_HASH__}</a>
-        </span>
-        {deployLabel && (
-          <>
-            <span> · </span>
-            {deployUrl
-              ? <a href={deployUrl} target="_blank" rel="noopener noreferrer">{deployLabel}</a>
-              : <span>{deployLabel}</span>
-            }
-          </>
-        )}
-      </footer>
+      {deployLabel && (
+        <div className="landing-deploy">
+          {deployUrl
+            ? <a href={deployUrl} target="_blank" rel="noopener noreferrer">{deployLabel}</a>
+            : <span>{deployLabel}</span>
+          }
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/pages/IdeaInbox.jsx
+++ b/frontend/src/pages/IdeaInbox.jsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
 import { Link } from 'react-router-dom'
 import { idx } from '../api'
-import VersionBadge from '../components/VersionBadge'
 
 const TABS = [
   { key: 'inbox',    label: 'IN',  status: 'inbox' },
@@ -346,7 +345,6 @@ export default function IdeaInbox() {
         <div className="topbar-left">
           <Link to="/productivity"><button className="topbar-back btn btn-sm">←</button></Link>
           <span className="topbar-title">idx</span>
-          <VersionBadge version="v3.0" />
         </div>
       </div>
       <div className="page">

--- a/frontend/src/pages/Meetings.jsx
+++ b/frontend/src/pages/Meetings.jsx
@@ -1,7 +1,6 @@
 import { useState, useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import { mtg } from '../api'
-import VersionBadge from '../components/VersionBadge'
 
 function uid() { return Date.now() + Math.random().toString(36).slice(2) }
 
@@ -91,7 +90,6 @@ export default function Meetings() {
         <div className="topbar-left">
           <Link to="/"><button className="topbar-back btn btn-sm">←</button></Link>
           <span className="topbar-title">mtg</span>
-          <VersionBadge version="v3.0" />
         </div>
       </div>
       <div className="page">

--- a/frontend/src/pages/Personal.jsx
+++ b/frontend/src/pages/Personal.jsx
@@ -1,5 +1,4 @@
 import { Link } from 'react-router-dom'
-import Enderman from '../components/Enderman'
 
 const TOOLS = [
   { path: '/str', label: '01', name: 'str', desc: 'string tracker' },
@@ -9,16 +8,11 @@ const TOOLS = [
 export default function Personal() {
   return (
     <div className="landing-page">
-      <Enderman />
       <header className="landing-header">
-        <h1 className="landing-title">END<br />ERM<br />ATX</h1>
-        <p className="landing-sub">tools</p>
+        <Link to="/" className="landing-crumb">endermatx</Link>
+        <h1 className="landing-title">personal</h1>
       </header>
       <nav className="landing-grid">
-        <Link to="/" className="nav-card">
-          <div className="nav-card-label">←</div>
-          <div className="nav-card-name">back</div>
-        </Link>
         {TOOLS.map(t => (
           <Link key={t.path} to={t.path} className="nav-card">
             <div className="nav-card-label">{t.label}</div>

--- a/frontend/src/pages/Pomodoro.jsx
+++ b/frontend/src/pages/Pomodoro.jsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
 import { Link } from 'react-router-dom'
 import { pom } from '../api'
-import VersionBadge from '../components/VersionBadge'
 
 const WORK_MINS = 25
 const BREAK_MINS = 5
@@ -107,7 +106,6 @@ export default function Pomodoro() {
         <div className="topbar-left">
           <Link to="/"><button className="topbar-back btn btn-sm">←</button></Link>
           <span className="topbar-title">pom</span>
-          <VersionBadge version="v3.0" />
         </div>
       </div>
       <div className="page" style={{ textAlign: 'center', paddingTop: 48 }}>

--- a/frontend/src/pages/Productivity.jsx
+++ b/frontend/src/pages/Productivity.jsx
@@ -1,27 +1,21 @@
 import { Link } from 'react-router-dom'
-import Enderman from '../components/Enderman'
 
 const TOOLS = [
-  { path: '/tts', label: '01', name: 'tts', desc: 'time tracker' },
-  { path: '/cal', label: '02', name: 'cal', desc: 'calendar' },
-  { path: '/pom', label: '03', name: 'pom', desc: 'pomodoro' },
-  { path: '/mtg', label: '04', name: 'mtg', desc: 'meeting notes' },
-  { path: '/idx', label: '05', name: 'idx', desc: 'idea inbox' },
+  { path: '/tts', label: '01', name: 'tts',  desc: 'time tracker' },
+  { path: '/cal', label: '02', name: 'cal',  desc: 'calendar' },
+  { path: '/pom', label: '03', name: 'pom',  desc: 'pomodoro' },
+  { path: '/mtg', label: '04', name: 'mtg',  desc: 'meeting notes' },
+  { path: '/idx', label: '05', name: 'idx',  desc: 'idea inbox' },
 ]
 
 export default function Productivity() {
   return (
     <div className="landing-page">
-      <Enderman />
       <header className="landing-header">
-        <h1 className="landing-title">END<br />ERM<br />ATX</h1>
-        <p className="landing-sub">tools</p>
+        <Link to="/" className="landing-crumb">endermatx</Link>
+        <h1 className="landing-title">productivity</h1>
       </header>
       <nav className="landing-grid">
-        <Link to="/" className="nav-card">
-          <div className="nav-card-label">←</div>
-          <div className="nav-card-name">back</div>
-        </Link>
         {TOOLS.map(t => (
           <Link key={t.path} to={t.path} className="nav-card">
             <div className="nav-card-label">{t.label}</div>

--- a/frontend/src/pages/StringTracker.jsx
+++ b/frontend/src/pages/StringTracker.jsx
@@ -1,7 +1,6 @@
 import { useState, useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import { str } from '../api'
-import VersionBadge from '../components/VersionBadge'
 
 function daysSince(iso) {
   if (!iso) return null
@@ -61,7 +60,6 @@ export default function StringTracker() {
         <div className="topbar-left">
           <Link to="/"><button className="topbar-back btn btn-sm">←</button></Link>
           <span className="topbar-title">str</span>
-          <VersionBadge version="v3.0" />
         </div>
       </div>
       <div className="page">

--- a/frontend/src/pages/TimeTracker.jsx
+++ b/frontend/src/pages/TimeTracker.jsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
 import { Link } from 'react-router-dom'
 import { tts } from '../api'
-import VersionBadge from '../components/VersionBadge'
 
 const COLORS = [
   '#7effa0','#ff6b6b','#6bb5ff','#ffd56b','#d06bff',
@@ -785,7 +784,6 @@ export default function TimeTracker() {
         <div className="topbar-left">
           <Link to="/productivity"><button className="topbar-back btn btn-sm">←</button></Link>
           <span className="topbar-title">tts</span>
-          <VersionBadge version="v3.8" />
         </div>
       </div>
 

--- a/frontend/src/pages/TimeTracker.jsx
+++ b/frontend/src/pages/TimeTracker.jsx
@@ -872,7 +872,7 @@ export default function TimeTracker() {
                 })}
               </div>
             ) : (
-              <div style={{ color: '#444', fontSize: 12, padding: '20px 0', textAlign: 'center', letterSpacing: '0.08em' }}>
+              <div style={{ color: '#888', fontSize: 12, padding: '20px 0', textAlign: 'center', letterSpacing: '0.08em' }}>
                 no projects yet — add one in the org tab
               </div>
             )}


### PR DESCRIPTION
Shifts every TTS text color significantly brighter while preserving the relative gradation between semantic levels:

| Old | New | Semantic role |
|-----|-----|---------------|
| `#333` | `#666` | empty / no-data states |
| `#444` | `#777` | secondary dates |
| `#555` | `#888` | section headings, hints, bar names, heatmap day headers |
| `#666` | `#999` | row labels (SESSION / TODAY / TOTAL), bounds, minor totals |
| `#777` | `#aaa` | log meta, week table project labels, heat project names |
| `#888` | `#bbb` | row values, CW label, day column headers, modal labels |
| `#aaa` | `#ccc` | log duration, week table cells |
| `#bbb` | `#ddd` | toggle button text, modal head |
| `#ccc` | `#e0e0e0` | org-tab project names, row totals, heatmap cell values |

One inline style in `TimeTracker.jsx` ("no projects yet") also updated `#444 → #888`.

Accent colors (`#7effa0`, `#ff6b6b`, project colors, today highlight) are untouched.

https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw

---
_Generated by [Claude Code](https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw)_