### PR TITLE
feat: restore back card to category nav pages

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "endermatx-frontend",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/pages/Games.jsx
+++ b/frontend/src/pages/Games.jsx
@@ -13,6 +13,11 @@ export default function Games() {
         <h1 className="landing-title">games</h1>
       </header>
       <nav className="landing-grid">
+        <Link to="/" className="nav-card">
+          <div className="nav-card-label"></div>
+          <div className="nav-card-name">← back</div>
+          <div className="nav-card-arrow"></div>
+        </Link>
         {GAMES.map(g => (
           <a key={g.href} href={g.href} className="nav-card">
             <div className="nav-card-label">{g.label}</div>

--- a/frontend/src/pages/Personal.jsx
+++ b/frontend/src/pages/Personal.jsx
@@ -13,6 +13,11 @@ export default function Personal() {
         <h1 className="landing-title">personal</h1>
       </header>
       <nav className="landing-grid">
+        <Link to="/" className="nav-card">
+          <div className="nav-card-label"></div>
+          <div className="nav-card-name">← back</div>
+          <div className="nav-card-arrow"></div>
+        </Link>
         {TOOLS.map(t => (
           <Link key={t.path} to={t.path} className="nav-card">
             <div className="nav-card-label">{t.label}</div>

--- a/frontend/src/pages/Productivity.jsx
+++ b/frontend/src/pages/Productivity.jsx
@@ -16,6 +16,11 @@ export default function Productivity() {
         <h1 className="landing-title">productivity</h1>
       </header>
       <nav className="landing-grid">
+        <Link to="/" className="nav-card">
+          <div className="nav-card-label"></div>
+          <div className="nav-card-name">← back</div>
+          <div className="nav-card-arrow"></div>
+        </Link>
         {TOOLS.map(t => (
           <Link key={t.path} to={t.path} className="nav-card">
             <div className="nav-card-label">{t.label}</div>


### PR DESCRIPTION
## Summary

- Adds a `← back` card as the first item in the nav grid on Productivity, Personal, and Games pages
- Bumps version to v1.1

---
_Generated by [Claude Code](https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw)_