### PR TITLE
security: fix path traversal, CORS, headers, input validation, URL injection

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -9,10 +9,11 @@ _startup_time = datetime.now(timezone.utc)
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
+from starlette.middleware.base import BaseHTTPMiddleware
 
 from .database import engine, Base, SessionLocal
 from .models import TtsEntry
@@ -79,11 +80,25 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(title="endermatx API", lifespan=lifespan)
 
+# Security headers on every response
+class SecurityHeadersMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        response = await call_next(request)
+        response.headers.setdefault("X-Content-Type-Options", "nosniff")
+        response.headers.setdefault("X-Frame-Options", "DENY")
+        response.headers.setdefault("Referrer-Policy", "strict-origin-when-cross-origin")
+        return response
+
+app.add_middleware(SecurityHeadersMiddleware)
+
+# CORS: restrict to configured origins (defaults to local dev server)
+_raw_origins = os.environ.get("ALLOWED_ORIGINS", "http://localhost:5173")
+_allowed_origins = [o.strip() for o in _raw_origins.split(",") if o.strip()]
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_origins=_allowed_origins,
+    allow_methods=["GET", "POST", "PUT", "DELETE"],
+    allow_headers=["Content-Type"],
 )
 
 app.include_router(tts.router, prefix="/api/tts", tags=["tts"])
@@ -144,9 +159,14 @@ async def root():
 
 @app.get("/{full_path:path}")
 async def spa_fallback(full_path: str):
-    candidate = FRONTEND_DIST / full_path
-    if full_path and candidate.is_file():
-        return FileResponse(candidate)
+    dist = FRONTEND_DIST.resolve()
+    candidate = (FRONTEND_DIST / full_path).resolve()
+    try:
+        candidate.relative_to(dist)
+        if candidate.is_file():
+            return FileResponse(candidate)
+    except ValueError:
+        pass  # path traversal attempt — fall through to index.html
     index = FRONTEND_DIST / "index.html"
     if index.exists():
         return FileResponse(index)

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from typing import Annotated, Any, Optional
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from pydantic.functional_serializers import PlainSerializer
 
 # Timezone-naive datetimes from SQLAlchemy are serialized without a 'Z', so
@@ -9,16 +9,18 @@ from pydantic.functional_serializers import PlainSerializer
 UtcDt    = Annotated[datetime,          PlainSerializer(lambda v: v.isoformat() + 'Z', return_type=str)]
 UtcDtOpt = Annotated[Optional[datetime], PlainSerializer(lambda v: v.isoformat() + 'Z' if v else None, return_type=Optional[str])]
 
+_COLOR   = r'^#[0-9a-fA-F]{6}$'   # e.g. #4a9eff
+_DATE    = r'^\d{4}-\d{2}-\d{2}$' # e.g. 2026-05-01
 
 # ── tts ───────────────────────────────────────────────────────────────────────
 
 class TtsProjectCreate(BaseModel):
-    name: str
-    color: str = "#888888"
+    name:  str = Field(..., max_length=100)
+    color: str = Field("#888888", pattern=_COLOR)
 
 class TtsProjectUpdate(BaseModel):
-    name: Optional[str] = None
-    color: Optional[str] = None
+    name:     Optional[str]  = Field(None, max_length=100)
+    color:    Optional[str]  = Field(None, pattern=_COLOR)
     archived: Optional[bool] = None
 
 class TtsProjectOut(BaseModel):
@@ -36,9 +38,9 @@ class TtsEntryCreate(BaseModel):
     end_time: Optional[datetime] = None
 
 class TtsEntryUpdate(BaseModel):
-    end_time: Optional[datetime] = None
+    end_time:   Optional[datetime] = None
     start_time: Optional[datetime] = None
-    project_id: Optional[int] = None
+    project_id: Optional[int]      = None
 
 class TtsEntryOut(BaseModel):
     id: int
@@ -50,17 +52,19 @@ class TtsEntryOut(BaseModel):
 
 # ── cal ───────────────────────────────────────────────────────────────────────
 
+_VALID_COUNTRIES = {"DE", "AT", "US", "GB", "FR", "CN", "JP"}
+
 class CalProjectCreate(BaseModel):
-    name: str
-    color: str = "#4a9eff"
-    start_date: str
-    end_date: str
+    name:       str = Field(..., max_length=100)
+    color:      str = Field("#4a9eff", pattern=_COLOR)
+    start_date: str = Field(..., pattern=_DATE)
+    end_date:   str = Field(..., pattern=_DATE)
 
 class CalProjectUpdate(BaseModel):
-    name: Optional[str] = None
-    color: Optional[str] = None
-    start_date: Optional[str] = None
-    end_date: Optional[str] = None
+    name:       Optional[str] = Field(None, max_length=100)
+    color:      Optional[str] = Field(None, pattern=_COLOR)
+    start_date: Optional[str] = Field(None, pattern=_DATE)
+    end_date:   Optional[str] = Field(None, pattern=_DATE)
 
 class CalProjectOut(BaseModel):
     id: int
@@ -72,54 +76,60 @@ class CalProjectOut(BaseModel):
 
 
 class CalSettingsUpdate(BaseModel):
-    start_year: Optional[int] = None
-    start_month: Optional[int] = None
-    end_year: Optional[int] = None
-    end_month: Optional[int] = None
-    tile_width: Optional[int] = None
-    countries: Optional[list[str]] = None
+    start_year:  Optional[int]       = Field(None, ge=2000, le=2100)
+    start_month: Optional[int]       = Field(None, ge=0,    le=11)
+    end_year:    Optional[int]       = Field(None, ge=2000, le=2100)
+    end_month:   Optional[int]       = Field(None, ge=0,    le=11)
+    tile_width:  Optional[int]       = Field(None, ge=100,  le=1200)
+    countries:   Optional[list[str]] = None
+
+    def model_post_init(self, __context: Any) -> None:
+        if self.countries is not None:
+            invalid = [c for c in self.countries if c not in _VALID_COUNTRIES]
+            if invalid:
+                raise ValueError(f"unknown country codes: {invalid}")
 
 class CalSettingsOut(BaseModel):
-    start_year: Optional[int]
+    start_year:  Optional[int]
     start_month: Optional[int]
-    end_year: Optional[int]
-    end_month: Optional[int]
-    tile_width: int
-    countries: list[str]
+    end_year:    Optional[int]
+    end_month:   Optional[int]
+    tile_width:  int
+    countries:   list[str]
     model_config = {"from_attributes": True}
 
 
 # ── pom ───────────────────────────────────────────────────────────────────────
 
 class PomStateUpdate(BaseModel):
-    sessions: Optional[dict[str, Any]] = None
-    total_mins: Optional[float] = None
-    timer: Optional[dict[str, Any]] = None
+    sessions:   Optional[dict[str, Any]] = None
+    total_mins: Optional[float]          = Field(None, ge=0)
+    timer:      Optional[dict[str, Any]] = None
 
 class PomStateOut(BaseModel):
-    sessions: dict[str, Any]
+    sessions:   dict[str, Any]
     total_mins: float
-    timer: Optional[dict[str, Any]]
+    timer:      Optional[dict[str, Any]]
     model_config = {"from_attributes": True}
 
 
 # ── mtg ───────────────────────────────────────────────────────────────────────
 
 class MeetingCreate(BaseModel):
-    title: str
-    date: str = ""
-    notes: str = ""
-    attendees: list[str] = []
-    actions: list[dict[str, Any]] = []
-    summary: str = ""
+    title:     str            = Field(...,  max_length=200)
+    date:      str            = Field("",   max_length=20)
+    notes:     str            = Field("",   max_length=20000)
+    attendees: list[str]      = Field(default_factory=list)
+    actions:   list[dict[str, Any]] = Field(default_factory=list)
+    summary:   str            = Field("",   max_length=5000)
 
 class MeetingUpdate(BaseModel):
-    title: Optional[str] = None
-    date: Optional[str] = None
-    notes: Optional[str] = None
-    attendees: Optional[list[str]] = None
-    actions: Optional[list[dict[str, Any]]] = None
-    summary: Optional[str] = None
+    title:     Optional[str]                  = Field(None, max_length=200)
+    date:      Optional[str]                  = Field(None, max_length=20)
+    notes:     Optional[str]                  = Field(None, max_length=20000)
+    attendees: Optional[list[str]]            = None
+    actions:   Optional[list[dict[str, Any]]] = None
+    summary:   Optional[str]                  = Field(None, max_length=5000)
 
 class MeetingOut(BaseModel):
     id: int
@@ -135,12 +145,18 @@ class MeetingOut(BaseModel):
 
 # ── idx ───────────────────────────────────────────────────────────────────────
 
+_VALID_STATUSES = {"inbox", "promoted", "deferred", "done", "killed"}
+
 class IdeaCreate(BaseModel):
-    text: str
+    text: str = Field(..., max_length=500)
 
 class IdeaUpdate(BaseModel):
-    text: Optional[str] = None
+    text:   Optional[str] = Field(None, max_length=500)
     status: Optional[str] = None
+
+    def model_post_init(self, __context: Any) -> None:
+        if self.status is not None and self.status not in _VALID_STATUSES:
+            raise ValueError(f"invalid status")
 
 class IdeaOut(BaseModel):
     id: int
@@ -154,12 +170,12 @@ class IdeaOut(BaseModel):
 # ── str ───────────────────────────────────────────────────────────────────────
 
 class GuitarCreate(BaseModel):
-    name: str
-    threshold_days: int = 30
+    name:           str = Field(..., max_length=100)
+    threshold_days: int = Field(30, ge=1, le=3650)
 
 class GuitarUpdate(BaseModel):
-    name: Optional[str] = None
-    threshold_days: Optional[int] = None
+    name:           Optional[str] = Field(None, max_length=100)
+    threshold_days: Optional[int] = Field(None, ge=1, le=3650)
 
 class GuitarOut(BaseModel):
     id: int
@@ -173,22 +189,22 @@ class GuitarOut(BaseModel):
 # ── crd ───────────────────────────────────────────────────────────────────────
 
 class CrdStateUpdate(BaseModel):
-    lyrics: Optional[str] = None
-    manual_chords: Optional[str] = None
-    media_url: Optional[str] = None
-    chords: Optional[list[Any]] = None
-    cursor: Optional[int] = None
-    word_seq: Optional[int] = None
-    lines: Optional[list[Any]] = None
-    manual_output: Optional[str] = None
+    lyrics:       Optional[str]       = Field(None, max_length=50000)
+    manual_chords:Optional[str]       = Field(None, max_length=2000)
+    media_url:    Optional[str]       = Field(None, max_length=2000)
+    chords:       Optional[list[Any]] = None
+    cursor:       Optional[int]       = Field(None, ge=0)
+    word_seq:     Optional[int]       = Field(None, ge=0)
+    lines:        Optional[list[Any]] = None
+    manual_output:Optional[str]       = Field(None, max_length=50000)
 
 class CrdStateOut(BaseModel):
-    lyrics: str
+    lyrics:        str
     manual_chords: str
-    media_url: str
-    chords: list[Any]
-    cursor: int
-    word_seq: int
-    lines: list[Any]
+    media_url:     str
+    chords:        list[Any]
+    cursor:        int
+    word_seq:      int
+    lines:         list[Any]
     manual_output: Optional[str]
     model_config = {"from_attributes": True}

--- a/frontend/src/pages/ChordAligner.jsx
+++ b/frontend/src/pages/ChordAligner.jsx
@@ -115,7 +115,7 @@ export default function ChordAligner() {
             <textarea className="textarea" rows={4} value={manualChords} onChange={e => handleChordsChange(e.target.value)} placeholder="G G C G D G C G" />
             <label className="label mt8">audio / video URL</label>
             <input className="input" value={mediaUrl} onChange={e => handleUrlChange(e.target.value)} placeholder="https://…" />
-            {mediaUrl && (
+            {mediaUrl && /^https?:\/\//i.test(mediaUrl) && (
               <audio controls src={mediaUrl} style={{ marginTop: 8, width: '100%' }} />
             )}
           </div>


### PR DESCRIPTION
## Summary

Five concrete security fixes — skipped theoretical issues (auth, rate limiting) that don't apply to a single-user personal tool.

### 1. Path traversal (`backend/main.py`)
The SPA fallback `FRONTEND_DIST / full_path` would follow `../` segments and serve files outside `frontend/dist/`. Fixed with `resolve()` + `relative_to()` — traversal attempts now silently serve `index.html`.

### 2. CORS (`backend/main.py`)
`allow_origins=["*"]` let any website hit the API cross-origin. Replaced with an `ALLOWED_ORIGINS` env var (comma-separated). **Action needed:** set `ALLOWED_ORIGINS=https://your-railway-domain.up.railway.app` in the Railway service variables. Default is `http://localhost:5173` for local dev (Vite proxy means CORS isn't needed in production at all, but the env var gives an explicit allowlist).

### 3. Security headers (`backend/main.py`)
New `SecurityHeadersMiddleware` adds to every response:
- `X-Content-Type-Options: nosniff`
- `X-Frame-Options: DENY`
- `Referrer-Policy: strict-origin-when-cross-origin`

### 4. Input validation (`backend/schemas.py`)
All Pydantic schemas now enforce:
- `max_length` on every string field (e.g. name ≤ 100, notes ≤ 20 000, lyrics ≤ 50 000)
- `pattern=r'^#[0-9a-fA-F]{6}$'` on all color fields
- `pattern=r'^\d{4}-\d{2}-\d{2}$'` on date strings
- `ge`/`le` bounds on numeric fields (threshold_days 1–3650, years 2000–2100, etc.)
- Country code allowlist in `CalSettingsUpdate`
- Status allowlist in `IdeaUpdate`

### 5. Audio URL injection (`frontend/src/pages/ChordAligner.jsx`)
`<audio src={mediaUrl}>` previously accepted `data:` and `javascript:` URLs. Now only renders if the URL starts with `http://` or `https://`.

---
_Generated by [Claude Code](https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw)_