### PR TITLE
str: rework status display and yellow threshold

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "endermatx-frontend",
   "private": true,
-  "version": "1.5.0",
+  "version": "1.6.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "endermatx-frontend",
   "private": true,
-  "version": "1.6.0",
+  "version": "1.7.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/pages/Calendar.jsx
+++ b/frontend/src/pages/Calendar.jsx
@@ -2,6 +2,14 @@ import { useState, useEffect, useLayoutEffect, useRef } from 'react'
 import { Link } from 'react-router-dom'
 import { cal } from '../api'
 
+// ── Helpers ────────────────────────────────────────────────────
+// Format a yyyy-mm-dd string as dd.mm.yyyy without creating a Date object
+function fmtIsoDate(s) {
+  if (!s) return ''
+  const [y, m, d] = s.split('-')
+  return `${d}.${m}.${y}`
+}
+
 // ── Constants ──────────────────────────────────────────────────
 const MONTHS   = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec']
 const COLORS   = ['#4a9eff','#e74c3c','#2ecc71','#f1c40f','#9b59b6','#e67e22','#1abc9c','#e91e63']
@@ -582,7 +590,7 @@ export default function Calendar() {
                 <div key={p.id} style={{ marginTop: 4, display: 'flex', alignItems: 'center', gap: 6, fontSize: 11, color: '#9ab0d0' }}>
                   <span style={{ width: 6, height: 6, borderRadius: '50%', background: p.color }} />
                   {p.name}
-                  <span style={{ color: '#374d66' }}>{p.start_date} → {p.end_date}</span>
+                  <span style={{ color: '#374d66' }}>{fmtIsoDate(p.start_date)} → {fmtIsoDate(p.end_date)}</span>
                 </div>
               ))}
             </div>

--- a/frontend/src/pages/StringTracker.jsx
+++ b/frontend/src/pages/StringTracker.jsx
@@ -10,7 +10,7 @@ function daysSince(iso) {
 function statusColor(days, threshold) {
   if (days === null) return '#f44336'
   if (days >= threshold) return '#f44336'
-  if (days >= Math.floor(threshold * 0.75)) return '#ff9800'
+  if (days >= threshold * 0.8) return '#ff9800'
   return '#4caf50'
 }
 
@@ -142,6 +142,8 @@ export default function StringTracker() {
         {guitars.map(g => {
           const days = daysSince(g.last_changed)
           const color = statusColor(days, g.threshold_days)
+          // positive → days remaining; negative → days overdue; null → never changed
+          const remaining = days !== null ? g.threshold_days - days : null
           const expanded = expandedId === g.id
           const swipeX = swipeOffset.id === g.id ? swipeOffset.x : 0
           const snapping = swipeOffset.id !== g.id
@@ -175,10 +177,11 @@ export default function StringTracker() {
                 >
                   <span style={{ width: 8, height: 8, borderRadius: '50%', background: color, flexShrink: 0 }} />
                   <span style={{ flex: 1, fontSize: 14, color: '#ddd' }}>{g.name}</span>
-                  <span style={{ fontSize: 12, color }}>
-                    {days === null ? 'never changed' : `${days}d ago`}
-                  </span>
-                  <span style={{ fontSize: 11, color: '#444' }}>/{g.threshold_days}d</span>
+                  <span style={{ fontSize: 12, color }}>{days !== null ? `${days}d` : '—'}</span>
+                  <span style={{ fontSize: 12, color: '#374d66', margin: '0 2px' }}>|</span>
+                  <span style={{ fontSize: 12, color }}>{remaining !== null ? `${Math.abs(remaining)}d` : '—'}</span>
+                  <span style={{ fontSize: 12, color: '#374d66', margin: '0 2px' }}>|</span>
+                  <span style={{ fontSize: 12, color: '#374d66' }}>{g.threshold_days}d</span>
                 </div>
 
                 {expanded && (

--- a/frontend/src/pages/StringTracker.jsx
+++ b/frontend/src/pages/StringTracker.jsx
@@ -16,7 +16,9 @@ function statusColor(days, threshold) {
 
 function fmtDate(iso) {
   if (!iso) return 'never'
-  return new Date(iso).toLocaleDateString()
+  const d = new Date(iso)
+  const p = n => String(n).padStart(2, '0')
+  return `${p(d.getDate())}.${p(d.getMonth() + 1)}.${d.getFullYear()}`
 }
 
 function todayStr() {


### PR DESCRIPTION
Small display polish for the string tracker.

- **Yellow zone** now starts at 80 % of the threshold (last 20 % of lifetime), up from 75 %.
- **"ago" removed** — just the number.
- **New three-part format** in the card row:

  `[days since last change]d | [days until next change / days overdue]d | [interval]d`

  The first two segments are coloured green / yellow / red to match the dot indicator. The interval segment stays grey. Guitars that have never been changed show `— | — | Nd`.

https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw

---
_Generated by [Claude Code](https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw)_