### PR TITLE
Add Spotify explorer (/spt)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "endermatx-frontend",
   "private": true,
-  "version": "1.7.0",
+  "version": "1.8.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,6 +8,7 @@ import Calendar from './pages/Calendar'
 import IdeaInbox from './pages/IdeaInbox'
 import StringTracker from './pages/StringTracker'
 import BpmCounter from './pages/BpmCounter'
+import SpotifyExplorer from './pages/SpotifyExplorer'
 
 function VersionFooter() {
   return (
@@ -36,6 +37,7 @@ export default function App() {
         <Route path="/idx" element={<IdeaInbox />} />
         <Route path="/str" element={<StringTracker />} />
         <Route path="/bpm" element={<BpmCounter />} />
+        <Route path="/spt" element={<SpotifyExplorer />} />
       </Routes>
       <VersionFooter />
     </BrowserRouter>

--- a/frontend/src/pages/Personal.jsx
+++ b/frontend/src/pages/Personal.jsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 const TOOLS = [
   { path: '/str', label: '01', name: 'str', desc: 'string tracker' },
   { path: '/bpm', label: '02', name: 'bpm', desc: 'bpm counter' },
+  { path: '/spt', label: '03', name: 'spt', desc: 'spotify explorer' },
 ]
 
 export default function Personal() {

--- a/frontend/src/pages/SpotifyExplorer.jsx
+++ b/frontend/src/pages/SpotifyExplorer.jsx
@@ -1,0 +1,228 @@
+import { useState, useEffect, useMemo } from 'react'
+import { Link } from 'react-router-dom'
+import * as spotify from '../spotify'
+
+function fmtDuration(ms) {
+  const s = Math.round(ms / 1000)
+  return `${Math.floor(s / 60)}:${String(s % 60).padStart(2, '0')}`
+}
+
+export default function SpotifyExplorer() {
+  const [clientId, setClientIdState] = useState(() => spotify.getClientId())
+  const [clientIdInput, setClientIdInput] = useState(() => spotify.getClientId())
+  const [connected, setConnected]   = useState(false)
+  const [playlists, setPlaylists]   = useState([])
+  const [selectedId, setSelectedId] = useState('')
+  const [tracks, setTracks]         = useState(null)   // enriched track array or null
+  const [status, setStatus]         = useState('')     // progress message
+  const [error, setError]           = useState('')
+
+  // On mount: handle OAuth callback or restore existing session
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    const code   = params.get('code')
+
+    async function init() {
+      if (code) {
+        // Clear the code from the URL immediately so refresh doesn't re-trigger it
+        window.history.replaceState({}, '', '/spt')
+        try {
+          await spotify.handleCallback(code)
+          setConnected(true)
+          setPlaylists(await spotify.getPlaylists())
+        } catch (e) {
+          setError(e.message)
+        }
+      } else if (spotify.isConnected()) {
+        setConnected(true)
+        try {
+          setPlaylists(await spotify.getPlaylists())
+        } catch (e) {
+          setError(e.message)
+        }
+      }
+    }
+
+    init()
+  }, [])
+
+  async function connect() {
+    const id = clientIdInput.trim()
+    if (!id) return
+    spotify.setClientId(id)
+    setClientIdState(id)
+    await spotify.authorize()  // redirects away
+  }
+
+  function disconnect() {
+    spotify.logout()
+    setConnected(false)
+    setPlaylists([])
+    setTracks(null)
+    setSelectedId('')
+    setError('')
+  }
+
+  async function loadTracks() {
+    if (!selectedId) return
+    setTracks(null)
+    setError('')
+    setStatus('starting…')
+    try {
+      const enriched = await spotify.loadPlaylistTracks(selectedId, (phase, n) => {
+        setStatus(phase === 'tracks'
+          ? `fetching tracks… ${n}`
+          : `fetching audio features… ${n}`)
+      })
+      setTracks(enriched)
+    } catch (e) {
+      setError(e.message)
+    } finally {
+      setStatus('')
+    }
+  }
+
+  // displayedTracks is separate from tracks so future filter controls
+  // can operate on this without re-fetching from Spotify
+  const displayedTracks = useMemo(() => tracks ?? [], [tracks])
+
+  const selectedPlaylist = playlists.find(p => p.id === selectedId)
+
+  return (
+    <div>
+      <div className="topbar">
+        <div className="topbar-left">
+          <Link to="/"><button className="topbar-back btn btn-sm">←</button></Link>
+          <span className="topbar-title">spt</span>
+        </div>
+      </div>
+      <div className="page">
+
+        {!connected ? (
+          <>
+            <div className="section-header">connect spotify</div>
+            <div className="card">
+              <p style={{ fontSize: 12, color: '#9ab0d0', margin: '0 0 12px' }}>
+                Create an app at{' '}
+                <a
+                  href="https://developer.spotify.com/dashboard"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  style={{ color: '#4a9eff' }}
+                >
+                  developer.spotify.com/dashboard
+                </a>
+                , add{' '}
+                <code style={{ fontSize: 11, background: '#111827', padding: '1px 4px', borderRadius: 3 }}>
+                  {window.location.origin}/spt
+                </code>{' '}
+                as a redirect URI, then paste your Client ID below.
+              </p>
+              <input
+                className="input"
+                placeholder="client id"
+                value={clientIdInput}
+                onChange={e => setClientIdInput(e.target.value)}
+                onKeyDown={e => { if (e.key === 'Enter') connect() }}
+              />
+              {error && <div style={{ fontSize: 12, color: '#f44336', marginTop: 8 }}>{error}</div>}
+              <div style={{ marginTop: 12 }}>
+                <button
+                  className="btn btn-sm btn-primary"
+                  onClick={connect}
+                  disabled={!clientIdInput.trim()}
+                >
+                  connect with spotify
+                </button>
+              </div>
+            </div>
+          </>
+        ) : (
+          <>
+            {/* Playlist picker */}
+            <div className="section-header">playlists</div>
+            {playlists.length === 0 ? (
+              <div style={{ fontSize: 13, color: '#555' }}>loading…</div>
+            ) : (
+              <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+                <select
+                  className="input"
+                  style={{ flex: 1 }}
+                  value={selectedId}
+                  onChange={e => { setSelectedId(e.target.value); setTracks(null); setError('') }}
+                >
+                  <option value="">— pick a playlist —</option>
+                  {playlists.map(p => (
+                    <option key={p.id} value={p.id}>
+                      {p.name} ({p.tracks.total})
+                    </option>
+                  ))}
+                </select>
+                <button
+                  className="btn btn-sm btn-primary"
+                  onClick={loadTracks}
+                  disabled={!selectedId || !!status}
+                >
+                  load
+                </button>
+              </div>
+            )}
+
+            {status && (
+              <div style={{ fontSize: 12, color: '#9ab0d0', marginTop: 10 }}>{status}</div>
+            )}
+            {error && (
+              <div style={{ fontSize: 12, color: '#f44336', marginTop: 10 }}>{error}</div>
+            )}
+
+            {/* Track list */}
+            {tracks && (
+              <div style={{ marginTop: 20 }}>
+                <div className="section-header">
+                  {selectedPlaylist?.name} — {displayedTracks.length} tracks
+                </div>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                  {displayedTracks.map(t => (
+                    <div
+                      key={t.id}
+                      className="card"
+                      style={{ padding: '8px 12px', display: 'flex', alignItems: 'center', gap: 10 }}
+                    >
+                      {/* BPM */}
+                      <div style={{ textAlign: 'right', flexShrink: 0, width: 36 }}>
+                        <span style={{ fontSize: 14, fontWeight: 600, color: '#eef2ff' }}>{t.bpm}</span>
+                        <div style={{ fontSize: 10, color: '#374d66' }}>bpm</div>
+                      </div>
+
+                      {/* Separator */}
+                      <div style={{ width: 1, height: 28, background: '#1a2840', flexShrink: 0 }} />
+
+                      {/* Track info */}
+                      <div style={{ flex: 1, minWidth: 0 }}>
+                        <div style={{ fontSize: 13, color: '#eef2ff', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                          {t.name}
+                        </div>
+                        <div style={{ fontSize: 11, color: '#9ab0d0', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                          {t.artists.map(a => a.name).join(', ')}
+                        </div>
+                      </div>
+
+                      {/* Duration */}
+                      <span style={{ fontSize: 11, color: '#374d66', flexShrink: 0 }}>
+                        {fmtDuration(t.duration_ms)}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            <div style={{ marginTop: 24, borderTop: '1px solid #1a2840', paddingTop: 16 }}>
+              <button className="btn btn-sm" onClick={disconnect}>disconnect spotify</button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/spotify.js
+++ b/frontend/src/spotify.js
@@ -1,0 +1,199 @@
+const BASE     = 'https://api.spotify.com/v1'
+const ACCOUNTS = 'https://accounts.spotify.com'
+const SCOPES   = 'playlist-read-private playlist-read-collaborative'
+
+// ── Persistent storage ────────────────────────────────────────
+export const getClientId = () => localStorage.getItem('spt_client_id') || ''
+export const setClientId = id => localStorage.setItem('spt_client_id', id)
+export const isConnected = () => !!localStorage.getItem('spt_access_token')
+
+function storeTokens({ access_token, refresh_token, expires_in }) {
+  localStorage.setItem('spt_access_token', access_token)
+  if (refresh_token) localStorage.setItem('spt_refresh_token', refresh_token)
+  localStorage.setItem('spt_expires_at', String(Date.now() + expires_in * 1000))
+}
+
+export function logout() {
+  ['spt_access_token', 'spt_refresh_token', 'spt_expires_at'].forEach(k =>
+    localStorage.removeItem(k)
+  )
+}
+
+// ── PKCE helpers ──────────────────────────────────────────────
+function generateVerifier() {
+  const arr = new Uint8Array(32)
+  crypto.getRandomValues(arr)
+  return btoa(String.fromCharCode(...arr))
+    .replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '')
+}
+
+async function sha256b64url(str) {
+  const data = new TextEncoder().encode(str)
+  const hash = await crypto.subtle.digest('SHA-256', data)
+  return btoa(String.fromCharCode(...new Uint8Array(hash)))
+    .replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '')
+}
+
+function redirectUri() {
+  return window.location.origin + '/spt'
+}
+
+// ── Auth ──────────────────────────────────────────────────────
+export async function authorize() {
+  const verifier  = generateVerifier()
+  const challenge = await sha256b64url(verifier)
+  sessionStorage.setItem('spt_verifier', verifier)
+
+  const params = new URLSearchParams({
+    client_id:             getClientId(),
+    response_type:         'code',
+    redirect_uri:          redirectUri(),
+    scope:                 SCOPES,
+    code_challenge_method: 'S256',
+    code_challenge:        challenge,
+  })
+  window.location.href = `${ACCOUNTS}/authorize?${params}`
+}
+
+export async function handleCallback(code) {
+  const verifier = sessionStorage.getItem('spt_verifier')
+  sessionStorage.removeItem('spt_verifier')
+
+  const res = await fetch(`${ACCOUNTS}/api/token`, {
+    method:  'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body:    new URLSearchParams({
+      client_id:     getClientId(),
+      grant_type:    'authorization_code',
+      code,
+      redirect_uri:  redirectUri(),
+      code_verifier: verifier,
+    }),
+  })
+  if (!res.ok) throw new Error(`Auth failed (${res.status}) — check your Client ID and redirect URI`)
+  storeTokens(await res.json())
+}
+
+async function getValidToken() {
+  const expiresAt = Number(localStorage.getItem('spt_expires_at') || 0)
+  if (Date.now() < expiresAt - 60_000) {
+    return localStorage.getItem('spt_access_token')
+  }
+
+  const refresh = localStorage.getItem('spt_refresh_token')
+  if (!refresh) { logout(); return null }
+
+  const res = await fetch(`${ACCOUNTS}/api/token`, {
+    method:  'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body:    new URLSearchParams({
+      client_id:     getClientId(),
+      grant_type:    'refresh_token',
+      refresh_token: refresh,
+    }),
+  })
+  if (!res.ok) { logout(); throw new Error('Session expired — please reconnect') }
+  const data = await res.json()
+  storeTokens(data)
+  return data.access_token
+}
+
+// ── Core fetch ────────────────────────────────────────────────
+async function apiGet(url) {
+  const token = await getValidToken()
+  if (!token) throw new Error('Not authenticated')
+
+  const fullUrl = url.startsWith('http') ? url : BASE + url
+  const res = await fetch(fullUrl, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+
+  if (res.status === 401) { logout(); throw new Error('Session expired — please reconnect') }
+  if (res.status === 403) throw new Error(
+    'Spotify denied access to audio features. Your app may need Extended Quota Mode for public use, ' +
+    'but in Development Mode you must add yourself as an authorised user in the Spotify dashboard.'
+  )
+  if (!res.ok) throw new Error(`Spotify error ${res.status}`)
+  return res.json()
+}
+
+// ── Public API ────────────────────────────────────────────────
+
+export async function getPlaylists() {
+  const items = []
+  let url = '/me/playlists?limit=50'
+  while (url) {
+    const data = await apiGet(url)
+    items.push(...data.items.filter(Boolean))
+    url = data.next   // full URL returned by Spotify — apiGet handles it
+  }
+  return items
+}
+
+export async function getPlaylistTracks(playlistId, onProgress) {
+  const tracks = []
+  let url = `/playlists/${encodeURIComponent(playlistId)}/tracks?limit=100`
+  while (url) {
+    const data = await apiGet(url)
+    const valid = data.items.map(i => i?.track).filter(t => t?.id && !t.is_local)
+    tracks.push(...valid)
+    onProgress?.('tracks', tracks.length)
+    url = data.next
+  }
+  return tracks
+}
+
+export async function getAudioFeatures(trackIds, onProgress) {
+  const features = []
+  for (let i = 0; i < trackIds.length; i += 100) {
+    const ids  = trackIds.slice(i, i + 100).join(',')
+    const data = await apiGet(`/audio-features?ids=${ids}`)
+    features.push(...(data.audio_features || []))
+    onProgress?.('features', features.length)
+  }
+  return features
+}
+
+// Fetch artist details (includes genres) — used for future genre-based filtering
+export async function getArtists(artistIds) {
+  const artists = []
+  for (let i = 0; i < artistIds.length; i += 50) {
+    const ids  = artistIds.slice(i, i + 50).join(',')
+    const data = await apiGet(`/artists?ids=${ids}`)
+    artists.push(...(data.artists || []))
+  }
+  return artists
+}
+
+// ── High-level helpers ────────────────────────────────────────
+
+// Returns a flat array of enriched track objects sorted by BPM.
+// Preserves all audio feature fields and artist IDs for future filtering.
+export async function loadPlaylistTracks(playlistId, onProgress) {
+  const tracks   = await getPlaylistTracks(playlistId, onProgress)
+  const ids      = tracks.map(t => t.id)
+  const features = await getAudioFeatures(ids, onProgress)
+
+  const featureMap = new Map(features.filter(Boolean).map(f => [f.id, f]))
+
+  return tracks
+    .filter(t => featureMap.has(t.id))
+    .map(t => {
+      const f = featureMap.get(t.id)
+      return {
+        id:           t.id,
+        name:         t.name,
+        artists:      t.artists,          // [{ id, name }] — IDs needed for genre lookup
+        album:        t.album?.name ?? '',
+        duration_ms:  t.duration_ms,
+        bpm:          Math.round(f.tempo),
+        energy:       f.energy,           // 0–1
+        danceability: f.danceability,     // 0–1
+        valence:      f.valence,          // 0–1 (musical positivity)
+        key:          f.key,
+        time_sig:     f.time_signature,
+        _features:    f,                  // full object preserved for future filter predicates
+      }
+    })
+    .sort((a, b) => a.bpm - b.bpm)
+}


### PR DESCRIPTION
Adds a new personal tool at `/spt` — Spotify playlist explorer.

## How it works

**Auth**: PKCE flow, entirely in the browser — no backend changes. The user enters their Spotify Client ID once; it's stored in `localStorage`. Tokens auto-refresh silently.

**Setup required** (one-time):
1. Create an app at `developer.spotify.com/dashboard`
2. Add your Railway domain + `/spt` as a redirect URI (e.g. `https://your-app.railway.app/spt`), and `http://localhost:5173/spt` for local dev
3. Add your Spotify account as an authorised user (Development Mode limit: 25 users)
4. Paste the Client ID into the connect screen

**Data flow**: `getPlaylists()` → pick one → `loadPlaylistTracks()` fetches all tracks (paginated, 100/req) then all audio features (batched 100/req) → merged into enriched track objects, sorted by BPM.

## Architecture for future features

`spotify.js` exposes the full data layer independently from the UI:
- `getArtists()` already implemented for future genre lookups
- Each track record includes `_features` (full Spotify audio feature object) plus `energy`, `danceability`, `valence`, `key`, `time_sig` for filter predicates
- `SpotifyExplorer.jsx` separates `tracks` (fetched dataset) from `displayedTracks` (`useMemo` over tracks) — future filter controls slot in there without re-fetching

Future "crawl all playlists and find punk songs between 100–120 BPM" becomes: `getPlaylists()` → for each playlist `getPlaylistTracks()` + `getAudioFeatures()` → `getArtists()` for genre → filter predicate on the flat array.

https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw

---
_Generated by [Claude Code](https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw)_