### PR TITLE
spt: limit playlist fetch to 1 (timing diagnosis)

### DIFF
--- a/frontend/src/pages/SpotifyExplorer.jsx
+++ b/frontend/src/pages/SpotifyExplorer.jsx
@@ -37,14 +37,14 @@ export default function SpotifyExplorer() {
         try {
           await spotify.handleCallback(code)
           setConnected(true)
-          setPlaylists(await spotify.getPlaylists())
+          setPlaylists(await spotify.getPlaylists(1))
         } catch (e) {
           setError(e.message)
         }
       } else if (spotify.isConnected()) {
         setConnected(true)
         try {
-          setPlaylists(await spotify.getPlaylists())
+          setPlaylists(await spotify.getPlaylists(1))
         } catch (e) {
           setError(e.message)
         }

--- a/frontend/src/spotify.js
+++ b/frontend/src/spotify.js
@@ -119,15 +119,15 @@ async function apiGet(url) {
 
 // ── Public API ────────────────────────────────────────────────
 
-export async function getPlaylists() {
+export async function getPlaylists(max = Infinity) {
   const items = []
-  let url = '/me/playlists?limit=50'
-  while (url) {
+  let url = `/me/playlists?limit=${Math.min(max, 50)}`
+  while (url && items.length < max) {
     const data = await apiGet(url)
     items.push(...data.items.filter(Boolean))
-    url = data.next   // full URL returned by Spotify — apiGet handles it
+    url = data.next
   }
-  return items
+  return items.slice(0, max)
 }
 
 export async function getPlaylistTracks(playlistId, onProgress) {


### PR DESCRIPTION
Diagnostic build — fetches only the first playlist (`limit=1` sent to Spotify) so the connected UI appears almost immediately after auth.

- If the page still goes blank → timing is not the issue, something else is causing it
- If the page now shows correctly → the blank was caused by the async wait during playlist loading, and we need to show the connected UI immediately with a loading state for playlists

The `getPlaylists(max?)` signature is kept for the full load once diagnosed.

https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw

---
_Generated by [Claude Code](https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw)_