### PR TITLE
spt: 3-tier BPM resolution — DB cache → GetSongBPM → audio

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -17,7 +17,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 
 from .database import engine, Base, SessionLocal
 from .models import TtsEntry
-from .routers import tts, cal, idx, strings
+from .routers import tts, cal, idx, strings, bpm
 
 logger = logging.getLogger(__name__)
 
@@ -105,6 +105,7 @@ app.include_router(tts.router, prefix="/api/tts", tags=["tts"])
 app.include_router(cal.router, prefix="/api/cal", tags=["cal"])
 app.include_router(idx.router, prefix="/api/idx", tags=["idx"])
 app.include_router(strings.router, prefix="/api/str", tags=["str"])
+app.include_router(bpm.router,     prefix="/api/bpm", tags=["bpm"])
 
 FRONTEND_DIST = Path(__file__).parent.parent / "frontend" / "dist"
 GAMES_DIR = Path(__file__).parent.parent / "games"

--- a/backend/models.py
+++ b/backend/models.py
@@ -67,3 +67,16 @@ class Guitar(Base):
     history = Column(JSONB, default=list)
 
 
+# ── spt ───────────────────────────────────────────────────────────────────────
+
+class TrackBpm(Base):
+    __tablename__ = "spt_track_bpm"
+    spotify_id = Column(String, primary_key=True)
+    title      = Column(String, nullable=False)
+    artist     = Column(String, nullable=False)
+    album      = Column(String, nullable=False, default="")
+    bpm        = Column(Integer, nullable=False)
+    source     = Column(String, nullable=False)   # 'getsongbpm' | 'audio'
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,4 @@ sqlalchemy==2.0.35
 psycopg2-binary==2.9.10
 pydantic==2.9.2
 apscheduler==3.11.2
+httpx==0.27.2

--- a/backend/routers/bpm.py
+++ b/backend/routers/bpm.py
@@ -1,0 +1,75 @@
+import os
+from datetime import datetime
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from .. import models, schemas
+from ..database import SessionLocal
+
+router = APIRouter()
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@router.post("/batch-lookup", response_model=list[schemas.TrackBpmOut])
+def batch_lookup(body: schemas.BatchLookupRequest, db: Session = Depends(get_db)):
+    if not body.spotify_ids:
+        return []
+    return db.query(models.TrackBpm).filter(
+        models.TrackBpm.spotify_id.in_(body.spotify_ids)
+    ).all()
+
+
+@router.get("/getsongbpm")
+def getsongbpm_lookup(title: str = Query(...), artist: str = Query(...)):
+    api_key = os.getenv("GETSONGBPM_API_KEY", "")
+    if not api_key:
+        raise HTTPException(503, "GetSongBPM not configured")
+
+    query = f"{title} {artist}"
+    try:
+        r = httpx.get(
+            "https://api.getsongbpm.com/search/",
+            params={"api_key": api_key, "type": "both", "lookup": query},
+            timeout=10,
+        )
+    except httpx.TimeoutException:
+        raise HTTPException(504, "GetSongBPM timeout")
+    except Exception:
+        return {"bpm": None}
+
+    if not r.is_success:
+        return {"bpm": None}
+
+    results = (r.json() or {}).get("search") or []
+    if not results:
+        return {"bpm": None}
+
+    tempo = results[0].get("tempo")
+    if not tempo:
+        return {"bpm": None}
+
+    try:
+        return {"bpm": round(float(tempo))}
+    except (ValueError, TypeError):
+        return {"bpm": None}
+
+
+@router.post("/store", response_model=schemas.TrackBpmOut)
+def store_bpm(body: schemas.TrackBpmIn, db: Session = Depends(get_db)):
+    existing = db.get(models.TrackBpm, body.spotify_id)
+    if existing:
+        return existing
+    entry = models.TrackBpm(**body.model_dump(), created_at=datetime.utcnow())
+    db.add(entry)
+    db.commit()
+    db.refresh(entry)
+    return entry

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -144,3 +144,21 @@ class GuitarOut(BaseModel):
     history: list[str]
     model_config = {"from_attributes": True}
 
+
+# ── spt ───────────────────────────────────────────────────────────────────────
+
+class TrackBpmIn(BaseModel):
+    spotify_id: str
+    title:      str
+    artist:     str
+    album:      str = ""
+    bpm:        int
+    source:     str
+
+class TrackBpmOut(TrackBpmIn):
+    created_at: UtcDt
+    model_config = {"from_attributes": True}
+
+class BatchLookupRequest(BaseModel):
+    spotify_ids: list[str]
+

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "endermatx-frontend",
   "private": true,
-  "version": "1.9.0",
+  "version": "1.10.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/bpm.js
+++ b/frontend/src/bpm.js
@@ -1,0 +1,145 @@
+// ── Tier 1: DB cache ──────────────────────────────────────────
+
+async function batchLookupDb(spotifyIds) {
+  try {
+    const res = await fetch('/api/bpm/batch-lookup', {
+      method:  'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body:    JSON.stringify({ spotify_ids: spotifyIds }),
+    })
+    if (!res.ok) return []
+    return await res.json()  // [{ spotify_id, bpm, ... }]
+  } catch {
+    return []
+  }
+}
+
+async function storeBpm(entry) {
+  try {
+    await fetch('/api/bpm/store', {
+      method:  'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body:    JSON.stringify(entry),
+    })
+  } catch { /* non-fatal */ }
+}
+
+// ── Tier 2: GetSongBPM via backend proxy ─────────────────────
+
+async function lookupGetSongBpm(title, artist) {
+  try {
+    const params = new URLSearchParams({ title, artist })
+    const res = await fetch(`/api/bpm/getsongbpm?${params}`)
+    if (!res.ok) return null
+    const data = await res.json()
+    return typeof data.bpm === 'number' ? data.bpm : null
+  } catch {
+    return null
+  }
+}
+
+// ── Tier 3: Audio analysis of Spotify 30-second preview ──────
+
+async function detectBpmFromAudio(previewUrl) {
+  let arrayBuffer
+  try {
+    const res = await fetch(previewUrl)
+    if (!res.ok) return null
+    arrayBuffer = await res.arrayBuffer()
+  } catch {
+    return null
+  }
+
+  let audioBuffer
+  try {
+    const ctx = new AudioContext()
+    audioBuffer = await ctx.decodeAudioData(arrayBuffer)
+    ctx.close()
+  } catch {
+    return null
+  }
+
+  const data    = audioBuffer.getChannelData(0)
+  const sr      = audioBuffer.sampleRate
+  const winSize = Math.floor(sr * 0.01)      // 10 ms windows → ~100 frames/sec
+  const nFrames = Math.floor(data.length / winSize)
+
+  // Energy per window
+  const energy = new Float32Array(nFrames)
+  for (let i = 0; i < nFrames; i++) {
+    let e = 0
+    const off = i * winSize
+    for (let j = 0; j < winSize; j++) e += data[off + j] ** 2
+    energy[i] = e / winSize
+  }
+
+  // Onset strength = positive first difference of energy
+  const onset = new Float32Array(nFrames)
+  for (let i = 1; i < nFrames; i++) {
+    const diff = energy[i] - energy[i - 1]
+    if (diff > 0) onset[i] = diff
+  }
+
+  // Autocorrelation over onset signal to find dominant beat period
+  const fps    = sr / winSize
+  const minLag = Math.max(1, Math.round(fps * 60 / 200))  // 200 BPM ceiling
+  const maxLag = Math.round(fps * 60 / 60)                // 60 BPM floor
+
+  let bestLag = minLag, bestCorr = 0
+  for (let lag = minLag; lag <= maxLag; lag++) {
+    let corr = 0
+    const n = nFrames - lag
+    for (let i = 0; i < n; i++) corr += onset[i] * onset[i + lag]
+    if (corr > bestCorr) { bestCorr = corr; bestLag = lag }
+  }
+
+  const bpm = Math.round(fps * 60 / bestLag)
+  return bpm >= 50 && bpm <= 220 ? bpm : null
+}
+
+// ── Main resolution entry point ───────────────────────────────
+
+const BATCH = 5
+
+/**
+ * Resolve BPMs for an array of track objects using three tiers:
+ *   1. DB cache  2. GetSongBPM API  3. Spotify preview audio analysis
+ *
+ * onUpdate(spotifyId, bpm) — called each time a BPM is resolved
+ * onProgress(done, total)  — called after each uncached track settles
+ */
+export async function resolveBpms(tracks, onUpdate, onProgress) {
+  // Tier 1: DB batch lookup
+  const cached = await batchLookupDb(tracks.map(t => t.id))
+  const cachedMap = new Map(cached.map(c => [c.spotify_id, c.bpm]))
+
+  for (const t of tracks) {
+    if (cachedMap.has(t.id)) onUpdate(t.id, cachedMap.get(t.id))
+  }
+
+  const uncached = tracks.filter(t => !cachedMap.has(t.id))
+  if (!uncached.length) return
+
+  // Tiers 2 + 3: process in parallel batches
+  let done = 0
+  for (let i = 0; i < uncached.length; i += BATCH) {
+    await Promise.all(uncached.slice(i, i + BATCH).map(async track => {
+      const artist = track.artists[0]?.name ?? ''
+
+      let bpm    = await lookupGetSongBpm(track.name, artist)
+      let source = bpm ? 'getsongbpm' : null
+
+      if (!bpm && track.preview_url) {
+        bpm    = await detectBpmFromAudio(track.preview_url)
+        source = bpm ? 'audio' : null
+      }
+
+      if (bpm) {
+        onUpdate(track.id, bpm)
+        storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm, source })
+      }
+
+      onProgress(++done, uncached.length)
+    }))
+  }
+}

--- a/frontend/src/pages/SpotifyExplorer.jsx
+++ b/frontend/src/pages/SpotifyExplorer.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo } from 'react'
 import { Link } from 'react-router-dom'
 import * as spotify from '../spotify'
+import { resolveBpms } from '../bpm'
 
 function fmtDuration(ms) {
   const s = Math.round(ms / 1000)
@@ -9,12 +10,12 @@ function fmtDuration(ms) {
 
 export default function SpotifyExplorer() {
   const [clientIdInput, setClientIdInput] = useState(() => spotify.getClientId())
-  // Initialise from localStorage so returning users see connected UI instantly
   const [connected, setConnected]   = useState(() => spotify.isConnected())
   const [playlists, setPlaylists]   = useState([])
   const [selectedId, setSelectedId] = useState('')
   const [tracks, setTracks]         = useState(null)
   const [status, setStatus]         = useState('')
+  const [bpmStatus, setBpmStatus]   = useState('')
   const [error, setError]           = useState('')
 
   // Handle OAuth callback — only token exchange, no API calls
@@ -48,6 +49,7 @@ export default function SpotifyExplorer() {
     setTracks(null)
     setSelectedId('')
     setError('')
+    setBpmStatus('')
   }
 
   async function loadPlaylists() {
@@ -66,14 +68,22 @@ export default function SpotifyExplorer() {
     if (!selectedId) return
     setTracks(null)
     setError('')
-    setStatus('starting…')
+    setBpmStatus('')
+    setStatus('loading tracks…')
     try {
-      const enriched = await spotify.loadPlaylistTracks(selectedId, (phase, n) => {
-        setStatus(phase === 'tracks'
-          ? `fetching tracks… ${n}`
-          : `fetching audio features… ${n}`)
+      const raw = await spotify.loadPlaylistTracks(selectedId, (_, n) => {
+        setStatus(`fetching tracks… ${n}`)
       })
-      setTracks(enriched)
+      setTracks(raw)
+      setStatus('')
+
+      // BPM resolution — updates tracks incrementally as each one resolves
+      setBpmStatus(`resolving BPMs… 0/${raw.length}`)
+      await resolveBpms(
+        raw,
+        (id, bpm) => setTracks(prev => prev?.map(t => t.id === id ? { ...t, bpm } : t) ?? prev),
+        (done, total) => setBpmStatus(done < total ? `resolving BPMs… ${done}/${total}` : ''),
+      )
     } catch (e) {
       setError(e.message)
     } finally {
@@ -81,11 +91,19 @@ export default function SpotifyExplorer() {
     }
   }
 
-  const displayedTracks  = useMemo(() => tracks ?? [], [tracks])
+  // Sort by BPM ascending; unresolved tracks sink to the bottom
+  const displayedTracks = useMemo(() => {
+    if (!tracks) return []
+    return [...tracks].sort((a, b) => {
+      if (a.bpm === null && b.bpm === null) return 0
+      if (a.bpm === null) return 1
+      if (b.bpm === null) return -1
+      return a.bpm - b.bpm
+    })
+  }, [tracks])
+
   const selectedPlaylist = playlists.find(p => p.id === selectedId)
 
-  // Spotify's simplified playlist object used to have `tracks.total`;
-  // newer API responses use `items.total` instead.
   function trackCount(p) {
     return (p.tracks ?? p.items)?.total ?? '?'
   }
@@ -157,7 +175,7 @@ export default function SpotifyExplorer() {
                   className="input"
                   style={{ flex: 1 }}
                   value={selectedId}
-                  onChange={e => { setSelectedId(e.target.value); setTracks(null); setError('') }}
+                  onChange={e => { setSelectedId(e.target.value); setTracks(null); setError(''); setBpmStatus('') }}
                 >
                   <option value="">— pick a playlist —</option>
                   {playlists.map(p => (
@@ -179,6 +197,9 @@ export default function SpotifyExplorer() {
             {status && (
               <div style={{ fontSize: 12, color: '#9ab0d0', marginTop: 10 }}>{status}</div>
             )}
+            {bpmStatus && (
+              <div style={{ fontSize: 12, color: '#9ab0d0', marginTop: 10 }}>{bpmStatus}</div>
+            )}
             {error && (
               <div style={{ fontSize: 12, color: '#f44336', marginTop: 10 }}>{error}</div>
             )}
@@ -196,7 +217,9 @@ export default function SpotifyExplorer() {
                       style={{ padding: '8px 12px', display: 'flex', alignItems: 'center', gap: 10 }}
                     >
                       <div style={{ textAlign: 'right', flexShrink: 0, width: 36 }}>
-                        <span style={{ fontSize: 14, fontWeight: 600, color: '#eef2ff' }}>{t.bpm}</span>
+                        <span style={{ fontSize: 14, fontWeight: 600, color: '#eef2ff' }}>
+                          {t.bpm ?? '—'}
+                        </span>
                         <div style={{ fontSize: 10, color: '#374d66' }}>bpm</div>
                       </div>
                       <div style={{ width: 1, height: 28, background: '#1a2840', flexShrink: 0 }} />
@@ -217,8 +240,16 @@ export default function SpotifyExplorer() {
               </div>
             )}
 
-            <div style={{ marginTop: 24, borderTop: '1px solid #1a2840', paddingTop: 16 }}>
+            <div style={{ marginTop: 24, borderTop: '1px solid #1a2840', paddingTop: 16, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
               <button className="btn btn-sm" onClick={disconnect}>disconnect spotify</button>
+              <a
+                href="https://getsongbpm.com"
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{ fontSize: 10, color: '#374d66', textDecoration: 'none' }}
+              >
+                BPM data: GetSongBPM
+              </a>
             </div>
           </>
         )}

--- a/frontend/src/spotify.js
+++ b/frontend/src/spotify.js
@@ -109,10 +109,7 @@ async function apiGet(url) {
   })
 
   if (res.status === 401) { logout(); throw new Error('Session expired — please reconnect') }
-  if (res.status === 403) throw new Error(
-    'Spotify denied access to audio features. Your app may need Extended Quota Mode for public use, ' +
-    'but in Development Mode you must add yourself as an authorised user in the Spotify dashboard.'
-  )
+  if (res.status === 403) throw new Error(`Spotify access denied (${res.status})`)
   if (!res.ok) throw new Error(`Spotify error ${res.status}`)
   return res.json()
 }
@@ -143,57 +140,18 @@ export async function getPlaylistTracks(playlistId, onProgress) {
   return tracks
 }
 
-export async function getAudioFeatures(trackIds, onProgress) {
-  const features = []
-  for (let i = 0; i < trackIds.length; i += 100) {
-    const ids  = trackIds.slice(i, i + 100).join(',')
-    const data = await apiGet(`/audio-features?ids=${ids}`)
-    features.push(...(data.audio_features || []))
-    onProgress?.('features', features.length)
-  }
-  return features
-}
-
-// Fetch artist details (includes genres) — used for future genre-based filtering
-export async function getArtists(artistIds) {
-  const artists = []
-  for (let i = 0; i < artistIds.length; i += 50) {
-    const ids  = artistIds.slice(i, i + 50).join(',')
-    const data = await apiGet(`/artists?ids=${ids}`)
-    artists.push(...(data.artists || []))
-  }
-  return artists
-}
-
 // ── High-level helpers ────────────────────────────────────────
 
-// Returns a flat array of enriched track objects sorted by BPM.
-// Preserves all audio feature fields and artist IDs for future filtering.
+// Returns track metadata only; BPM is resolved separately via bpm.js.
 export async function loadPlaylistTracks(playlistId, onProgress) {
-  const tracks   = await getPlaylistTracks(playlistId, onProgress)
-  const ids      = tracks.map(t => t.id)
-  const features = await getAudioFeatures(ids, onProgress)
-
-  const featureMap = new Map(features.filter(Boolean).map(f => [f.id, f]))
-
-  return tracks
-    .filter(t => featureMap.has(t.id))
-    .map(t => {
-      const f = featureMap.get(t.id)
-      return {
-        id:           t.id,
-        name:         t.name,
-        artists:      t.artists,          // [{ id, name }] — IDs needed for genre lookup
-        album:        t.album?.name ?? '',
-        duration_ms:  t.duration_ms,
-        bpm:          Math.round(f.tempo),
-        energy:       f.energy,           // 0–1
-        danceability: f.danceability,     // 0–1
-        valence:      f.valence,          // 0–1 (musical positivity)
-        key:          f.key,
-        time_sig:     f.time_signature,
-        _features:    f,                  // full object preserved for future filter predicates
-      }
-    })
-    .sort((a, b) => a.bpm - b.bpm)
+  const tracks = await getPlaylistTracks(playlistId, onProgress)
+  return tracks.map(t => ({
+    id:          t.id,
+    name:        t.name,
+    artists:     t.artists,
+    album:       t.album?.name ?? '',
+    duration_ms: t.duration_ms,
+    preview_url: t.preview_url ?? null,
+    bpm:         null,
+  }))
 }


### PR DESCRIPTION
## What this does

Replaces the deprecated Spotify `/audio-features` endpoint with a 3-tier BPM resolution pipeline:

1. **DB cache** — `spt_track_bpm` table in Postgres; any previously-resolved track returns instantly
2. **GetSongBPM** — backend proxies to `api.getsongbpm.com` (API key stays server-side as `GETSONGBPM_API_KEY` env var)
3. **Audio fallback** — fetches the Spotify 30-second preview clip and runs in-browser BPM detection via Web Audio API autocorrelation

## Before merging

Add `GETSONGBPM_API_KEY=<your key>` to Railway environment variables.

## Behaviour

- Playlist tracks appear immediately after Spotify fetch; BPM values fill in as each resolves (sorted ascending, unresolved tracks sink to bottom)
- A `resolving BPMs… 12/105` status line shows progress
- Each resolved BPM is stored in the DB so repeat loads are instant
- GetSongBPM attribution link shown in the footer per their terms

## New backend endpoints

| Method | Path | Purpose |
|--------|------|---------|
| POST | `/api/bpm/batch-lookup` | Return cached BPMs for a list of Spotify IDs |
| GET | `/api/bpm/getsongbpm?title=&artist=` | Proxy lookup to GetSongBPM |
| POST | `/api/bpm/store` | Persist a resolved BPM entry |

https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw

---
_Generated by [Claude Code](https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw)_