### PR TITLE
spt: fix 403 — switch to /items endpoint for playlist tracks

### DIFF
--- a/frontend/src/spotify.js
+++ b/frontend/src/spotify.js
@@ -129,7 +129,7 @@ export async function getPlaylists(max = Infinity) {
 
 export async function getPlaylistTracks(playlistId, onProgress) {
   const tracks = []
-  let url = `/playlists/${encodeURIComponent(playlistId)}/tracks?limit=100`
+  let url = `/playlists/${encodeURIComponent(playlistId)}/items?limit=100`
   while (url) {
     const data = await apiGet(url)
     const valid = data.items.map(i => i?.track).filter(t => t?.id && !t.is_local)


### PR DESCRIPTION
Spotify deprecated `/playlists/{id}/tracks` for new apps (same pattern as `/audio-features`) — it returns 403. The replacement is `/playlists/{id}/items`, which returns the same response structure. Our existing filter (`i?.track` + null check) already handles the difference: the `/items` endpoint can also return podcast episodes, but those have `track: null` and are quietly dropped.

One character change: `tracks` → `items` in the URL.

https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw

---
_Generated by [Claude Code](https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw)_