### PR TITLE
spt: diagnostic logging for 0-entries bug + version 1.10.1

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "endermatx-frontend",
   "private": true,
-  "version": "1.10.0",
+  "version": "1.10.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/pages/SpotifyExplorer.jsx
+++ b/frontend/src/pages/SpotifyExplorer.jsx
@@ -17,6 +17,7 @@ export default function SpotifyExplorer() {
   const [status, setStatus]         = useState('')
   const [bpmStatus, setBpmStatus]   = useState('')
   const [error, setError]           = useState('')
+  const [debugInfo, setDebugInfo]   = useState(null)
 
   // Handle OAuth callback — only token exchange, no API calls
   useEffect(() => {
@@ -73,7 +74,7 @@ export default function SpotifyExplorer() {
     try {
       const raw = await spotify.loadPlaylistTracks(selectedId, (_, n) => {
         setStatus(`fetching tracks… ${n}`)
-      })
+      }, info => setDebugInfo(info))
       setTracks(raw)
       setStatus('')
 
@@ -202,6 +203,12 @@ export default function SpotifyExplorer() {
             )}
             {error && (
               <div style={{ fontSize: 12, color: '#f44336', marginTop: 10 }}>{error}</div>
+            )}
+
+            {debugInfo && (
+              <pre style={{ fontSize: 10, color: '#9ab0d0', background: '#0d1221', padding: 8, borderRadius: 4, marginTop: 10, overflowX: 'auto', whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>
+                {JSON.stringify(debugInfo, null, 2)}
+              </pre>
             )}
 
             {tracks && (

--- a/frontend/src/spotify.js
+++ b/frontend/src/spotify.js
@@ -127,15 +127,14 @@ export async function getPlaylists(max = Infinity) {
   return items.slice(0, max)
 }
 
-export async function getPlaylistTracks(playlistId, onProgress) {
+export async function getPlaylistTracks(playlistId, onProgress, onDebug) {
   const tracks = []
   let url = `/playlists/${encodeURIComponent(playlistId)}/items?limit=100`
   let firstPage = true
   while (url) {
     const data = await apiGet(url)
     if (firstPage) {
-      console.log('[spt] items[0]:', JSON.stringify(data.items?.[0]))
-      console.log('[spt] total items in page:', data.items?.length, '/ total:', data.total)
+      onDebug?.({ total: data.total, pageSize: data.items?.length, item0: data.items?.[0] })
       firstPage = false
     }
     const valid = data.items.map(i => i?.track).filter(t => t?.id && !t.is_local)
@@ -149,8 +148,8 @@ export async function getPlaylistTracks(playlistId, onProgress) {
 // ── High-level helpers ────────────────────────────────────────
 
 // Returns track metadata only; BPM is resolved separately via bpm.js.
-export async function loadPlaylistTracks(playlistId, onProgress) {
-  const tracks = await getPlaylistTracks(playlistId, onProgress)
+export async function loadPlaylistTracks(playlistId, onProgress, onDebug) {
+  const tracks = await getPlaylistTracks(playlistId, onProgress, onDebug)
   return tracks.map(t => ({
     id:          t.id,
     name:        t.name,

--- a/frontend/src/spotify.js
+++ b/frontend/src/spotify.js
@@ -130,8 +130,14 @@ export async function getPlaylists(max = Infinity) {
 export async function getPlaylistTracks(playlistId, onProgress) {
   const tracks = []
   let url = `/playlists/${encodeURIComponent(playlistId)}/items?limit=100`
+  let firstPage = true
   while (url) {
     const data = await apiGet(url)
+    if (firstPage) {
+      console.log('[spt] items[0]:', JSON.stringify(data.items?.[0]))
+      console.log('[spt] total items in page:', data.items?.length, '/ total:', data.total)
+      firstPage = false
+    }
     const valid = data.items.map(i => i?.track).filter(t => t?.id && !t.is_local)
     tracks.push(...valid)
     onProgress?.('tracks', tracks.length)


### PR DESCRIPTION
Temporary diagnostic: logs the first item and page totals from the `/items` response to the browser console so we can see the actual response structure and identify why the filter returns 0 tracks.

Also fixes the missing version bump from the previous two PRs.

https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw

---
_Generated by [Claude Code](https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw)_