### PR TITLE
spt: fix 0 tracks — /items wraps under i.item not i.track

### DIFF
--- a/frontend/src/pages/SpotifyExplorer.jsx
+++ b/frontend/src/pages/SpotifyExplorer.jsx
@@ -52,17 +52,15 @@ export default function SpotifyExplorer() {
     setBpmStatus('')
   }
 
-  async function loadPlaylists() {
-    setError('')
+  // Auto-load playlists whenever the connected state becomes true
+  useEffect(() => {
+    if (!connected) return
     setStatus('loading playlists…')
-    try {
-      setPlaylists(await spotify.getPlaylists())
-    } catch (e) {
-      setError(e.message)
-    } finally {
-      setStatus('')
-    }
-  }
+    spotify.getPlaylists()
+      .then(setPlaylists)
+      .catch(e => setError(e.message))
+      .finally(() => setStatus(''))
+  }, [connected])
 
   async function loadTracks() {
     if (!selectedId) return
@@ -161,38 +159,29 @@ export default function SpotifyExplorer() {
           <>
             <div className="section-header">playlists</div>
 
-            {playlists.length === 0 ? (
+            <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+              <select
+                className="input"
+                style={{ flex: 1 }}
+                value={selectedId}
+                onChange={e => { setSelectedId(e.target.value); setTracks(null); setError(''); setBpmStatus('') }}
+                disabled={playlists.length === 0}
+              >
+                <option value="">— pick a playlist —</option>
+                {playlists.map(p => (
+                  <option key={p.id} value={p.id}>
+                    {p.name} ({trackCount(p)})
+                  </option>
+                ))}
+              </select>
               <button
                 className="btn btn-sm btn-primary"
-                onClick={loadPlaylists}
-                disabled={!!status}
+                onClick={loadTracks}
+                disabled={!selectedId || !!status}
               >
-                load playlists
+                load
               </button>
-            ) : (
-              <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-                <select
-                  className="input"
-                  style={{ flex: 1 }}
-                  value={selectedId}
-                  onChange={e => { setSelectedId(e.target.value); setTracks(null); setError(''); setBpmStatus('') }}
-                >
-                  <option value="">— pick a playlist —</option>
-                  {playlists.map(p => (
-                    <option key={p.id} value={p.id}>
-                      {p.name} ({trackCount(p)})
-                    </option>
-                  ))}
-                </select>
-                <button
-                  className="btn btn-sm btn-primary"
-                  onClick={loadTracks}
-                  disabled={!selectedId || !!status}
-                >
-                  load
-                </button>
-              </div>
-            )}
+            </div>
 
             {status && (
               <div style={{ fontSize: 12, color: '#9ab0d0', marginTop: 10 }}>{status}</div>

--- a/frontend/src/pages/SpotifyExplorer.jsx
+++ b/frontend/src/pages/SpotifyExplorer.jsx
@@ -17,7 +17,6 @@ export default function SpotifyExplorer() {
   const [status, setStatus]         = useState('')
   const [bpmStatus, setBpmStatus]   = useState('')
   const [error, setError]           = useState('')
-  const [debugInfo, setDebugInfo]   = useState(null)
 
   // Handle OAuth callback — only token exchange, no API calls
   useEffect(() => {
@@ -74,7 +73,7 @@ export default function SpotifyExplorer() {
     try {
       const raw = await spotify.loadPlaylistTracks(selectedId, (_, n) => {
         setStatus(`fetching tracks… ${n}`)
-      }, info => setDebugInfo(info))
+      })
       setTracks(raw)
       setStatus('')
 
@@ -203,12 +202,6 @@ export default function SpotifyExplorer() {
             )}
             {error && (
               <div style={{ fontSize: 12, color: '#f44336', marginTop: 10 }}>{error}</div>
-            )}
-
-            {debugInfo && (
-              <pre style={{ fontSize: 10, color: '#9ab0d0', background: '#0d1221', padding: 8, borderRadius: 4, marginTop: 10, overflowX: 'auto', whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>
-                {JSON.stringify(debugInfo, null, 2)}
-              </pre>
             )}
 
             {tracks && (

--- a/frontend/src/spotify.js
+++ b/frontend/src/spotify.js
@@ -127,17 +127,12 @@ export async function getPlaylists(max = Infinity) {
   return items.slice(0, max)
 }
 
-export async function getPlaylistTracks(playlistId, onProgress, onDebug) {
+export async function getPlaylistTracks(playlistId, onProgress) {
   const tracks = []
   let url = `/playlists/${encodeURIComponent(playlistId)}/items?limit=100`
-  let firstPage = true
   while (url) {
     const data = await apiGet(url)
-    if (firstPage) {
-      onDebug?.({ total: data.total, pageSize: data.items?.length, item0: data.items?.[0] })
-      firstPage = false
-    }
-    const valid = data.items.map(i => i?.track).filter(t => t?.id && !t.is_local)
+    const valid = data.items.map(i => i?.item).filter(t => t?.id && !t.is_local)
     tracks.push(...valid)
     onProgress?.('tracks', tracks.length)
     url = data.next
@@ -148,8 +143,8 @@ export async function getPlaylistTracks(playlistId, onProgress, onDebug) {
 // ── High-level helpers ────────────────────────────────────────
 
 // Returns track metadata only; BPM is resolved separately via bpm.js.
-export async function loadPlaylistTracks(playlistId, onProgress, onDebug) {
-  const tracks = await getPlaylistTracks(playlistId, onProgress, onDebug)
+export async function loadPlaylistTracks(playlistId, onProgress) {
+  const tracks = await getPlaylistTracks(playlistId, onProgress)
   return tracks.map(t => ({
     id:          t.id,
     name:        t.name,


### PR DESCRIPTION
The debug output confirmed the root cause: Spotify's new `/playlists/{id}/items` endpoint nests the track object under the key `item` (not `track` as the old `/tracks` endpoint did). The filter `data.items.map(i => i?.track)` was always producing `undefined`, hence 0 results.

Fix: `i?.track` → `i?.item`. Also removes all debug scaffolding.

https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw

---
_Generated by [Claude Code](https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw)_