### PR TITLE
spt: BPM resolution stats on page for diagnosis

### DIFF
--- a/frontend/src/bpm.js
+++ b/frontend/src/bpm.js
@@ -30,11 +30,11 @@ async function lookupGetSongBpm(title, artist) {
   try {
     const params = new URLSearchParams({ title, artist })
     const res = await fetch(`/api/bpm/getsongbpm?${params}`)
-    if (!res.ok) return null
     const data = await res.json()
-    return typeof data.bpm === 'number' ? data.bpm : null
-  } catch {
-    return null
+    if (!res.ok) return { bpm: null, err: data?.detail ?? `HTTP ${res.status}` }
+    return { bpm: typeof data.bpm === 'number' ? data.bpm : null, raw: data }
+  } catch (e) {
+    return { bpm: null, err: e.message }
   }
 }
 
@@ -108,7 +108,7 @@ const BATCH = 5
  * onUpdate(spotifyId, bpm) — called each time a BPM is resolved
  * onProgress(done, total)  — called after each uncached track settles
  */
-export async function resolveBpms(tracks, onUpdate, onProgress) {
+export async function resolveBpms(tracks, onUpdate, onProgress, onStats) {
   // Tier 1: DB batch lookup
   const cached = await batchLookupDb(tracks.map(t => t.id))
   const cachedMap = new Map(cached.map(c => [c.spotify_id, c.bpm]))
@@ -120,26 +120,40 @@ export async function resolveBpms(tracks, onUpdate, onProgress) {
   const uncached = tracks.filter(t => !cachedMap.has(t.id))
   if (!uncached.length) return
 
-  // Tiers 2 + 3: process in parallel batches
+  const stats = { db: cachedMap.size, getsongbpm: 0, audio: 0, failed: 0, noPreview: 0, getsongbpmErr: null }
   let done = 0
+
   for (let i = 0; i < uncached.length; i += BATCH) {
     await Promise.all(uncached.slice(i, i + BATCH).map(async track => {
       const artist = track.artists[0]?.name ?? ''
 
-      let bpm    = await lookupGetSongBpm(track.name, artist)
+      const gResult = await lookupGetSongBpm(track.name, artist)
+      if (!stats.getsongbpmErr && gResult.err) stats.getsongbpmErr = gResult.err
+      let bpm    = gResult.bpm
       let source = bpm ? 'getsongbpm' : null
+      if (bpm) stats.getsongbpm++
 
-      if (!bpm && track.preview_url) {
-        bpm    = await detectBpmFromAudio(track.preview_url)
-        source = bpm ? 'audio' : null
+      if (!bpm) {
+        if (!track.preview_url) {
+          stats.noPreview++
+        } else {
+          bpm    = await detectBpmFromAudio(track.preview_url)
+          source = bpm ? 'audio' : null
+          if (bpm) stats.audio++
+        }
       }
 
       if (bpm) {
         onUpdate(track.id, bpm)
         storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm, source })
+      } else {
+        stats.failed++
       }
 
       onProgress(++done, uncached.length)
+      if (done === 1) onStats?.({ ...stats })  // report after first track
     }))
   }
+
+  onStats?.({ ...stats })  // final report
 }

--- a/frontend/src/pages/SpotifyExplorer.jsx
+++ b/frontend/src/pages/SpotifyExplorer.jsx
@@ -16,6 +16,7 @@ export default function SpotifyExplorer() {
   const [tracks, setTracks]         = useState(null)
   const [status, setStatus]         = useState('')
   const [bpmStatus, setBpmStatus]   = useState('')
+  const [bpmStats, setBpmStats]     = useState(null)
   const [error, setError]           = useState('')
 
   // Handle OAuth callback — only token exchange, no API calls
@@ -50,6 +51,7 @@ export default function SpotifyExplorer() {
     setSelectedId('')
     setError('')
     setBpmStatus('')
+    setBpmStats(null)
   }
 
   // Auto-load playlists whenever the connected state becomes true
@@ -67,6 +69,7 @@ export default function SpotifyExplorer() {
     setTracks(null)
     setError('')
     setBpmStatus('')
+    setBpmStats(null)
     setStatus('loading tracks…')
     try {
       const raw = await spotify.loadPlaylistTracks(selectedId, (_, n) => {
@@ -81,6 +84,7 @@ export default function SpotifyExplorer() {
         raw,
         (id, bpm) => setTracks(prev => prev?.map(t => t.id === id ? { ...t, bpm } : t) ?? prev),
         (done, total) => setBpmStatus(done < total ? `resolving BPMs… ${done}/${total}` : ''),
+        stats => setBpmStats(stats),
       )
     } catch (e) {
       setError(e.message)
@@ -191,6 +195,12 @@ export default function SpotifyExplorer() {
             )}
             {error && (
               <div style={{ fontSize: 12, color: '#f44336', marginTop: 10 }}>{error}</div>
+            )}
+
+            {bpmStats && (
+              <pre style={{ fontSize: 10, color: '#9ab0d0', background: '#0d1221', padding: 8, borderRadius: 4, marginTop: 10, whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>
+                {JSON.stringify(bpmStats, null, 2)}
+              </pre>
             )}
 
             {tracks && (


### PR DESCRIPTION
After loading a playlist's BPMs, a JSON block appears on the page showing:
- `db` — hits from the Postgres cache
- `getsongbpm` — hits from GetSongBPM API
- `audio` — hits from Spotify preview audio analysis
- `failed` — tracks where all tiers returned nothing
- `noPreview` — tracks where `preview_url` was null (audio fallback skipped)
- `getsongbpmErr` — the first error message from GetSongBPM, if any

This tells us exactly which tier is failing and why.

https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw

---
_Generated by [Claude Code](https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw)_