### PR TITLE
spt: expose raw GetSongBPM response in debug output

### DIFF
--- a/backend/routers/bpm.py
+++ b/backend/routers/bpm.py
@@ -46,21 +46,27 @@ def getsongbpm_lookup(title: str = Query(...), artist: str = Query(...)):
     except Exception:
         return {"bpm": None}
 
-    if not r.is_success:
-        return {"bpm": None}
+    raw = None
+    try:
+        raw = r.json()
+    except Exception:
+        return {"bpm": None, "debug": f"HTTP {r.status_code}, non-JSON body"}
 
-    results = (r.json() or {}).get("search") or []
+    if not r.is_success:
+        return {"bpm": None, "debug": raw}
+
+    results = (raw or {}).get("search") or []
     if not results:
-        return {"bpm": None}
+        return {"bpm": None, "debug": raw}
 
     tempo = results[0].get("tempo")
     if not tempo:
-        return {"bpm": None}
+        return {"bpm": None, "debug": raw}
 
     try:
         return {"bpm": round(float(tempo))}
     except (ValueError, TypeError):
-        return {"bpm": None}
+        return {"bpm": None, "debug": raw}
 
 
 @router.post("/store", response_model=schemas.TrackBpmOut)

--- a/frontend/src/bpm.js
+++ b/frontend/src/bpm.js
@@ -120,7 +120,7 @@ export async function resolveBpms(tracks, onUpdate, onProgress, onStats) {
   const uncached = tracks.filter(t => !cachedMap.has(t.id))
   if (!uncached.length) return
 
-  const stats = { db: cachedMap.size, getsongbpm: 0, audio: 0, failed: 0, noPreview: 0, getsongbpmErr: null }
+  const stats = { db: cachedMap.size, getsongbpm: 0, audio: 0, failed: 0, noPreview: 0, getsongbpmErr: null, getsongbpmRaw: null }
   let done = 0
 
   for (let i = 0; i < uncached.length; i += BATCH) {
@@ -129,6 +129,7 @@ export async function resolveBpms(tracks, onUpdate, onProgress, onStats) {
 
       const gResult = await lookupGetSongBpm(track.name, artist)
       if (!stats.getsongbpmErr && gResult.err) stats.getsongbpmErr = gResult.err
+      if (!stats.getsongbpmRaw && !gResult.bpm && gResult.raw?.debug !== undefined) stats.getsongbpmRaw = gResult.raw.debug
       let bpm    = gResult.bpm
       let source = bpm ? 'getsongbpm' : null
       if (bpm) stats.getsongbpm++


### PR DESCRIPTION
When GetSongBPM returns no BPM, the backend now includes the raw API response in a `debug` field. The frontend captures this in the stats block as `getsongbpmRaw`, so we can see exactly what the API is returning and fix the response parsing accordingly.

https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw

---
_Generated by [Claude Code](https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw)_