### PR TITLE
spt: surface GetSongBPM HTTP errors in getsongbpmErr

### DIFF
--- a/backend/routers/bpm.py
+++ b/backend/routers/bpm.py
@@ -50,10 +50,10 @@ def getsongbpm_lookup(title: str = Query(...), artist: str = Query(...)):
     try:
         raw = r.json()
     except Exception:
-        return {"bpm": None, "debug": f"HTTP {r.status_code}, non-JSON body"}
+        return {"bpm": None, "err": f"GetSongBPM HTTP {r.status_code}, non-JSON body"}
 
     if not r.is_success:
-        return {"bpm": None, "debug": raw}
+        return {"bpm": None, "err": f"GetSongBPM HTTP {r.status_code}", "debug": raw}
 
     results = (raw or {}).get("search") or []
     if not results:

--- a/frontend/src/bpm.js
+++ b/frontend/src/bpm.js
@@ -32,6 +32,7 @@ async function lookupGetSongBpm(title, artist) {
     const res = await fetch(`/api/bpm/getsongbpm?${params}`)
     const data = await res.json()
     if (!res.ok) return { bpm: null, err: data?.detail ?? `HTTP ${res.status}` }
+    if (data.err) return { bpm: null, err: data.err, raw: data }
     return { bpm: typeof data.bpm === 'number' ? data.bpm : null, raw: data }
   } catch (e) {
     return { bpm: null, err: e.message }


### PR DESCRIPTION
The 403 from GetSongBPM was showing in `getsongbpmRaw` but not `getsongbpmErr`. Non-2xx responses now populate `getsongbpmErr` directly so it's visible at a glance.

---

**The actual fix needed is on your side:** GetSongBPM is returning 403, which means the API key is being rejected. Please check:
1. Railway → your service → Variables → `GETSONGBPM_API_KEY` — paste the value exactly, no quotes or spaces
2. Log in to getsongbpm.com and confirm the app shows as active

https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw

---
_Generated by [Claude Code](https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw)_