### PR TITLE
spt: fix GetSongBPM 403 — add Referer/Origin headers + test endpoint

### DIFF
--- a/backend/routers/bpm.py
+++ b/backend/routers/bpm.py
@@ -28,6 +28,20 @@ def batch_lookup(body: schemas.BatchLookupRequest, db: Session = Depends(get_db)
     ).all()
 
 
+def _getsongbpm_request(api_key: str, query: str):
+    app_url = os.getenv("GETSONGBPM_APP_URL", "https://matmaxx.org/spt")
+    return httpx.get(
+        "https://api.getsongbpm.com/search/",
+        params={"api_key": api_key, "type": "both", "lookup": query},
+        headers={
+            "Referer": app_url,
+            "Origin":  app_url,
+            "User-Agent": "Mozilla/5.0 (compatible; endermatx/1.0)",
+        },
+        timeout=10,
+    )
+
+
 @router.get("/getsongbpm")
 def getsongbpm_lookup(title: str = Query(...), artist: str = Query(...)):
     api_key = os.getenv("GETSONGBPM_API_KEY", "")
@@ -36,11 +50,7 @@ def getsongbpm_lookup(title: str = Query(...), artist: str = Query(...)):
 
     query = f"{title} {artist}"
     try:
-        r = httpx.get(
-            "https://api.getsongbpm.com/search/",
-            params={"api_key": api_key, "type": "both", "lookup": query},
-            timeout=10,
-        )
+        r = _getsongbpm_request(api_key, query)
     except httpx.TimeoutException:
         raise HTTPException(504, "GetSongBPM timeout")
     except Exception:
@@ -67,6 +77,35 @@ def getsongbpm_lookup(title: str = Query(...), artist: str = Query(...)):
         return {"bpm": round(float(tempo))}
     except (ValueError, TypeError):
         return {"bpm": None, "debug": raw}
+
+
+@router.get("/test")
+def getsongbpm_test():
+    """Debug endpoint — hit /api/bpm/test in browser to see raw GetSongBPM response."""
+    api_key = os.getenv("GETSONGBPM_API_KEY", "")
+    if not api_key:
+        return {"error": "GETSONGBPM_API_KEY not set"}
+
+    app_url = os.getenv("GETSONGBPM_APP_URL", "https://matmaxx.org/spt")
+    query = "Never Gonna Give You Up Rick Astley"
+    try:
+        r = _getsongbpm_request(api_key, query)
+    except Exception as e:
+        return {"error": str(e)}
+
+    body = None
+    try:
+        body = r.json()
+    except Exception:
+        body = r.text
+
+    return {
+        "url":            str(r.url),
+        "status":         r.status_code,
+        "response_headers": dict(r.headers),
+        "referer_sent":   app_url,
+        "body":           body,
+    }
 
 
 @router.post("/store", response_model=schemas.TrackBpmOut)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "endermatx-frontend",
   "private": true,
-  "version": "1.10.1",
+  "version": "1.11.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

- Add `Referer` and `Origin` headers to all GetSongBPM API requests (matching the registered app URL `https://matmaxx.org/spt`). Some APIs enforce that requests come from the registered domain — Railway's backend has no Referer by default, which is the most likely cause of the 403.
- Add `GETSONGBPM_APP_URL` env var support (defaults to `https://matmaxx.org/spt`) so the Referer can be overridden without a redeploy.
- Add `/api/bpm/test` debug endpoint that calls GetSongBPM with a fixed query ("Never Gonna Give You Up Rick Astley") and returns the full raw response — status, headers, and body — so you can see exactly what GetSongBPM is responding with.

## After deploying

Visit `https://matmaxx.org/api/bpm/test` in your browser. If BPMs still don't populate, paste the JSON response here and we'll see the exact error from GetSongBPM.

https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw

---
_Generated by [Claude Code](https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw)_