### PR TITLE
spt: fix BPM lookup — API domain moved to getsong.co

### DIFF
--- a/backend/routers/bpm.py
+++ b/backend/routers/bpm.py
@@ -31,7 +31,7 @@ def batch_lookup(body: schemas.BatchLookupRequest, db: Session = Depends(get_db)
 def _getsongbpm_request(api_key: str, query: str):
     app_url = os.getenv("GETSONGBPM_APP_URL", "https://matmaxx.org/spt")
     return httpx.get(
-        "https://api.getsongbpm.com/search/",
+        "https://api.getsong.co/search/",
         params={"api_key": api_key, "type": "both", "lookup": query},
         headers={
             "Referer": app_url,

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,7 +9,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
   </head>
   <body>
-    <a href="https://getsongbpm.com" style="display:none" rel="noopener noreferrer">BPM data by GetSongBPM</a>
+    <a href="https://getsong.co" style="display:none" rel="noopener noreferrer">BPM data by GetSong.co</a>
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "endermatx-frontend",
   "private": true,
-  "version": "1.11.0",
+  "version": "1.11.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/pages/SpotifyExplorer.jsx
+++ b/frontend/src/pages/SpotifyExplorer.jsx
@@ -242,12 +242,12 @@ export default function SpotifyExplorer() {
             <div style={{ marginTop: 24, borderTop: '1px solid #1a2840', paddingTop: 16, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
               <button className="btn btn-sm" onClick={disconnect}>disconnect spotify</button>
               <a
-                href="https://getsongbpm.com"
+                href="https://getsong.co"
                 target="_blank"
                 rel="noopener noreferrer"
                 style={{ fontSize: 10, color: '#374d66', textDecoration: 'none' }}
               >
-                BPM data: GetSongBPM
+                BPM data: GetSong.co
               </a>
             </div>
           </>


### PR DESCRIPTION
## Summary

- The `/test` endpoint revealed the real cause: `api.getsongbpm.com` returns a 301 redirect to `api.getsong.co`. Since `httpx` doesn't follow redirects by default, every request was silently stopping at the redirect and returning a non-2xx status.
- Updated the API URL from `https://api.getsongbpm.com/search/` → `https://api.getsong.co/search/`
- Updated the visible backlink and hidden crawler backlink to `getsong.co` to match

https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw

---
_Generated by [Claude Code](https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw)_