### PR TITLE
spt: fix getsong.co query type parameter

### DIFF
--- a/backend/routers/bpm.py
+++ b/backend/routers/bpm.py
@@ -32,7 +32,7 @@ def _getsongbpm_request(api_key: str, query: str):
     app_url = os.getenv("GETSONGBPM_APP_URL", "https://matmaxx.org/spt")
     return httpx.get(
         "https://api.getsong.co/search/",
-        params={"api_key": api_key, "type": "both", "lookup": query},
+        params={"api_key": api_key, "type": "song_name", "lookup": query},
         headers={
             "Referer": app_url,
             "Origin":  app_url,


### PR DESCRIPTION
## Summary

The `getsong.co` API no longer accepts `type=both`. Changed to `type=song_name` which searches by song title.

## After deploying

Check `/api/bpm/test` again. If it returns a `"bpm"` value, BPMs will populate. If still failing, the `"body"` field in the test response will show the exact shape of what the API returns so we can fix the response parsing too.

https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw

---
_Generated by [Claude Code](https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw)_