### PR TITLE
spt: fix BPM lookup — title-only search + artist matching

### DIFF
--- a/backend/routers/bpm.py
+++ b/backend/routers/bpm.py
@@ -28,11 +28,11 @@ def batch_lookup(body: schemas.BatchLookupRequest, db: Session = Depends(get_db)
     ).all()
 
 
-def _getsongbpm_request(api_key: str, query: str):
+def _getsong_search(api_key: str, title: str):
     app_url = os.getenv("GETSONGBPM_APP_URL", "https://matmaxx.org/spt")
     return httpx.get(
         "https://api.getsong.co/search/",
-        params={"api_key": api_key, "type": "song_name", "lookup": query},
+        params={"api_key": api_key, "type": "song", "lookup": title},
         headers={
             "Referer": app_url,
             "Origin":  app_url,
@@ -42,15 +42,29 @@ def _getsongbpm_request(api_key: str, query: str):
     )
 
 
+def _pick_best(results: list, artist: str) -> dict | None:
+    """Return the result whose artist name best matches, falling back to first with a tempo."""
+    artist_lower = artist.lower()
+    for r in results:
+        name = (r.get("artist") or {}).get("name", "").lower()
+        if artist_lower and (artist_lower in name or name in artist_lower):
+            if r.get("tempo"):
+                return r
+    # fallback: first result with a non-null tempo
+    for r in results:
+        if r.get("tempo"):
+            return r
+    return None
+
+
 @router.get("/getsongbpm")
 def getsongbpm_lookup(title: str = Query(...), artist: str = Query(...)):
     api_key = os.getenv("GETSONGBPM_API_KEY", "")
     if not api_key:
         raise HTTPException(503, "GetSongBPM not configured")
 
-    query = f"{title} {artist}"
     try:
-        r = _getsongbpm_request(api_key, query)
+        r = _getsong_search(api_key, title)
     except httpx.TimeoutException:
         raise HTTPException(504, "GetSongBPM timeout")
     except Exception:
@@ -66,59 +80,17 @@ def getsongbpm_lookup(title: str = Query(...), artist: str = Query(...)):
         return {"bpm": None, "err": f"GetSongBPM HTTP {r.status_code}", "debug": raw}
 
     results = (raw or {}).get("search") or []
-    if not results:
+    if not isinstance(results, list) or not results:
         return {"bpm": None, "debug": raw}
 
-    tempo = results[0].get("tempo")
-    if not tempo:
+    match = _pick_best(results, artist)
+    if not match:
         return {"bpm": None, "debug": raw}
 
     try:
-        return {"bpm": round(float(tempo))}
+        return {"bpm": round(float(match["tempo"]))}
     except (ValueError, TypeError):
         return {"bpm": None, "debug": raw}
-
-
-@router.get("/test")
-def getsongbpm_test():
-    """Probe multiple type values to find which one getsong.co accepts."""
-    api_key = os.getenv("GETSONGBPM_API_KEY", "")
-    if not api_key:
-        return {"error": "GETSONGBPM_API_KEY not set"}
-
-    app_url = os.getenv("GETSONGBPM_APP_URL", "https://matmaxx.org/spt")
-    headers = {
-        "Referer":    app_url,
-        "Origin":     app_url,
-        "User-Agent": "Mozilla/5.0 (compatible; endermatx/1.0)",
-    }
-
-    probes = [
-        {"type": "song",       "lookup": "Never Gonna Give You Up Rick Astley"},
-        {"type": "song",       "lookup": "Never Gonna Give You Up"},
-        {"type": "both",       "lookup": "Never Gonna Give You Up Rick Astley"},
-        {"type": "artist",     "lookup": "Rick Astley"},
-        {"type": "song_name",  "lookup": "Never Gonna Give You Up"},
-    ]
-
-    results = []
-    for p in probes:
-        try:
-            r = httpx.get(
-                "https://api.getsong.co/search/",
-                params={"api_key": api_key, **p},
-                headers=headers,
-                timeout=10,
-            )
-            try:
-                body = r.json()
-            except Exception:
-                body = r.text
-            results.append({"params": p, "status": r.status_code, "body": body})
-        except Exception as e:
-            results.append({"params": p, "error": str(e)})
-
-    return results
 
 
 @router.post("/store", response_model=schemas.TrackBpmOut)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "endermatx-frontend",
   "private": true,
-  "version": "1.11.1",
+  "version": "1.12.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/bpm.js
+++ b/frontend/src/bpm.js
@@ -102,14 +102,7 @@ async function detectBpmFromAudio(previewUrl) {
 
 const BATCH = 5
 
-/**
- * Resolve BPMs for an array of track objects using three tiers:
- *   1. DB cache  2. GetSongBPM API  3. Spotify preview audio analysis
- *
- * onUpdate(spotifyId, bpm) — called each time a BPM is resolved
- * onProgress(done, total)  — called after each uncached track settles
- */
-export async function resolveBpms(tracks, onUpdate, onProgress, onStats) {
+export async function resolveBpms(tracks, onUpdate, onProgress) {
   // Tier 1: DB batch lookup
   const cached = await batchLookupDb(tracks.map(t => t.id))
   const cachedMap = new Map(cached.map(c => [c.spotify_id, c.bpm]))
@@ -121,7 +114,6 @@ export async function resolveBpms(tracks, onUpdate, onProgress, onStats) {
   const uncached = tracks.filter(t => !cachedMap.has(t.id))
   if (!uncached.length) return
 
-  const stats = { db: cachedMap.size, getsongbpm: 0, audio: 0, failed: 0, noPreview: 0, getsongbpmErr: null, getsongbpmRaw: null }
   let done = 0
 
   for (let i = 0; i < uncached.length; i += BATCH) {
@@ -129,33 +121,20 @@ export async function resolveBpms(tracks, onUpdate, onProgress, onStats) {
       const artist = track.artists[0]?.name ?? ''
 
       const gResult = await lookupGetSongBpm(track.name, artist)
-      if (!stats.getsongbpmErr && gResult.err) stats.getsongbpmErr = gResult.err
-      if (!stats.getsongbpmRaw && !gResult.bpm && gResult.raw?.debug !== undefined) stats.getsongbpmRaw = gResult.raw.debug
       let bpm    = gResult.bpm
       let source = bpm ? 'getsongbpm' : null
-      if (bpm) stats.getsongbpm++
 
-      if (!bpm) {
-        if (!track.preview_url) {
-          stats.noPreview++
-        } else {
-          bpm    = await detectBpmFromAudio(track.preview_url)
-          source = bpm ? 'audio' : null
-          if (bpm) stats.audio++
-        }
+      if (!bpm && track.preview_url) {
+        bpm    = await detectBpmFromAudio(track.preview_url)
+        source = bpm ? 'audio' : null
       }
 
       if (bpm) {
         onUpdate(track.id, bpm)
         storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm, source })
-      } else {
-        stats.failed++
       }
 
       onProgress(++done, uncached.length)
-      if (done === 1) onStats?.({ ...stats })  // report after first track
     }))
   }
-
-  onStats?.({ ...stats })  // final report
 }

--- a/frontend/src/pages/SpotifyExplorer.jsx
+++ b/frontend/src/pages/SpotifyExplorer.jsx
@@ -16,7 +16,6 @@ export default function SpotifyExplorer() {
   const [tracks, setTracks]         = useState(null)
   const [status, setStatus]         = useState('')
   const [bpmStatus, setBpmStatus]   = useState('')
-  const [bpmStats, setBpmStats]     = useState(null)
   const [error, setError]           = useState('')
 
   // Handle OAuth callback — only token exchange, no API calls
@@ -51,7 +50,6 @@ export default function SpotifyExplorer() {
     setSelectedId('')
     setError('')
     setBpmStatus('')
-    setBpmStats(null)
   }
 
   // Auto-load playlists whenever the connected state becomes true
@@ -69,7 +67,6 @@ export default function SpotifyExplorer() {
     setTracks(null)
     setError('')
     setBpmStatus('')
-    setBpmStats(null)
     setStatus('loading tracks…')
     try {
       const raw = await spotify.loadPlaylistTracks(selectedId, (_, n) => {
@@ -84,7 +81,6 @@ export default function SpotifyExplorer() {
         raw,
         (id, bpm) => setTracks(prev => prev?.map(t => t.id === id ? { ...t, bpm } : t) ?? prev),
         (done, total) => setBpmStatus(done < total ? `resolving BPMs… ${done}/${total}` : ''),
-        stats => setBpmStats(stats),
       )
     } catch (e) {
       setError(e.message)
@@ -195,12 +191,6 @@ export default function SpotifyExplorer() {
             )}
             {error && (
               <div style={{ fontSize: 12, color: '#f44336', marginTop: 10 }}>{error}</div>
-            )}
-
-            {bpmStats && (
-              <pre style={{ fontSize: 10, color: '#9ab0d0', background: '#0d1221', padding: 8, borderRadius: 4, marginTop: 10, whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>
-                {JSON.stringify(bpmStats, null, 2)}
-              </pre>
             )}
 
             {tracks && (


### PR DESCRIPTION
## Summary

The probe confirmed: `type=song` with just the song title works (returns a list of results). Including the artist in the `lookup` string causes "no result". Fixed:

- **Backend**: search by title only, then `_pick_best()` scans the results for an artist name match (case-insensitive substring), falling back to the first result with a non-null tempo
- **Frontend**: removed debug stats block, `bpmStats` state, and `onStats` callback — no longer needed
- Also removed the `/api/bpm/test` probe endpoint (no longer needed)

https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw

---
_Generated by [Claude Code](https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw)_