### PR TITLE
spt: throttle BPM requests to fix last 2-3 tracks missing

### DIFF
--- a/frontend/src/bpm.js
+++ b/frontend/src/bpm.js
@@ -100,7 +100,8 @@ async function detectBpmFromAudio(previewUrl) {
 
 // ── Main resolution entry point ───────────────────────────────
 
-const BATCH = 5
+const BATCH        = 3
+const BATCH_DELAY  = 300  // ms between batches to avoid rate limiting
 
 export async function resolveBpms(tracks, onUpdate, onProgress) {
   // Tier 1: DB batch lookup
@@ -117,6 +118,7 @@ export async function resolveBpms(tracks, onUpdate, onProgress) {
   let done = 0
 
   for (let i = 0; i < uncached.length; i += BATCH) {
+    if (i > 0) await new Promise(r => setTimeout(r, BATCH_DELAY))
     await Promise.all(uncached.slice(i, i + BATCH).map(async track => {
       const artist = track.artists[0]?.name ?? ''
 


### PR DESCRIPTION
## Summary

The "last 2-3 songs always show `—`" pattern is rate limiting: getsong.co throttles rapid bursts of requests and the final batch gets cut off.

- Reduced batch size: 5 → 3 concurrent requests
- Added 300 ms pause between batches

https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw

---
_Generated by [Claude Code](https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw)_