### PR TITLE
spt: DB-cached BPMs show original source color + magenta dot

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "endermatx-frontend",
   "private": true,
-  "version": "1.14.0",
+  "version": "1.15.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/bpm.js
+++ b/frontend/src/bpm.js
@@ -108,10 +108,13 @@ const BATCH_DELAY  = 600  // ms between batches to avoid rate limiting
 export async function resolveBpms(tracks, onUpdate, onProgress) {
   // Tier 1: DB batch lookup
   const cached = await batchLookupDb(tracks.map(t => t.id))
-  const cachedMap = new Map(cached.map(c => [c.spotify_id, c.bpm]))
+  const cachedMap = new Map(cached.map(c => [c.spotify_id, { bpm: c.bpm, source: c.source }]))
 
   for (const t of tracks) {
-    if (cachedMap.has(t.id)) onUpdate(t.id, cachedMap.get(t.id), 'cached')
+    if (cachedMap.has(t.id)) {
+      const { bpm, source } = cachedMap.get(t.id)
+      onUpdate(t.id, bpm, source, true)
+    }
   }
 
   const uncached = tracks.filter(t => !cachedMap.has(t.id))
@@ -134,10 +137,10 @@ export async function resolveBpms(tracks, onUpdate, onProgress) {
       }
 
       if (bpm) {
-        onUpdate(track.id, bpm, source)
+        onUpdate(track.id, bpm, source, false)
         storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm, source })
       } else {
-        onUpdate(track.id, null, 'failed')
+        onUpdate(track.id, null, 'failed', false)
       }
 
       onProgress(++done, uncached.length)

--- a/frontend/src/pages/SpotifyExplorer.jsx
+++ b/frontend/src/pages/SpotifyExplorer.jsx
@@ -79,7 +79,7 @@ export default function SpotifyExplorer() {
       setBpmStatus(`resolving BPMs… 0/${raw.length}`)
       await resolveBpms(
         raw,
-        (id, bpm, src) => setTracks(prev => prev?.map(t => t.id === id ? { ...t, bpm, bpmSource: src } : t) ?? prev),
+        (id, bpm, src, cached) => setTracks(prev => prev?.map(t => t.id === id ? { ...t, bpm, bpmSource: src, bpmCached: cached } : t) ?? prev),
         (done, total) => setBpmStatus(done < total ? `resolving BPMs… ${done}/${total}` : ''),
       )
     } catch (e) {
@@ -202,16 +202,20 @@ export default function SpotifyExplorer() {
                       className="card"
                       style={{ padding: '8px 12px', display: 'flex', alignItems: 'center', gap: 10 }}
                     >
-                      <div style={{ textAlign: 'right', flexShrink: 0, width: 36 }}>
-                        <span style={{ fontSize: 14, fontWeight: 600, color:
-                          t.bpmSource === 'getsongbpm' ? '#4ade80'
-                          : t.bpmSource === 'cached'  ? '#e879f9'
-                          : t.bpmSource === 'audio'   ? '#22d3ee'
-                          : t.bpmSource === 'failed'  ? '#f44336'
-                          : '#eef2ff'
-                        }}>
-                          {t.bpm ?? '—'}
-                        </span>
+                      <div style={{ textAlign: 'right', flexShrink: 0, width: 40 }}>
+                        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end', gap: 3 }}>
+                          {t.bpmCached && (
+                            <div style={{ width: 5, height: 5, borderRadius: '50%', background: '#e879f9', flexShrink: 0 }} />
+                          )}
+                          <span style={{ fontSize: 14, fontWeight: 600, color:
+                            t.bpmSource === 'getsongbpm' ? '#4ade80'
+                            : t.bpmSource === 'audio'   ? '#22d3ee'
+                            : t.bpmSource === 'failed'  ? '#f44336'
+                            : '#eef2ff'
+                          }}>
+                            {t.bpm ?? '—'}
+                          </span>
+                        </div>
                         <div style={{ fontSize: 10, color: '#374d66' }}>bpm</div>
                       </div>
                       <div style={{ width: 1, height: 28, background: '#1a2840', flexShrink: 0 }} />
@@ -231,7 +235,6 @@ export default function SpotifyExplorer() {
                 </div>
                 <div style={{ display: 'flex', gap: 16, marginTop: 12, flexWrap: 'wrap' }}>
                   {[
-                    { color: '#e879f9', label: 'db cache' },
                     { color: '#4ade80', label: 'getsong.co' },
                     { color: '#22d3ee', label: 'audio' },
                     { color: '#f44336', label: 'not found' },
@@ -242,6 +245,10 @@ export default function SpotifyExplorer() {
                       <span style={{ fontSize: 10, color: '#374d66' }}>{label}</span>
                     </div>
                   ))}
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
+                    <div style={{ width: 5, height: 5, borderRadius: '50%', background: '#e879f9', flexShrink: 0 }} />
+                    <span style={{ fontSize: 10, color: '#374d66' }}>db cache</span>
+                  </div>
                 </div>
               </div>
             )}

--- a/frontend/src/spotify.js
+++ b/frontend/src/spotify.js
@@ -154,5 +154,6 @@ export async function loadPlaylistTracks(playlistId, onProgress) {
     preview_url: t.preview_url ?? null,
     bpm:         null,
     bpmSource:   null,
+    bpmCached:   false,
   }))
 }


### PR DESCRIPTION
## Summary

- DB batch-lookup response already includes `source` — now forwarded through `onUpdate(id, bpm, source, cached)`
- BPM color reflects the original resolution source (green = getsong.co, cyan = audio)
- A small magenta dot appears before the BPM number when it came from the DB cache
- Legend updated: the "db cache" entry shows the smaller dot instead of a full-size circle, matching how it looks inline

https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw

---
_Generated by [Claude Code](https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw)_