### PR TITLE
spt: remove dead audio fallback

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "endermatx-frontend",
   "private": true,
-  "version": "1.15.0",
+  "version": "1.16.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/bpm.js
+++ b/frontend/src/bpm.js
@@ -8,7 +8,7 @@ async function batchLookupDb(spotifyIds) {
       body:    JSON.stringify({ spotify_ids: spotifyIds }),
     })
     if (!res.ok) return []
-    return await res.json()  // [{ spotify_id, bpm, ... }]
+    return await res.json()  // [{ spotify_id, bpm, source, ... }]
   } catch {
     return []
   }
@@ -41,65 +41,6 @@ async function lookupGetSongBpm(title, artist) {
   }
 }
 
-// ── Tier 3: Audio analysis of Spotify 30-second preview ──────
-
-async function detectBpmFromAudio(previewUrl) {
-  let arrayBuffer
-  try {
-    const res = await fetch(previewUrl)
-    if (!res.ok) return null
-    arrayBuffer = await res.arrayBuffer()
-  } catch {
-    return null
-  }
-
-  let audioBuffer
-  try {
-    const ctx = new AudioContext()
-    audioBuffer = await ctx.decodeAudioData(arrayBuffer)
-    ctx.close()
-  } catch {
-    return null
-  }
-
-  const data    = audioBuffer.getChannelData(0)
-  const sr      = audioBuffer.sampleRate
-  const winSize = Math.floor(sr * 0.01)      // 10 ms windows → ~100 frames/sec
-  const nFrames = Math.floor(data.length / winSize)
-
-  // Energy per window
-  const energy = new Float32Array(nFrames)
-  for (let i = 0; i < nFrames; i++) {
-    let e = 0
-    const off = i * winSize
-    for (let j = 0; j < winSize; j++) e += data[off + j] ** 2
-    energy[i] = e / winSize
-  }
-
-  // Onset strength = positive first difference of energy
-  const onset = new Float32Array(nFrames)
-  for (let i = 1; i < nFrames; i++) {
-    const diff = energy[i] - energy[i - 1]
-    if (diff > 0) onset[i] = diff
-  }
-
-  // Autocorrelation over onset signal to find dominant beat period
-  const fps    = sr / winSize
-  const minLag = Math.max(1, Math.round(fps * 60 / 200))  // 200 BPM ceiling
-  const maxLag = Math.round(fps * 60 / 60)                // 60 BPM floor
-
-  let bestLag = minLag, bestCorr = 0
-  for (let lag = minLag; lag <= maxLag; lag++) {
-    let corr = 0
-    const n = nFrames - lag
-    for (let i = 0; i < n; i++) corr += onset[i] * onset[i + lag]
-    if (corr > bestCorr) { bestCorr = corr; bestLag = lag }
-  }
-
-  const bpm = Math.round(fps * 60 / bestLag)
-  return bpm >= 50 && bpm <= 220 ? bpm : null
-}
-
 // ── Main resolution entry point ───────────────────────────────
 
 const BATCH        = 2
@@ -128,17 +69,11 @@ export async function resolveBpms(tracks, onUpdate, onProgress) {
       const artist = track.artists[0]?.name ?? ''
 
       const gResult = await lookupGetSongBpm(track.name, artist)
-      let bpm    = gResult.bpm
-      let source = bpm ? 'getsongbpm' : null
-
-      if (!bpm && track.preview_url) {
-        bpm    = await detectBpmFromAudio(track.preview_url)
-        source = bpm ? 'audio' : null
-      }
+      const bpm    = gResult.bpm
 
       if (bpm) {
-        onUpdate(track.id, bpm, source, false)
-        storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm, source })
+        onUpdate(track.id, bpm, 'getsongbpm', false)
+        storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm, source: 'getsongbpm' })
       } else {
         onUpdate(track.id, null, 'failed', false)
       }

--- a/frontend/src/pages/SpotifyExplorer.jsx
+++ b/frontend/src/pages/SpotifyExplorer.jsx
@@ -209,7 +209,6 @@ export default function SpotifyExplorer() {
                           )}
                           <span style={{ fontSize: 14, fontWeight: 600, color:
                             t.bpmSource === 'getsongbpm' ? '#4ade80'
-                            : t.bpmSource === 'audio'   ? '#22d3ee'
                             : t.bpmSource === 'failed'  ? '#f44336'
                             : '#eef2ff'
                           }}>
@@ -236,7 +235,6 @@ export default function SpotifyExplorer() {
                 <div style={{ display: 'flex', gap: 16, marginTop: 12, flexWrap: 'wrap' }}>
                   {[
                     { color: '#4ade80', label: 'getsong.co' },
-                    { color: '#22d3ee', label: 'audio' },
                     { color: '#f44336', label: 'not found' },
                     { color: '#eef2ff', label: 'pending' },
                   ].map(({ color, label }) => (

--- a/frontend/src/spotify.js
+++ b/frontend/src/spotify.js
@@ -151,7 +151,6 @@ export async function loadPlaylistTracks(playlistId, onProgress) {
     artists:     t.artists,
     album:       t.album?.name ?? '',
     duration_ms: t.duration_ms,
-    preview_url: t.preview_url ?? null,
     bpm:         null,
     bpmSource:   null,
     bpmCached:   false,


### PR DESCRIPTION
## Summary

Removed the audio analysis fallback entirely — Spotify stopped providing `preview_url` for apps created after November 2024, so the code could never execute.

- Deleted `detectBpmFromAudio` (~60 lines of Web Audio API autocorrelation code)
- Removed `preview_url` from the track shape
- Removed the audio fallback branch from `resolveBpms`
- Removed cyan "audio" entry from the color legend

https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw

---
_Generated by [Claude Code](https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw)_