### PR TITLE
spt: add MusicBrainz tier-3 BPM fallback

### DIFF
--- a/backend/routers/bpm.py
+++ b/backend/routers/bpm.py
@@ -93,6 +93,40 @@ def getsongbpm_lookup(title: str = Query(...), artist: str = Query(...)):
         return {"bpm": None, "debug": raw}
 
 
+@router.get("/musicbrainz")
+def musicbrainz_lookup(title: str = Query(...), artist: str = Query(...)):
+    query = f'recording:"{title}" AND artistname:"{artist}"'
+    try:
+        r = httpx.get(
+            "https://musicbrainz.org/ws/2/recording/",
+            params={"query": query, "limit": 5, "fmt": "json"},
+            headers={"User-Agent": "endermatx/1.0 (https://matmaxx.org)"},
+            timeout=10,
+        )
+    except httpx.TimeoutException:
+        raise HTTPException(504, "MusicBrainz timeout")
+    except Exception:
+        return {"bpm": None}
+
+    if not r.is_success:
+        return {"bpm": None, "err": f"MusicBrainz HTTP {r.status_code}"}
+
+    try:
+        data = r.json()
+    except Exception:
+        return {"bpm": None}
+
+    for rec in (data or {}).get("recordings") or []:
+        bpm = rec.get("bpm")
+        if bpm:
+            try:
+                return {"bpm": round(float(bpm))}
+            except (ValueError, TypeError):
+                continue
+
+    return {"bpm": None}
+
+
 @router.post("/store", response_model=schemas.TrackBpmOut)
 def store_bpm(body: schemas.TrackBpmIn, db: Session = Depends(get_db)):
     existing = db.get(models.TrackBpm, body.spotify_id)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "endermatx-frontend",
   "private": true,
-  "version": "1.16.0",
+  "version": "1.17.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/bpm.js
+++ b/frontend/src/bpm.js
@@ -41,10 +41,27 @@ async function lookupGetSongBpm(title, artist) {
   }
 }
 
+// ── Tier 3: MusicBrainz fallback ─────────────────────────────
+
+async function lookupMusicBrainz(title, artist) {
+  try {
+    const params = new URLSearchParams({ title, artist })
+    const res = await fetch(`/api/bpm/musicbrainz?${params}`, {
+      signal: AbortSignal.timeout(12000),
+    })
+    const data = await res.json()
+    if (!res.ok) return { bpm: null }
+    return { bpm: typeof data.bpm === 'number' ? data.bpm : null }
+  } catch {
+    return { bpm: null }
+  }
+}
+
 // ── Main resolution entry point ───────────────────────────────
 
 const BATCH        = 2
-const BATCH_DELAY  = 600  // ms between batches to avoid rate limiting
+const BATCH_DELAY  = 600   // ms between getsong.co batches
+const MB_DELAY     = 1100  // ms between MusicBrainz requests (1 req/sec limit)
 
 export async function resolveBpms(tracks, onUpdate, onProgress) {
   // Tier 1: DB batch lookup
@@ -61,24 +78,38 @@ export async function resolveBpms(tracks, onUpdate, onProgress) {
   const uncached = tracks.filter(t => !cachedMap.has(t.id))
   if (!uncached.length) return
 
+  // Tier 2: getsong.co (batched, concurrent)
+  const failed = []
   let done = 0
 
   for (let i = 0; i < uncached.length; i += BATCH) {
     if (i > 0) await new Promise(r => setTimeout(r, BATCH_DELAY))
     await Promise.all(uncached.slice(i, i + BATCH).map(async track => {
       const artist = track.artists[0]?.name ?? ''
-
       const gResult = await lookupGetSongBpm(track.name, artist)
-      const bpm    = gResult.bpm
 
-      if (bpm) {
-        onUpdate(track.id, bpm, 'getsongbpm', false)
-        storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm, source: 'getsongbpm' })
+      if (gResult.bpm) {
+        onUpdate(track.id, gResult.bpm, 'getsongbpm', false)
+        storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm: gResult.bpm, source: 'getsongbpm' })
       } else {
         onUpdate(track.id, null, 'failed', false)
+        failed.push(track)
       }
 
       onProgress(++done, uncached.length)
     }))
+  }
+
+  // Tier 3: MusicBrainz sequential fallback for getsong.co misses
+  for (let i = 0; i < failed.length; i++) {
+    if (i > 0) await new Promise(r => setTimeout(r, MB_DELAY))
+    const track  = failed[i]
+    const artist = track.artists[0]?.name ?? ''
+    const mbResult = await lookupMusicBrainz(track.name, artist)
+
+    if (mbResult.bpm) {
+      onUpdate(track.id, mbResult.bpm, 'musicbrainz', false)
+      storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm: mbResult.bpm, source: 'musicbrainz' })
+    }
   }
 }

--- a/frontend/src/pages/SpotifyExplorer.jsx
+++ b/frontend/src/pages/SpotifyExplorer.jsx
@@ -208,8 +208,9 @@ export default function SpotifyExplorer() {
                             <div style={{ width: 5, height: 5, borderRadius: '50%', background: '#e879f9', flexShrink: 0 }} />
                           )}
                           <span style={{ fontSize: 14, fontWeight: 600, color:
-                            t.bpmSource === 'getsongbpm' ? '#4ade80'
-                            : t.bpmSource === 'failed'  ? '#f44336'
+                            t.bpmSource === 'getsongbpm'   ? '#4ade80'
+                            : t.bpmSource === 'musicbrainz' ? '#fb923c'
+                            : t.bpmSource === 'failed'      ? '#f44336'
                             : '#eef2ff'
                           }}>
                             {t.bpm ?? '—'}
@@ -235,6 +236,7 @@ export default function SpotifyExplorer() {
                 <div style={{ display: 'flex', gap: 16, marginTop: 12, flexWrap: 'wrap' }}>
                   {[
                     { color: '#4ade80', label: 'getsong.co' },
+                    { color: '#fb923c', label: 'musicbrainz' },
                     { color: '#f44336', label: 'not found' },
                     { color: '#eef2ff', label: 'pending' },
                   ].map(({ color, label }) => (


### PR DESCRIPTION
## Summary

Adds MusicBrainz as a tier-3 BPM fallback for tracks getsong.co can't find.

**Flow:**
1. DB cache (magenta dot)
2. getsong.co (green) — batched, 2 concurrent, 600ms between batches
3. MusicBrainz (orange) — sequential, 1.1s between requests to respect the 1 req/sec limit, only for tracks that failed tier 2

MusicBrainz runs silently after the progress counter clears — failed tracks (red) may turn orange as it works through the list.

https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw

---
_Generated by [Claude Code](https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw)_