### PR TITLE
spt: add per-source BPM resolution log

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "endermatx-frontend",
   "private": true,
-  "version": "1.17.0",
+  "version": "1.18.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/bpm.js
+++ b/frontend/src/bpm.js
@@ -63,7 +63,7 @@ const BATCH        = 2
 const BATCH_DELAY  = 600   // ms between getsong.co batches
 const MB_DELAY     = 1100  // ms between MusicBrainz requests (1 req/sec limit)
 
-export async function resolveBpms(tracks, onUpdate, onProgress) {
+export async function resolveBpms(tracks, onUpdate, onProgress, onLog) {
   // Tier 1: DB batch lookup
   const cached = await batchLookupDb(tracks.map(t => t.id))
   const cachedMap = new Map(cached.map(c => [c.spotify_id, { bpm: c.bpm, source: c.source }]))
@@ -89,9 +89,11 @@ export async function resolveBpms(tracks, onUpdate, onProgress) {
       const gResult = await lookupGetSongBpm(track.name, artist)
 
       if (gResult.bpm) {
+        onLog?.({ source: 'getsongbpm', name: track.name, bpm: gResult.bpm })
         onUpdate(track.id, gResult.bpm, 'getsongbpm', false)
         storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm: gResult.bpm, source: 'getsongbpm' })
       } else {
+        onLog?.({ source: 'getsongbpm', name: track.name, bpm: null })
         onUpdate(track.id, null, 'failed', false)
         failed.push(track)
       }
@@ -107,6 +109,7 @@ export async function resolveBpms(tracks, onUpdate, onProgress) {
     const artist = track.artists[0]?.name ?? ''
     const mbResult = await lookupMusicBrainz(track.name, artist)
 
+    onLog?.({ source: 'musicbrainz', name: track.name, bpm: mbResult.bpm })
     if (mbResult.bpm) {
       onUpdate(track.id, mbResult.bpm, 'musicbrainz', false)
       storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm: mbResult.bpm, source: 'musicbrainz' })

--- a/frontend/src/pages/SpotifyExplorer.jsx
+++ b/frontend/src/pages/SpotifyExplorer.jsx
@@ -16,6 +16,7 @@ export default function SpotifyExplorer() {
   const [tracks, setTracks]         = useState(null)
   const [status, setStatus]         = useState('')
   const [bpmStatus, setBpmStatus]   = useState('')
+  const [bpmLog, setBpmLog]         = useState([])
   const [error, setError]           = useState('')
 
   // Handle OAuth callback — only token exchange, no API calls
@@ -50,6 +51,7 @@ export default function SpotifyExplorer() {
     setSelectedId('')
     setError('')
     setBpmStatus('')
+    setBpmLog([])
   }
 
   // Auto-load playlists whenever the connected state becomes true
@@ -67,6 +69,7 @@ export default function SpotifyExplorer() {
     setTracks(null)
     setError('')
     setBpmStatus('')
+    setBpmLog([])
     setStatus('loading tracks…')
     try {
       const raw = await spotify.loadPlaylistTracks(playlistId, (_, n) => {
@@ -81,6 +84,7 @@ export default function SpotifyExplorer() {
         raw,
         (id, bpm, src, cached) => setTracks(prev => prev?.map(t => t.id === id ? { ...t, bpm, bpmSource: src, bpmCached: cached } : t) ?? prev),
         (done, total) => setBpmStatus(done < total ? `resolving BPMs… ${done}/${total}` : ''),
+        entry => setBpmLog(prev => [...prev, entry]),
       )
     } catch (e) {
       setError(e.message)
@@ -168,6 +172,7 @@ export default function SpotifyExplorer() {
                 setTracks(null)
                 setError('')
                 setBpmStatus('')
+                setBpmLog([])
                 if (id) loadTracks(id)
               }}
               disabled={playlists.length === 0 || !!status}
@@ -185,6 +190,21 @@ export default function SpotifyExplorer() {
             )}
             {bpmStatus && (
               <div style={{ fontSize: 12, color: '#9ab0d0', marginTop: 10 }}>{bpmStatus}</div>
+            )}
+            {bpmLog.length > 0 && (
+              <div style={{ marginTop: 10, maxHeight: 160, overflowY: 'auto', display: 'flex', flexDirection: 'column', gap: 1 }}>
+                {bpmLog.map((e, i) => {
+                  const srcColor = e.source === 'getsongbpm' ? '#4ade80' : '#fb923c'
+                  const srcLabel = e.source === 'getsongbpm' ? 'getsong.co ' : 'musicbrainz'
+                  return (
+                    <div key={i} style={{ display: 'flex', gap: 8, fontSize: 11, fontFamily: 'monospace' }}>
+                      <span style={{ color: srcColor, flexShrink: 0 }}>{srcLabel}</span>
+                      <span style={{ color: '#374d66', flexShrink: 0 }}>{e.bpm ? `${e.bpm} bpm` : '—'}</span>
+                      <span style={{ color: '#9ab0d0', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{e.name}</span>
+                    </div>
+                  )
+                })}
+              </div>
             )}
             {error && (
               <div style={{ fontSize: 12, color: '#f44336', marginTop: 10 }}>{error}</div>


### PR DESCRIPTION
## Summary

Adds a scrollable resolution log below the status line. One line per lookup attempt, color-coded by source:

```
getsong.co   113 bpm  Never Gonna Give You Up
getsong.co   —        Some Obscure Track
musicbrainz  —        Some Obscure Track
```

- Green `getsong.co` label for tier-2 hits/misses
- Orange `musicbrainz` label for tier-3 attempts
- BPM value or `—` in muted color
- Track name in secondary color, truncated with ellipsis
- Max height 160px, scrollable
- Clears on playlist change

https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw

---
_Generated by [Claude Code](https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw)_