### PR TITLE
spt: not-found DB storage + live stacked bar chart

### DIFF
--- a/backend/routers/bpm.py
+++ b/backend/routers/bpm.py
@@ -131,6 +131,14 @@ def musicbrainz_lookup(title: str = Query(...), artist: str = Query(...)):
 def store_bpm(body: schemas.TrackBpmIn, db: Session = Depends(get_db)):
     existing = db.get(models.TrackBpm, body.spotify_id)
     if existing:
+        # Upgrade a previous not_found entry when a real BPM is now available
+        if existing.source == 'not_found' and body.source != 'not_found':
+            existing.bpm    = body.bpm
+            existing.source = body.source
+            existing.title  = body.title
+            existing.artist = body.artist
+            db.commit()
+            db.refresh(existing)
         return existing
     entry = models.TrackBpm(**body.model_dump(), created_at=datetime.utcnow())
     db.add(entry)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "endermatx-frontend",
   "private": true,
-  "version": "1.18.0",
+  "version": "1.19.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/bpm.js
+++ b/frontend/src/bpm.js
@@ -64,45 +64,48 @@ const BATCH_DELAY  = 600   // ms between getsong.co batches
 const MB_DELAY     = 1100  // ms between MusicBrainz requests (1 req/sec limit)
 
 export async function resolveBpms(tracks, onUpdate, onProgress, onLog) {
-  // Tier 1: DB batch lookup
+  // Tier 1: DB batch lookup — real BPM entries used as cache; not_found entries retried
   const cached = await batchLookupDb(tracks.map(t => t.id))
-  const cachedMap = new Map(cached.map(c => [c.spotify_id, { bpm: c.bpm, source: c.source }]))
+  const realCache = new Map(
+    cached.filter(c => c.source !== 'not_found').map(c => [c.spotify_id, { bpm: c.bpm, source: c.source }])
+  )
 
   for (const t of tracks) {
-    if (cachedMap.has(t.id)) {
-      const { bpm, source } = cachedMap.get(t.id)
+    if (realCache.has(t.id)) {
+      const { bpm, source } = realCache.get(t.id)
       onUpdate(t.id, bpm, source, true)
     }
   }
 
-  const uncached = tracks.filter(t => !cachedMap.has(t.id))
-  if (!uncached.length) return
+  // Tracks to resolve: not cached OR previously marked not_found (retry every time)
+  const toResolve = tracks.filter(t => !realCache.has(t.id))
+  if (!toResolve.length) return
 
   // Tier 2: getsong.co (batched, concurrent)
   const failed = []
   let done = 0
 
-  for (let i = 0; i < uncached.length; i += BATCH) {
+  for (let i = 0; i < toResolve.length; i += BATCH) {
     if (i > 0) await new Promise(r => setTimeout(r, BATCH_DELAY))
-    await Promise.all(uncached.slice(i, i + BATCH).map(async track => {
+    await Promise.all(toResolve.slice(i, i + BATCH).map(async track => {
       const artist = track.artists[0]?.name ?? ''
       const gResult = await lookupGetSongBpm(track.name, artist)
 
+      onLog?.({ source: 'getsongbpm', name: track.name, bpm: gResult.bpm })
       if (gResult.bpm) {
-        onLog?.({ source: 'getsongbpm', name: track.name, bpm: gResult.bpm })
         onUpdate(track.id, gResult.bpm, 'getsongbpm', false)
         storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm: gResult.bpm, source: 'getsongbpm' })
       } else {
-        onLog?.({ source: 'getsongbpm', name: track.name, bpm: null })
         onUpdate(track.id, null, 'failed', false)
         failed.push(track)
       }
 
-      onProgress(++done, uncached.length)
+      onProgress(++done, toResolve.length)
     }))
   }
 
-  // Tier 3: MusicBrainz sequential fallback for getsong.co misses
+  // Tier 3: MusicBrainz sequential fallback
+  const resolvedByMb = new Set()
   for (let i = 0; i < failed.length; i++) {
     if (i > 0) await new Promise(r => setTimeout(r, MB_DELAY))
     const track  = failed[i]
@@ -111,8 +114,17 @@ export async function resolveBpms(tracks, onUpdate, onProgress, onLog) {
 
     onLog?.({ source: 'musicbrainz', name: track.name, bpm: mbResult.bpm })
     if (mbResult.bpm) {
+      resolvedByMb.add(track.id)
       onUpdate(track.id, mbResult.bpm, 'musicbrainz', false)
       storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm: mbResult.bpm, source: 'musicbrainz' })
+    }
+  }
+
+  // Store still-failed tracks as not_found (retried next playlist load)
+  for (const track of failed) {
+    if (!resolvedByMb.has(track.id)) {
+      const artist = track.artists[0]?.name ?? ''
+      storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm: 0, source: 'not_found' })
     }
   }
 }

--- a/frontend/src/pages/SpotifyExplorer.jsx
+++ b/frontend/src/pages/SpotifyExplorer.jsx
@@ -8,6 +8,73 @@ function fmtDuration(ms) {
   return `${Math.floor(s / 60)}:${String(s % 60).padStart(2, '0')}`
 }
 
+const BAR_SEGMENTS = [
+  { key: 'getsongbpm',   color: '#4ade80', label: 'getsong.co'  },
+  { key: 'musicbrainz',  color: '#fb923c', label: 'musicbrainz' },
+  { key: 'notFound',     color: '#f44336', label: 'not found'   },
+  { key: 'pending',      color: '#1a2840', label: 'pending'      },
+]
+
+function BpmBar({ stats }) {
+  const { total, getsongbpm, musicbrainz, notFound, pending } = stats
+  if (!total) return null
+  const counts = { getsongbpm, musicbrainz, notFound, pending }
+  const [hovered, setHovered] = useState(null)
+
+  return (
+    <div style={{ marginTop: 16 }}>
+      {/* Stacked bar */}
+      <div style={{ display: 'flex', height: 10, borderRadius: 5, overflow: 'hidden', background: '#1a2840' }}>
+        {BAR_SEGMENTS.map(seg => {
+          const pct = (counts[seg.key] / total) * 100
+          if (!pct) return null
+          return (
+            <div
+              key={seg.key}
+              style={{ width: `${pct}%`, background: seg.color, transition: 'width 0.4s', cursor: 'default' }}
+              onMouseEnter={() => setHovered(seg.key)}
+              onMouseLeave={() => setHovered(null)}
+              title={`${seg.label}: ${counts[seg.key]}`}
+            />
+          )
+        })}
+      </div>
+      {/* Legend */}
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px 16px', marginTop: 8 }}>
+        {BAR_SEGMENTS.map(seg => {
+          const n = counts[seg.key]
+          if (!n && seg.key !== 'getsongbpm') return null
+          const pct = Math.round((n / total) * 100)
+          const isHovered = hovered === seg.key
+          return (
+            <div
+              key={seg.key}
+              style={{ display: 'flex', alignItems: 'center', gap: 5, cursor: 'default' }}
+              onMouseEnter={() => setHovered(seg.key)}
+              onMouseLeave={() => setHovered(null)}
+            >
+              <div style={{ width: 8, height: 8, borderRadius: 2, background: seg.color, flexShrink: 0 }} />
+              <span style={{ fontSize: 11, color: isHovered ? '#eef2ff' : '#9ab0d0' }}>
+                {seg.label}
+              </span>
+              <span style={{ fontSize: 11, color: isHovered ? seg.color : '#374d66', minWidth: 18, textAlign: 'right' }}>
+                {n}
+              </span>
+              {isHovered && (
+                <span style={{ fontSize: 10, color: '#374d66' }}>({pct}%)</span>
+              )}
+            </div>
+          )
+        })}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 5, marginLeft: 'auto' }}>
+          <span style={{ fontSize: 11, color: '#374d66' }}>total</span>
+          <span style={{ fontSize: 11, color: '#9ab0d0' }}>{total}</span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
 export default function SpotifyExplorer() {
   const [clientIdInput, setClientIdInput] = useState(() => spotify.getClientId())
   const [connected, setConnected]   = useState(() => spotify.isConnected())
@@ -92,6 +159,15 @@ export default function SpotifyExplorer() {
       setStatus('')
     }
   }
+
+  const bpmStats = useMemo(() => {
+    if (!tracks || !tracks.length) return null
+    const getsongbpm  = tracks.filter(t => t.bpmSource === 'getsongbpm').length
+    const musicbrainz = tracks.filter(t => t.bpmSource === 'musicbrainz').length
+    const notFound    = tracks.filter(t => t.bpmSource === 'failed').length
+    const pending     = tracks.filter(t => !t.bpmSource).length
+    return { total: tracks.length, getsongbpm, musicbrainz, notFound, pending }
+  }, [tracks])
 
   // Sort by BPM ascending; unresolved tracks sink to the bottom
   const displayedTracks = useMemo(() => {
@@ -209,6 +285,8 @@ export default function SpotifyExplorer() {
             {error && (
               <div style={{ fontSize: 12, color: '#f44336', marginTop: 10 }}>{error}</div>
             )}
+
+            {bpmStats && <BpmBar stats={bpmStats} />}
 
             {tracks && (
               <div style={{ marginTop: 20 }}>


### PR DESCRIPTION
## Summary

**Not-found storage:**
- After both getsong.co and MusicBrainz fail, the track is stored in the DB with `bpm=0, source='not_found'`
- On next playlist load, `not_found` entries are excluded from the cache and retried from scratch
- If a previously not-found track is now found, the DB entry is upgraded (store endpoint now allows this)

**Live stacked bar chart:**
- Appears as soon as tracks start loading, updates in real time as BPMs resolve
- Segments: green (getsong.co) / orange (musicbrainz) / red (not found) / dark (pending)
- Hover a segment or its legend row to highlight it and reveal the percentage flyout
- Total shown on the right

https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw

---
_Generated by [Claude Code](https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw)_