### PR TITLE
spt: global DB stats bar above playlist selector

### DIFF
--- a/backend/routers/bpm.py
+++ b/backend/routers/bpm.py
@@ -19,6 +19,23 @@ def get_db():
         db.close()
 
 
+@router.get("/stats")
+def bpm_stats(db: Session = Depends(get_db)):
+    from sqlalchemy import func, case
+    row = db.query(
+        func.count().label("total"),
+        func.sum(case((models.TrackBpm.source == "getsongbpm",  1), else_=0)).label("getsongbpm"),
+        func.sum(case((models.TrackBpm.source == "musicbrainz", 1), else_=0)).label("musicbrainz"),
+        func.sum(case((models.TrackBpm.source == "not_found",   1), else_=0)).label("not_found"),
+    ).one()
+    return {
+        "total":       row.total       or 0,
+        "getsongbpm":  row.getsongbpm  or 0,
+        "musicbrainz": row.musicbrainz or 0,
+        "not_found":   row.not_found   or 0,
+    }
+
+
 @router.post("/batch-lookup", response_model=list[schemas.TrackBpmOut])
 def batch_lookup(body: schemas.BatchLookupRequest, db: Session = Depends(get_db)):
     if not body.spotify_ids:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "endermatx-frontend",
   "private": true,
-  "version": "1.19.0",
+  "version": "1.20.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/pages/SpotifyExplorer.jsx
+++ b/frontend/src/pages/SpotifyExplorer.jsx
@@ -83,8 +83,9 @@ export default function SpotifyExplorer() {
   const [tracks, setTracks]         = useState(null)
   const [status, setStatus]         = useState('')
   const [bpmStatus, setBpmStatus]   = useState('')
-  const [bpmLog, setBpmLog]         = useState([])
-  const [error, setError]           = useState('')
+  const [bpmLog, setBpmLog]           = useState([])
+  const [globalStats, setGlobalStats] = useState(null)
+  const [error, setError]             = useState('')
 
   // Handle OAuth callback — only token exchange, no API calls
   useEffect(() => {
@@ -129,7 +130,12 @@ export default function SpotifyExplorer() {
       .then(setPlaylists)
       .catch(e => setError(e.message))
       .finally(() => setStatus(''))
+    fetch('/api/bpm/stats').then(r => r.json()).then(setGlobalStats).catch(() => {})
   }, [connected])
+
+  function refreshGlobalStats() {
+    fetch('/api/bpm/stats').then(r => r.json()).then(setGlobalStats).catch(() => {})
+  }
 
   async function loadTracks(playlistId) {
     if (!playlistId) return
@@ -153,6 +159,7 @@ export default function SpotifyExplorer() {
         (done, total) => setBpmStatus(done < total ? `resolving BPMs… ${done}/${total}` : ''),
         entry => setBpmLog(prev => [...prev, entry]),
       )
+      refreshGlobalStats()
     } catch (e) {
       setError(e.message)
     } finally {
@@ -238,6 +245,18 @@ export default function SpotifyExplorer() {
         ) : (
           <>
             <div className="section-header">playlists</div>
+
+            {globalStats?.total > 0 && (
+              <div style={{ marginBottom: 14 }}>
+                <BpmBar stats={{
+                  total:        globalStats.total,
+                  getsongbpm:   globalStats.getsongbpm,
+                  musicbrainz:  globalStats.musicbrainz,
+                  notFound:     globalStats.not_found,
+                  pending:      0,
+                }} />
+              </div>
+            )}
 
             <select
               className="input"


### PR DESCRIPTION
## Summary

- New `GET /api/bpm/stats` endpoint counts rows by source across the entire `spt_track_bpm` table
- A global stats bar (reusing the existing `BpmBar` component) appears above the playlist dropdown, showing totals for all songs ever tracked — not just the current playlist
- Refreshes after each playlist's BPM resolution completes

https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw

---
_Generated by [Claude Code](https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw)_