### PR TITLE
feat(cal): render months as week-per-line grid with weekday headers

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "endermatx-frontend",
   "private": true,
-  "version": "1.19.0",
+  "version": "1.20.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/pages/Calendar.jsx
+++ b/frontend/src/pages/Calendar.jsx
@@ -537,13 +537,28 @@ export default function Calendar() {
           const days      = daysInMonth(y, m)
           const today     = new Date()
           const thisMonth = today.getFullYear() === y && today.getMonth() === m
+          // Monday-first offset: how many blank cells before day 1
+          const offset    = (new Date(y, m, 1).getDay() + 6) % 7
+          const DOW_HDR   = ['Mo','Tu','We','Th','Fr','Sa','Su']
 
           return (
             <div key={`${y}-${m}`} style={{ marginBottom: 28 }}>
               <div style={{ fontSize: 11, color: '#5d7592', letterSpacing: '0.2em', marginBottom: 8, textTransform: 'uppercase' }}>
                 {MONTHS[m]} {y}
               </div>
-              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
+              {/* Day-of-week header */}
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(7, 28px)', gap: 2, marginBottom: 2 }}>
+                {DOW_HDR.map(d => (
+                  <div key={d} style={{ width: 28, textAlign: 'center', fontSize: 9, color: '#374d66', letterSpacing: '0.05em', padding: '2px 0' }}>
+                    {d}
+                  </div>
+                ))}
+              </div>
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(7, 28px)', gap: 2 }}>
+                {/* Leading blank cells */}
+                {Array.from({ length: offset }, (_, i) => (
+                  <div key={`blank-${i}`} style={{ width: 28, height: 28 }} />
+                ))}
                 {Array.from({ length: days }, (_, i) => {
                   const d         = i + 1
                   const isToday   = thisMonth && today.getDate() === d


### PR DESCRIPTION
## Summary

- Replaces the sequential `flexWrap` day layout with a 7-column CSS grid (Mon–Sun)
- Adds a `Mo Tu We Th Fr Sa Su` header row above each month
- Inserts blank leading cells so day 1 always falls on the correct weekday column
- Result: Outlook-style calendar where each row is exactly one week
- Version bumped to `1.20`

---
_Generated by [Claude Code](https://claude.ai/code/session_0138u48xPLQoym6hUGeyJEU9)_