### PR TITLE
fix: not_found updates global bar during playlist scan

### DIFF
--- a/frontend/src/bpm.js
+++ b/frontend/src/bpm.js
@@ -98,6 +98,7 @@ export async function resolveBpms(tracks, onUpdate, onProgress, onLog) {
       } else {
         onUpdate(track.id, null, 'failed', false)
         failed.push(track)
+        storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm: 0, source: 'not_found' })
       }
 
       onProgress(++done, toResolve.length)
@@ -105,7 +106,6 @@ export async function resolveBpms(tracks, onUpdate, onProgress, onLog) {
   }
 
   // Tier 3: MusicBrainz sequential fallback
-  const resolvedByMb = new Set()
   for (let i = 0; i < failed.length; i++) {
     if (i > 0) await new Promise(r => setTimeout(r, MB_DELAY))
     const track  = failed[i]
@@ -114,17 +114,9 @@ export async function resolveBpms(tracks, onUpdate, onProgress, onLog) {
 
     onLog?.({ source: 'musicbrainz', name: track.name, bpm: mbResult.bpm })
     if (mbResult.bpm) {
-      resolvedByMb.add(track.id)
       onUpdate(track.id, mbResult.bpm, 'musicbrainz', false)
       storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm: mbResult.bpm, source: 'musicbrainz' })
     }
   }
 
-  // Store still-failed tracks as not_found (retried next playlist load)
-  for (const track of failed) {
-    if (!resolvedByMb.has(track.id)) {
-      const artist = track.artists[0]?.name ?? ''
-      storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm: 0, source: 'not_found' })
-    }
-  }
 }


### PR DESCRIPTION
## Summary

- Move `storeBpm('not_found')` from after the MusicBrainz pass to immediately inside the getsong.co batch loop when a track fails
- Remove the now-redundant end-of-resolution storeBpm loop and unused `resolvedByMb` Set
- The store endpoint's existing upgrade logic (`not_found` → real BPM) already handles the case where MusicBrainz subsequently finds the track

**Root cause:** `refreshGlobalStats()` fires during the getsong.co scan via `onProgress`, but `not_found` rows weren't written to the DB until after the entire MusicBrainz pass — so the global bar never saw them mid-scan.

https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw

---
_Generated by [Claude Code](https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw)_