### PR TITLE
refactor: resolve BPM per-track (getsong.co → MusicBrainz → next)

### DIFF
--- a/frontend/src/bpm.js
+++ b/frontend/src/bpm.js
@@ -59,9 +59,8 @@ async function lookupMusicBrainz(title, artist) {
 
 // ── Main resolution entry point ───────────────────────────────
 
-const BATCH        = 2
-const BATCH_DELAY  = 600   // ms between getsong.co batches
-const MB_DELAY     = 1100  // ms between MusicBrainz requests (1 req/sec limit)
+const GETSONG_DELAY = 400   // ms between getsong.co calls
+const MB_DELAY      = 1100  // ms between MusicBrainz requests (1 req/sec limit)
 
 export async function resolveBpms(tracks, onUpdate, onProgress, onLog) {
   // Tier 1: DB batch lookup — real BPM entries used as cache; not_found entries retried
@@ -81,42 +80,39 @@ export async function resolveBpms(tracks, onUpdate, onProgress, onLog) {
   const toResolve = tracks.filter(t => !realCache.has(t.id))
   if (!toResolve.length) return
 
-  // Tier 2: getsong.co (batched, concurrent)
-  const failed = []
+  let lastMbCall = 0
   let done = 0
 
-  for (let i = 0; i < toResolve.length; i += BATCH) {
-    if (i > 0) await new Promise(r => setTimeout(r, BATCH_DELAY))
-    await Promise.all(toResolve.slice(i, i + BATCH).map(async track => {
-      const artist = track.artists[0]?.name ?? ''
-      const gResult = await lookupGetSongBpm(track.name, artist)
+  for (let i = 0; i < toResolve.length; i++) {
+    if (i > 0) await new Promise(r => setTimeout(r, GETSONG_DELAY))
+    const track  = toResolve[i]
+    const artist = track.artists[0]?.name ?? ''
 
-      onLog?.({ source: 'getsongbpm', name: track.name, bpm: gResult.bpm })
-      if (gResult.bpm) {
-        onUpdate(track.id, gResult.bpm, 'getsongbpm', false)
-        storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm: gResult.bpm, source: 'getsongbpm' })
+    // Tier 2: getsong.co
+    const gResult = await lookupGetSongBpm(track.name, artist)
+    onLog?.({ source: 'getsongbpm', name: track.name, bpm: gResult.bpm })
+
+    if (gResult.bpm) {
+      onUpdate(track.id, gResult.bpm, 'getsongbpm', false)
+      storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm: gResult.bpm, source: 'getsongbpm' })
+    } else {
+      // Tier 3: MusicBrainz fallback immediately for this track
+      const wait = MB_DELAY - (Date.now() - lastMbCall)
+      if (wait > 0) await new Promise(r => setTimeout(r, wait))
+      const mbResult = await lookupMusicBrainz(track.name, artist)
+      lastMbCall = Date.now()
+      onLog?.({ source: 'musicbrainz', name: track.name, bpm: mbResult.bpm })
+
+      if (mbResult.bpm) {
+        onUpdate(track.id, mbResult.bpm, 'musicbrainz', false)
+        storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm: mbResult.bpm, source: 'musicbrainz' })
       } else {
         onUpdate(track.id, null, 'failed', false)
-        failed.push(track)
         storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm: 0, source: 'not_found' })
       }
-
-      onProgress(++done, toResolve.length)
-    }))
-  }
-
-  // Tier 3: MusicBrainz sequential fallback
-  for (let i = 0; i < failed.length; i++) {
-    if (i > 0) await new Promise(r => setTimeout(r, MB_DELAY))
-    const track  = failed[i]
-    const artist = track.artists[0]?.name ?? ''
-    const mbResult = await lookupMusicBrainz(track.name, artist)
-
-    onLog?.({ source: 'musicbrainz', name: track.name, bpm: mbResult.bpm })
-    if (mbResult.bpm) {
-      onUpdate(track.id, mbResult.bpm, 'musicbrainz', false)
-      storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm: mbResult.bpm, source: 'musicbrainz' })
     }
-  }
 
+    onProgress(++done, toResolve.length)
+  }
 }
+


### PR DESCRIPTION
Previously two separate passes: all tracks through getsong.co, then all failures through MusicBrainz. Now each track tries getsong.co first; if that fails MusicBrainz is tried immediately before moving on to the next track. Progress and not_found storage happen after each individual track resolves.

https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw