### PR TITLE
feat: add SoundNet (RapidAPI) as tier-3 BPM source

### DIFF
--- a/backend/routers/bpm.py
+++ b/backend/routers/bpm.py
@@ -25,12 +25,14 @@ def bpm_stats(db: Session = Depends(get_db)):
     row = db.query(
         func.count().label("total"),
         func.sum(case((models.TrackBpm.source == "getsongbpm",  1), else_=0)).label("getsongbpm"),
+        func.sum(case((models.TrackBpm.source == "soundnet",    1), else_=0)).label("soundnet"),
         func.sum(case((models.TrackBpm.source == "musicbrainz", 1), else_=0)).label("musicbrainz"),
         func.sum(case((models.TrackBpm.source == "not_found",   1), else_=0)).label("not_found"),
     ).one()
     return {
         "total":       row.total       or 0,
         "getsongbpm":  row.getsongbpm  or 0,
+        "soundnet":    row.soundnet    or 0,
         "musicbrainz": row.musicbrainz or 0,
         "not_found":   row.not_found   or 0,
     }
@@ -140,6 +142,44 @@ def musicbrainz_lookup(title: str = Query(...), artist: str = Query(...)):
                 return {"bpm": round(float(bpm))}
             except (ValueError, TypeError):
                 continue
+
+    return {"bpm": None}
+
+
+@router.get("/soundnet")
+def soundnet_lookup(spotify_id: str = Query(...)):
+    api_key = os.getenv("SOUNDNET_API_KEY", "")
+    if not api_key:
+        raise HTTPException(503, "SoundNet not configured")
+
+    try:
+        r = httpx.get(
+            f"https://track-analysis.p.rapidapi.com/pktx/spotify/{spotify_id}",
+            headers={
+                "X-RapidAPI-Key":  api_key,
+                "X-RapidAPI-Host": "track-analysis.p.rapidapi.com",
+            },
+            timeout=10,
+        )
+    except httpx.TimeoutException:
+        raise HTTPException(504, "SoundNet timeout")
+    except Exception:
+        return {"bpm": None}
+
+    if not r.is_success:
+        return {"bpm": None, "err": f"SoundNet HTTP {r.status_code}"}
+
+    try:
+        data = r.json()
+    except Exception:
+        return {"bpm": None}
+
+    tempo = data.get("tempo")
+    if tempo:
+        try:
+            return {"bpm": round(float(tempo))}
+        except (ValueError, TypeError):
+            pass
 
     return {"bpm": None}
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "endermatx-frontend",
   "private": true,
-  "version": "1.21.0",
+  "version": "1.22.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/bpm.js
+++ b/frontend/src/bpm.js
@@ -41,7 +41,22 @@ async function lookupGetSongBpm(title, artist) {
   }
 }
 
-// ── Tier 3: MusicBrainz fallback ─────────────────────────────
+// ── Tier 3: SoundNet via RapidAPI ────────────────────────────
+
+async function lookupSoundNet(spotifyId) {
+  try {
+    const res = await fetch(`/api/bpm/soundnet?spotify_id=${encodeURIComponent(spotifyId)}`, {
+      signal: AbortSignal.timeout(12000),
+    })
+    const data = await res.json()
+    if (!res.ok) return { bpm: null }
+    return { bpm: typeof data.bpm === 'number' ? data.bpm : null }
+  } catch {
+    return { bpm: null }
+  }
+}
+
+// ── Tier 4: MusicBrainz fallback ─────────────────────────────
 
 async function lookupMusicBrainz(title, artist) {
   try {
@@ -59,8 +74,9 @@ async function lookupMusicBrainz(title, artist) {
 
 // ── Main resolution entry point ───────────────────────────────
 
-const GETSONG_DELAY = 400   // ms between getsong.co calls
-const MB_DELAY      = 1100  // ms between MusicBrainz requests (1 req/sec limit)
+const GETSONG_DELAY  = 400   // ms between getsong.co calls
+const SOUNDNET_DELAY = 300   // ms between SoundNet calls
+const MB_DELAY       = 1100  // ms between MusicBrainz requests (1 req/sec limit)
 
 export async function resolveBpms(tracks, onUpdate, onProgress, onLog) {
   // Tier 1: DB batch lookup — real BPM entries used as cache; not_found entries retried
@@ -96,19 +112,29 @@ export async function resolveBpms(tracks, onUpdate, onProgress, onLog) {
       onUpdate(track.id, gResult.bpm, 'getsongbpm', false)
       storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm: gResult.bpm, source: 'getsongbpm' })
     } else {
-      // Tier 3: MusicBrainz fallback immediately for this track
-      const wait = MB_DELAY - (Date.now() - lastMbCall)
-      if (wait > 0) await new Promise(r => setTimeout(r, wait))
-      const mbResult = await lookupMusicBrainz(track.name, artist)
-      lastMbCall = Date.now()
-      onLog?.({ source: 'musicbrainz', name: track.name, bpm: mbResult.bpm })
+      // Tier 3: SoundNet fallback (uses Spotify ID directly)
+      await new Promise(r => setTimeout(r, SOUNDNET_DELAY))
+      const snResult = await lookupSoundNet(track.id)
+      onLog?.({ source: 'soundnet', name: track.name, bpm: snResult.bpm })
 
-      if (mbResult.bpm) {
-        onUpdate(track.id, mbResult.bpm, 'musicbrainz', false)
-        storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm: mbResult.bpm, source: 'musicbrainz' })
+      if (snResult.bpm) {
+        onUpdate(track.id, snResult.bpm, 'soundnet', false)
+        storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm: snResult.bpm, source: 'soundnet' })
       } else {
-        onUpdate(track.id, null, 'failed', false)
-        storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm: 0, source: 'not_found' })
+        // Tier 4: MusicBrainz fallback
+        const wait = MB_DELAY - (Date.now() - lastMbCall)
+        if (wait > 0) await new Promise(r => setTimeout(r, wait))
+        const mbResult = await lookupMusicBrainz(track.name, artist)
+        lastMbCall = Date.now()
+        onLog?.({ source: 'musicbrainz', name: track.name, bpm: mbResult.bpm })
+
+        if (mbResult.bpm) {
+          onUpdate(track.id, mbResult.bpm, 'musicbrainz', false)
+          storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm: mbResult.bpm, source: 'musicbrainz' })
+        } else {
+          onUpdate(track.id, null, 'failed', false)
+          storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm: 0, source: 'not_found' })
+        }
       }
     }
 

--- a/frontend/src/pages/SpotifyExplorer.jsx
+++ b/frontend/src/pages/SpotifyExplorer.jsx
@@ -10,6 +10,7 @@ function fmtDuration(ms) {
 
 const BAR_SEGMENTS = [
   { key: 'getsongbpm',   color: '#4ade80', label: 'getsong.co'  },
+  { key: 'soundnet',     color: '#22d3ee', label: 'soundnet'    },
   { key: 'musicbrainz',  color: '#fb923c', label: 'musicbrainz' },
   { key: 'notFound',     color: '#f44336', label: 'not found'   },
   { key: 'pending',      color: '#1a2840', label: 'pending'      },
@@ -43,7 +44,7 @@ function BpmBar({ stats }) {
       <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px 16px', marginTop: 8 }}>
         {BAR_SEGMENTS.map(seg => {
           const n = counts[seg.key]
-          if (!n && seg.key !== 'getsongbpm' && seg.key !== 'notFound') return null
+          if (!n && seg.key !== 'getsongbpm' && seg.key !== 'soundnet' && seg.key !== 'notFound') return null
           const pct = Math.round((n / total) * 100)
           const isHovered = hovered === seg.key
           return (
@@ -187,10 +188,11 @@ export default function SpotifyExplorer() {
   const bpmStats = useMemo(() => {
     if (!tracks || !tracks.length) return null
     const getsongbpm  = tracks.filter(t => t.bpmSource === 'getsongbpm').length
+    const soundnet    = tracks.filter(t => t.bpmSource === 'soundnet').length
     const musicbrainz = tracks.filter(t => t.bpmSource === 'musicbrainz').length
     const notFound    = tracks.filter(t => t.bpmSource === 'failed').length
     const pending     = tracks.filter(t => !t.bpmSource).length
-    return { total: tracks.length, getsongbpm, musicbrainz, notFound, pending }
+    return { total: tracks.length, getsongbpm, soundnet, musicbrainz, notFound, pending }
   }, [tracks])
 
   // Sort by BPM ascending; unresolved tracks sink to the bottom
@@ -268,6 +270,7 @@ export default function SpotifyExplorer() {
                 <BpmBar stats={{
                   total:        globalStats.total,
                   getsongbpm:   globalStats.getsongbpm,
+                  soundnet:     globalStats.soundnet,
                   musicbrainz:  globalStats.musicbrainz,
                   notFound:     globalStats.not_found,
                   pending:      0,
@@ -306,8 +309,8 @@ export default function SpotifyExplorer() {
             {bpmLog.length > 0 && (
               <div style={{ marginTop: 10, maxHeight: 160, overflowY: 'auto', display: 'flex', flexDirection: 'column', gap: 1 }}>
                 {bpmLog.map((e, i) => {
-                  const srcColor = e.source === 'getsongbpm' ? '#4ade80' : '#fb923c'
-                  const srcLabel = e.source === 'getsongbpm' ? 'getsong.co ' : 'musicbrainz'
+                  const srcColor = e.source === 'getsongbpm' ? '#4ade80' : e.source === 'soundnet' ? '#22d3ee' : '#fb923c'
+                  const srcLabel = e.source === 'getsongbpm' ? 'getsong.co ' : e.source === 'soundnet' ? 'soundnet   ' : 'musicbrainz'
                   return (
                     <div key={i} style={{ display: 'flex', gap: 8, fontSize: 11, fontFamily: 'monospace' }}>
                       <span style={{ color: srcColor, flexShrink: 0 }}>{srcLabel}</span>
@@ -343,6 +346,7 @@ export default function SpotifyExplorer() {
                           )}
                           <span style={{ fontSize: 14, fontWeight: 600, color:
                             t.bpmSource === 'getsongbpm'   ? '#4ade80'
+                            : t.bpmSource === 'soundnet'    ? '#22d3ee'
                             : t.bpmSource === 'musicbrainz' ? '#fb923c'
                             : t.bpmSource === 'failed'      ? '#f44336'
                             : '#eef2ff'
@@ -370,6 +374,7 @@ export default function SpotifyExplorer() {
                 <div style={{ display: 'flex', gap: 16, marginTop: 12, flexWrap: 'wrap' }}>
                   {[
                     { color: '#4ade80', label: 'getsong.co' },
+                    { color: '#22d3ee', label: 'soundnet' },
                     { color: '#fb923c', label: 'musicbrainz' },
                     { color: '#f44336', label: 'not found' },
                     { color: '#eef2ff', label: 'pending' },


### PR DESCRIPTION
## Summary

- Adds SoundNet (via RapidAPI) as a third BPM lookup source between getsong.co and MusicBrainz
- SoundNet uses the Spotify track ID directly — no title/artist matching needed
- New backend proxy endpoint `GET /api/bpm/soundnet?spotify_id=...`
- SoundNet hits shown in cyan in the bar chart, track list, resolution log, and legend
- Stats endpoint now counts `soundnet` separately

## Resolution order (per track)
1. DB cache
2. getsong.co
3. **SoundNet** ← new
4. MusicBrainz
5. not_found

## Setup required
Add `SOUNDNET_API_KEY` to Railway environment variables. Get the key at:
https://rapidapi.com/soundnet-soundnet-default/api/track-analysis

https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw

---
_Generated by [Claude Code](https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw)_