### PR TITLE
fix: show raw API response in log for soundnet/musicbrainz misses

### DIFF
--- a/frontend/src/bpm.js
+++ b/frontend/src/bpm.js
@@ -49,10 +49,11 @@ async function lookupSoundNet(spotifyId) {
       signal: AbortSignal.timeout(12000),
     })
     const data = await res.json()
-    if (!res.ok) return { bpm: null }
-    return { bpm: typeof data.bpm === 'number' ? data.bpm : null }
-  } catch {
-    return { bpm: null }
+    if (!res.ok) return { bpm: null, err: `HTTP ${res.status}`, raw: data }
+    if (data.err) return { bpm: null, err: data.err, raw: data }
+    return { bpm: typeof data.bpm === 'number' ? data.bpm : null, raw: data }
+  } catch (e) {
+    return { bpm: null, err: e.message }
   }
 }
 
@@ -65,10 +66,11 @@ async function lookupMusicBrainz(title, artist) {
       signal: AbortSignal.timeout(12000),
     })
     const data = await res.json()
-    if (!res.ok) return { bpm: null }
-    return { bpm: typeof data.bpm === 'number' ? data.bpm : null }
-  } catch {
-    return { bpm: null }
+    if (!res.ok) return { bpm: null, err: `HTTP ${res.status}`, raw: data }
+    if (data.err) return { bpm: null, err: data.err, raw: data }
+    return { bpm: typeof data.bpm === 'number' ? data.bpm : null, raw: data }
+  } catch (e) {
+    return { bpm: null, err: e.message }
   }
 }
 
@@ -115,7 +117,7 @@ export async function resolveBpms(tracks, onUpdate, onProgress, onLog) {
       // Tier 3: SoundNet fallback (uses Spotify ID directly)
       await new Promise(r => setTimeout(r, SOUNDNET_DELAY))
       const snResult = await lookupSoundNet(track.id)
-      onLog?.({ source: 'soundnet', name: track.name, bpm: snResult.bpm })
+      onLog?.({ source: 'soundnet', name: track.name, bpm: snResult.bpm, err: snResult.err, raw: snResult.raw })
 
       if (snResult.bpm) {
         onUpdate(track.id, snResult.bpm, 'soundnet', false)
@@ -126,7 +128,7 @@ export async function resolveBpms(tracks, onUpdate, onProgress, onLog) {
         if (wait > 0) await new Promise(r => setTimeout(r, wait))
         const mbResult = await lookupMusicBrainz(track.name, artist)
         lastMbCall = Date.now()
-        onLog?.({ source: 'musicbrainz', name: track.name, bpm: mbResult.bpm })
+        onLog?.({ source: 'musicbrainz', name: track.name, bpm: mbResult.bpm, err: mbResult.err, raw: mbResult.raw })
 
         if (mbResult.bpm) {
           onUpdate(track.id, mbResult.bpm, 'musicbrainz', false)

--- a/frontend/src/pages/SpotifyExplorer.jsx
+++ b/frontend/src/pages/SpotifyExplorer.jsx
@@ -311,11 +311,21 @@ export default function SpotifyExplorer() {
                 {bpmLog.map((e, i) => {
                   const srcColor = e.source === 'getsongbpm' ? '#4ade80' : e.source === 'soundnet' ? '#22d3ee' : '#fb923c'
                   const srcLabel = e.source === 'getsongbpm' ? 'getsong.co ' : e.source === 'soundnet' ? 'soundnet   ' : 'musicbrainz'
+                  const detail = !e.bpm && (e.source === 'soundnet' || e.source === 'musicbrainz')
+                    ? (e.err ?? (e.raw != null ? JSON.stringify(e.raw).slice(0, 120) : 'no response'))
+                    : null
                   return (
-                    <div key={i} style={{ display: 'flex', gap: 8, fontSize: 11, fontFamily: 'monospace' }}>
-                      <span style={{ color: srcColor, flexShrink: 0 }}>{srcLabel}</span>
-                      <span style={{ color: '#374d66', flexShrink: 0 }}>{e.bpm ? `${e.bpm} bpm` : '—'}</span>
-                      <span style={{ color: '#9ab0d0', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{e.name}</span>
+                    <div key={i} style={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+                      <div style={{ display: 'flex', gap: 8, fontSize: 11, fontFamily: 'monospace' }}>
+                        <span style={{ color: srcColor, flexShrink: 0 }}>{srcLabel}</span>
+                        <span style={{ color: '#374d66', flexShrink: 0 }}>{e.bpm ? `${e.bpm} bpm` : '—'}</span>
+                        <span style={{ color: '#9ab0d0', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{e.name}</span>
+                      </div>
+                      {detail && (
+                        <div style={{ fontSize: 10, color: '#4d6fa0', fontFamily: 'monospace', paddingLeft: 88, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                          {detail}
+                        </div>
+                      )}
                     </div>
                   )
                 })}


### PR DESCRIPTION
## Summary

- `lookupSoundNet` and `lookupMusicBrainz` were silently dropping errors — now both return `err` and `raw` on failure
- `onLog` calls pass through `err` and `raw` for soundnet and musicbrainz entries
- The resolution log renders a second indented line below each failed soundnet/musicbrainz entry showing the error message or raw JSON response (truncated to 120 chars)

This makes it immediately visible whether the API is returning an error (e.g. 403, misconfigured key) or genuinely has no BPM for the track.

https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw

---
_Generated by [Claude Code](https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw)_