### PR TITLE
chore: remove MusicBrainz and SoundNet

### DIFF
--- a/backend/routers/bpm.py
+++ b/backend/routers/bpm.py
@@ -24,17 +24,13 @@ def bpm_stats(db: Session = Depends(get_db)):
     from sqlalchemy import func, case
     row = db.query(
         func.count().label("total"),
-        func.sum(case((models.TrackBpm.source == "getsongbpm",  1), else_=0)).label("getsongbpm"),
-        func.sum(case((models.TrackBpm.source == "soundnet",    1), else_=0)).label("soundnet"),
-        func.sum(case((models.TrackBpm.source == "musicbrainz", 1), else_=0)).label("musicbrainz"),
-        func.sum(case((models.TrackBpm.source == "not_found",   1), else_=0)).label("not_found"),
+        func.sum(case((models.TrackBpm.source == "getsongbpm", 1), else_=0)).label("getsongbpm"),
+        func.sum(case((models.TrackBpm.source == "not_found",  1), else_=0)).label("not_found"),
     ).one()
     return {
-        "total":       row.total       or 0,
-        "getsongbpm":  row.getsongbpm  or 0,
-        "soundnet":    row.soundnet    or 0,
-        "musicbrainz": row.musicbrainz or 0,
-        "not_found":   row.not_found   or 0,
+        "total":      row.total      or 0,
+        "getsongbpm": row.getsongbpm or 0,
+        "not_found":  row.not_found  or 0,
     }
 
 
@@ -69,7 +65,6 @@ def _pick_best(results: list, artist: str) -> dict | None:
         if artist_lower and (artist_lower in name or name in artist_lower):
             if r.get("tempo"):
                 return r
-    # fallback: first result with a non-null tempo
     for r in results:
         if r.get("tempo"):
             return r
@@ -112,78 +107,6 @@ def getsongbpm_lookup(title: str = Query(...), artist: str = Query(...)):
         return {"bpm": None, "debug": raw}
 
 
-@router.get("/musicbrainz")
-def musicbrainz_lookup(title: str = Query(...), artist: str = Query(...)):
-    query = f'recording:"{title}" AND artistname:"{artist}"'
-    try:
-        r = httpx.get(
-            "https://musicbrainz.org/ws/2/recording/",
-            params={"query": query, "limit": 5, "fmt": "json"},
-            headers={"User-Agent": "endermatx/1.0 (https://matmaxx.org)"},
-            timeout=10,
-        )
-    except httpx.TimeoutException:
-        raise HTTPException(504, "MusicBrainz timeout")
-    except Exception:
-        return {"bpm": None}
-
-    if not r.is_success:
-        return {"bpm": None, "err": f"MusicBrainz HTTP {r.status_code}"}
-
-    try:
-        data = r.json()
-    except Exception:
-        return {"bpm": None}
-
-    for rec in (data or {}).get("recordings") or []:
-        bpm = rec.get("bpm")
-        if bpm:
-            try:
-                return {"bpm": round(float(bpm))}
-            except (ValueError, TypeError):
-                continue
-
-    return {"bpm": None}
-
-
-@router.get("/soundnet")
-def soundnet_lookup(spotify_id: str = Query(...)):
-    api_key = os.getenv("SOUNDNET_API_KEY", "")
-    if not api_key:
-        raise HTTPException(503, "SoundNet not configured")
-
-    try:
-        r = httpx.get(
-            f"https://track-analysis.p.rapidapi.com/pktx/spotify/{spotify_id}",
-            headers={
-                "X-RapidAPI-Key":  api_key,
-                "X-RapidAPI-Host": "track-analysis.p.rapidapi.com",
-            },
-            timeout=10,
-        )
-    except httpx.TimeoutException:
-        raise HTTPException(504, "SoundNet timeout")
-    except Exception:
-        return {"bpm": None}
-
-    if not r.is_success:
-        return {"bpm": None, "err": f"SoundNet HTTP {r.status_code}"}
-
-    try:
-        data = r.json()
-    except Exception:
-        return {"bpm": None}
-
-    tempo = data.get("tempo")
-    if tempo:
-        try:
-            return {"bpm": round(float(tempo))}
-        except (ValueError, TypeError):
-            pass
-
-    return {"bpm": None}
-
-
 @router.delete("/all")
 def wipe_all(db: Session = Depends(get_db)):
     try:
@@ -199,7 +122,6 @@ def wipe_all(db: Session = Depends(get_db)):
 def store_bpm(body: schemas.TrackBpmIn, db: Session = Depends(get_db)):
     existing = db.get(models.TrackBpm, body.spotify_id)
     if existing:
-        # Upgrade a previous not_found entry when a real BPM is now available
         if existing.source == 'not_found' and body.source != 'not_found':
             existing.bpm    = body.bpm
             existing.source = body.source

--- a/frontend/src/bpm.js
+++ b/frontend/src/bpm.js
@@ -8,7 +8,7 @@ async function batchLookupDb(spotifyIds) {
       body:    JSON.stringify({ spotify_ids: spotifyIds }),
     })
     if (!res.ok) return []
-    return await res.json()  // [{ spotify_id, bpm, source, ... }]
+    return await res.json()
   } catch {
     return []
   }
@@ -41,44 +41,9 @@ async function lookupGetSongBpm(title, artist) {
   }
 }
 
-// ── Tier 3: SoundNet via RapidAPI ────────────────────────────
-
-async function lookupSoundNet(spotifyId) {
-  try {
-    const res = await fetch(`/api/bpm/soundnet?spotify_id=${encodeURIComponent(spotifyId)}`, {
-      signal: AbortSignal.timeout(12000),
-    })
-    const data = await res.json()
-    if (!res.ok) return { bpm: null, err: `HTTP ${res.status}`, raw: data }
-    if (data.err) return { bpm: null, err: data.err, raw: data }
-    return { bpm: typeof data.bpm === 'number' ? data.bpm : null, raw: data }
-  } catch (e) {
-    return { bpm: null, err: e.message }
-  }
-}
-
-// ── Tier 4: MusicBrainz fallback ─────────────────────────────
-
-async function lookupMusicBrainz(title, artist) {
-  try {
-    const params = new URLSearchParams({ title, artist })
-    const res = await fetch(`/api/bpm/musicbrainz?${params}`, {
-      signal: AbortSignal.timeout(12000),
-    })
-    const data = await res.json()
-    if (!res.ok) return { bpm: null, err: `HTTP ${res.status}`, raw: data }
-    if (data.err) return { bpm: null, err: data.err, raw: data }
-    return { bpm: typeof data.bpm === 'number' ? data.bpm : null, raw: data }
-  } catch (e) {
-    return { bpm: null, err: e.message }
-  }
-}
-
 // ── Main resolution entry point ───────────────────────────────
 
-const GETSONG_DELAY  = 400   // ms between getsong.co calls
-const SOUNDNET_DELAY = 300   // ms between SoundNet calls
-const MB_DELAY       = 1100  // ms between MusicBrainz requests (1 req/sec limit)
+const GETSONG_DELAY = 400  // ms between getsong.co calls
 
 export async function resolveBpms(tracks, onUpdate, onProgress, onLog) {
   // Tier 1: DB batch lookup — real BPM entries used as cache; not_found entries retried
@@ -94,11 +59,9 @@ export async function resolveBpms(tracks, onUpdate, onProgress, onLog) {
     }
   }
 
-  // Tracks to resolve: not cached OR previously marked not_found (retry every time)
   const toResolve = tracks.filter(t => !realCache.has(t.id))
   if (!toResolve.length) return
 
-  let lastMbCall = 0
   let done = 0
 
   for (let i = 0; i < toResolve.length; i++) {
@@ -106,7 +69,6 @@ export async function resolveBpms(tracks, onUpdate, onProgress, onLog) {
     const track  = toResolve[i]
     const artist = track.artists[0]?.name ?? ''
 
-    // Tier 2: getsong.co
     const gResult = await lookupGetSongBpm(track.name, artist)
     onLog?.({ source: 'getsongbpm', name: track.name, bpm: gResult.bpm })
 
@@ -114,33 +76,10 @@ export async function resolveBpms(tracks, onUpdate, onProgress, onLog) {
       onUpdate(track.id, gResult.bpm, 'getsongbpm', false)
       storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm: gResult.bpm, source: 'getsongbpm' })
     } else {
-      // Tier 3: SoundNet fallback (uses Spotify ID directly)
-      await new Promise(r => setTimeout(r, SOUNDNET_DELAY))
-      const snResult = await lookupSoundNet(track.id)
-      onLog?.({ source: 'soundnet', name: track.name, bpm: snResult.bpm, err: snResult.err, raw: snResult.raw })
-
-      if (snResult.bpm) {
-        onUpdate(track.id, snResult.bpm, 'soundnet', false)
-        storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm: snResult.bpm, source: 'soundnet' })
-      } else {
-        // Tier 4: MusicBrainz fallback
-        const wait = MB_DELAY - (Date.now() - lastMbCall)
-        if (wait > 0) await new Promise(r => setTimeout(r, wait))
-        const mbResult = await lookupMusicBrainz(track.name, artist)
-        lastMbCall = Date.now()
-        onLog?.({ source: 'musicbrainz', name: track.name, bpm: mbResult.bpm, err: mbResult.err, raw: mbResult.raw })
-
-        if (mbResult.bpm) {
-          onUpdate(track.id, mbResult.bpm, 'musicbrainz', false)
-          storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm: mbResult.bpm, source: 'musicbrainz' })
-        } else {
-          onUpdate(track.id, null, 'failed', false)
-          storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm: 0, source: 'not_found' })
-        }
-      }
+      onUpdate(track.id, null, 'failed', false)
+      storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm: 0, source: 'not_found' })
     }
 
     onProgress(++done, toResolve.length)
   }
 }
-

--- a/frontend/src/pages/SpotifyExplorer.jsx
+++ b/frontend/src/pages/SpotifyExplorer.jsx
@@ -9,17 +9,15 @@ function fmtDuration(ms) {
 }
 
 const BAR_SEGMENTS = [
-  { key: 'getsongbpm',   color: '#4ade80', label: 'getsong.co'  },
-  { key: 'soundnet',     color: '#22d3ee', label: 'soundnet'    },
-  { key: 'musicbrainz',  color: '#fb923c', label: 'musicbrainz' },
-  { key: 'notFound',     color: '#f44336', label: 'not found'   },
-  { key: 'pending',      color: '#1a2840', label: 'pending'      },
+  { key: 'getsongbpm', color: '#4ade80', label: 'getsong.co' },
+  { key: 'notFound',   color: '#f44336', label: 'not found'  },
+  { key: 'pending',    color: '#1a2840', label: 'pending'    },
 ]
 
 function BpmBar({ stats }) {
-  const { total, getsongbpm, musicbrainz, notFound, pending } = stats
+  const { total, getsongbpm, notFound, pending } = stats
   if (!total) return null
-  const counts = { getsongbpm, musicbrainz, notFound, pending }
+  const counts = { getsongbpm, notFound, pending }
   const [hovered, setHovered] = useState(null)
 
   return (
@@ -44,7 +42,7 @@ function BpmBar({ stats }) {
       <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px 16px', marginTop: 8 }}>
         {BAR_SEGMENTS.map(seg => {
           const n = counts[seg.key]
-          if (!n && seg.key !== 'getsongbpm' && seg.key !== 'soundnet' && seg.key !== 'notFound') return null
+          if (!n && seg.key !== 'getsongbpm' && seg.key !== 'notFound') return null
           const pct = Math.round((n / total) * 100)
           const isHovered = hovered === seg.key
           return (
@@ -187,12 +185,10 @@ export default function SpotifyExplorer() {
 
   const bpmStats = useMemo(() => {
     if (!tracks || !tracks.length) return null
-    const getsongbpm  = tracks.filter(t => t.bpmSource === 'getsongbpm').length
-    const soundnet    = tracks.filter(t => t.bpmSource === 'soundnet').length
-    const musicbrainz = tracks.filter(t => t.bpmSource === 'musicbrainz').length
-    const notFound    = tracks.filter(t => t.bpmSource === 'failed').length
-    const pending     = tracks.filter(t => !t.bpmSource).length
-    return { total: tracks.length, getsongbpm, soundnet, musicbrainz, notFound, pending }
+    const getsongbpm = tracks.filter(t => t.bpmSource === 'getsongbpm').length
+    const notFound   = tracks.filter(t => t.bpmSource === 'failed').length
+    const pending    = tracks.filter(t => !t.bpmSource).length
+    return { total: tracks.length, getsongbpm, notFound, pending }
   }, [tracks])
 
   // Sort by BPM ascending; unresolved tracks sink to the bottom
@@ -268,12 +264,10 @@ export default function SpotifyExplorer() {
             {globalStats?.total > 0 && (
               <div style={{ marginBottom: 14 }}>
                 <BpmBar stats={{
-                  total:        globalStats.total,
-                  getsongbpm:   globalStats.getsongbpm,
-                  soundnet:     globalStats.soundnet,
-                  musicbrainz:  globalStats.musicbrainz,
-                  notFound:     globalStats.not_found,
-                  pending:      0,
+                  total:      globalStats.total,
+                  getsongbpm: globalStats.getsongbpm,
+                  notFound:   globalStats.not_found,
+                  pending:    0,
                 }} />
               </div>
             )}
@@ -309,23 +303,11 @@ export default function SpotifyExplorer() {
             {bpmLog.length > 0 && (
               <div style={{ marginTop: 10, maxHeight: 160, overflowY: 'auto', display: 'flex', flexDirection: 'column', gap: 1 }}>
                 {bpmLog.map((e, i) => {
-                  const srcColor = e.source === 'getsongbpm' ? '#4ade80' : e.source === 'soundnet' ? '#22d3ee' : '#fb923c'
-                  const srcLabel = e.source === 'getsongbpm' ? 'getsong.co ' : e.source === 'soundnet' ? 'soundnet   ' : 'musicbrainz'
-                  const detail = !e.bpm && (e.source === 'soundnet' || e.source === 'musicbrainz')
-                    ? (e.err ?? (e.raw != null ? JSON.stringify(e.raw).slice(0, 120) : 'no response'))
-                    : null
                   return (
-                    <div key={i} style={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-                      <div style={{ display: 'flex', gap: 8, fontSize: 11, fontFamily: 'monospace' }}>
-                        <span style={{ color: srcColor, flexShrink: 0 }}>{srcLabel}</span>
-                        <span style={{ color: '#374d66', flexShrink: 0 }}>{e.bpm ? `${e.bpm} bpm` : '—'}</span>
-                        <span style={{ color: '#9ab0d0', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{e.name}</span>
-                      </div>
-                      {detail && (
-                        <div style={{ fontSize: 10, color: '#4d6fa0', fontFamily: 'monospace', paddingLeft: 88, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                          {detail}
-                        </div>
-                      )}
+                    <div key={i} style={{ display: 'flex', gap: 8, fontSize: 11, fontFamily: 'monospace' }}>
+                      <span style={{ color: '#4ade80', flexShrink: 0 }}>getsong.co</span>
+                      <span style={{ color: '#374d66', flexShrink: 0 }}>{e.bpm ? `${e.bpm} bpm` : '—'}</span>
+                      <span style={{ color: '#9ab0d0', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{e.name}</span>
                     </div>
                   )
                 })}
@@ -355,10 +337,8 @@ export default function SpotifyExplorer() {
                             <div style={{ width: 5, height: 5, borderRadius: '50%', background: '#e879f9', flexShrink: 0 }} />
                           )}
                           <span style={{ fontSize: 14, fontWeight: 600, color:
-                            t.bpmSource === 'getsongbpm'   ? '#4ade80'
-                            : t.bpmSource === 'soundnet'    ? '#22d3ee'
-                            : t.bpmSource === 'musicbrainz' ? '#fb923c'
-                            : t.bpmSource === 'failed'      ? '#f44336'
+                            t.bpmSource === 'getsongbpm' ? '#4ade80'
+                            : t.bpmSource === 'failed'   ? '#f44336'
                             : '#eef2ff'
                           }}>
                             {t.bpm ?? '—'}
@@ -384,8 +364,6 @@ export default function SpotifyExplorer() {
                 <div style={{ display: 'flex', gap: 16, marginTop: 12, flexWrap: 'wrap' }}>
                   {[
                     { color: '#4ade80', label: 'getsong.co' },
-                    { color: '#22d3ee', label: 'soundnet' },
-                    { color: '#fb923c', label: 'musicbrainz' },
                     { color: '#f44336', label: 'not found' },
                     { color: '#eef2ff', label: 'pending' },
                   ].map(({ color, label }) => (


### PR DESCRIPTION
Neither service found BPM data for any tested tracks. Removes both lookup endpoints, cleans up the stats endpoint, resolution log, bar chart, and color coding. Back to getsong.co only.

https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw

---
_Generated by [Claude Code](https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw)_