### PR TITLE
feat: Deezer BPM fallback + getsong.co title cleaning

### DIFF
--- a/backend/routers/bpm.py
+++ b/backend/routers/bpm.py
@@ -1,4 +1,5 @@
 import os
+import re
 from datetime import datetime
 
 import httpx
@@ -43,6 +44,21 @@ def batch_lookup(body: schemas.BatchLookupRequest, db: Session = Depends(get_db)
     ).all()
 
 
+_TITLE_NOISE = re.compile(
+    r'\s*[\(\[]'
+    r'(?:feat\.?|ft\.?|featuring|with|prod\.?|produced by'
+    r'|radio edit|album version|single version|extended|remaster(?:ed)?(?:\s+\d{4})?'
+    r'|live|acoustic|instrumental|explicit|bonus track|interlude'
+    r'|original mix|club mix|remix|edit)'
+    r'[^\)\]]*[\)\]]'
+    r'|\s+-\s+(?:feat\.?|ft\.?|featuring|remaster(?:ed)?(?:\s+\d{4})?|radio edit|live|acoustic|remix).*$',
+    re.IGNORECASE,
+)
+
+def _clean_title(title: str) -> str:
+    return _TITLE_NOISE.sub('', title).strip()
+
+
 def _getsong_search(api_key: str, title: str):
     app_url = os.getenv("GETSONGBPM_APP_URL", "https://matmaxx.org/spt")
     return httpx.get(
@@ -71,40 +87,44 @@ def _pick_best(results: list, artist: str) -> dict | None:
     return None
 
 
+def _getsong_results(api_key: str, title: str) -> list:
+    """Return search results list for a title, or [] on any failure."""
+    try:
+        r = _getsong_search(api_key, title)
+        if not r.is_success:
+            return []
+        data = r.json()
+        results = (data or {}).get("search") or []
+        return results if isinstance(results, list) else []
+    except Exception:
+        return []
+
+
 @router.get("/getsongbpm")
 def getsongbpm_lookup(title: str = Query(...), artist: str = Query(...)):
     api_key = os.getenv("GETSONGBPM_API_KEY", "")
     if not api_key:
         raise HTTPException(503, "GetSongBPM not configured")
 
-    try:
-        r = _getsong_search(api_key, title)
-    except httpx.TimeoutException:
-        raise HTTPException(504, "GetSongBPM timeout")
-    except Exception:
+    # Pass 1: full title
+    results = _getsong_results(api_key, title)
+
+    # Pass 2: cleaned title (strip feat., remaster tags, etc.) if pass 1 found nothing
+    cleaned = _clean_title(title)
+    if not results and cleaned != title:
+        results = _getsong_results(api_key, cleaned)
+
+    if not results:
         return {"bpm": None}
-
-    raw = None
-    try:
-        raw = r.json()
-    except Exception:
-        return {"bpm": None, "err": f"GetSongBPM HTTP {r.status_code}, non-JSON body"}
-
-    if not r.is_success:
-        return {"bpm": None, "err": f"GetSongBPM HTTP {r.status_code}", "debug": raw}
-
-    results = (raw or {}).get("search") or []
-    if not isinstance(results, list) or not results:
-        return {"bpm": None, "debug": raw}
 
     match = _pick_best(results, artist)
     if not match:
-        return {"bpm": None, "debug": raw}
+        return {"bpm": None}
 
     try:
         return {"bpm": round(float(match["tempo"]))}
     except (ValueError, TypeError):
-        return {"bpm": None, "debug": raw}
+        return {"bpm": None}
 
 
 @router.delete("/all")

--- a/backend/routers/bpm.py
+++ b/backend/routers/bpm.py
@@ -26,11 +26,13 @@ def bpm_stats(db: Session = Depends(get_db)):
     row = db.query(
         func.count().label("total"),
         func.sum(case((models.TrackBpm.source == "getsongbpm", 1), else_=0)).label("getsongbpm"),
+        func.sum(case((models.TrackBpm.source == "deezer",     1), else_=0)).label("deezer"),
         func.sum(case((models.TrackBpm.source == "not_found",  1), else_=0)).label("not_found"),
     ).one()
     return {
         "total":      row.total      or 0,
         "getsongbpm": row.getsongbpm or 0,
+        "deezer":     row.deezer     or 0,
         "not_found":  row.not_found  or 0,
     }
 
@@ -125,6 +127,72 @@ def getsongbpm_lookup(title: str = Query(...), artist: str = Query(...)):
         return {"bpm": round(float(match["tempo"]))}
     except (ValueError, TypeError):
         return {"bpm": None}
+
+
+def _pick_deezer(results: list, artist: str) -> dict | None:
+    artist_lower = artist.lower()
+    for r in results:
+        name = (r.get("artist") or {}).get("name", "").lower()
+        if artist_lower and (artist_lower in name or name in artist_lower):
+            return r
+    return results[0] if results else None
+
+
+def _deezer_search(title: str, artist: str) -> list:
+    try:
+        r = httpx.get(
+            "https://api.deezer.com/search",
+            params={"q": f'track:"{title}" artist:"{artist}"', "limit": 5},
+            headers={"User-Agent": "endermatx/1.0 (https://matmaxx.org)"},
+            timeout=10,
+        )
+        if not r.is_success:
+            return []
+        return r.json().get("data") or []
+    except Exception:
+        return []
+
+
+@router.get("/deezer")
+def deezer_lookup(title: str = Query(...), artist: str = Query(...)):
+    results = _deezer_search(title, artist)
+
+    if not results:
+        cleaned = _clean_title(title)
+        if cleaned != title:
+            results = _deezer_search(cleaned, artist)
+
+    if not results:
+        return {"bpm": None}
+
+    track = _pick_deezer(results, artist)
+    if not track:
+        return {"bpm": None}
+
+    try:
+        r = httpx.get(
+            f"https://api.deezer.com/track/{track['id']}",
+            headers={"User-Agent": "endermatx/1.0 (https://matmaxx.org)"},
+            timeout=10,
+        )
+    except httpx.TimeoutException:
+        raise HTTPException(504, "Deezer timeout")
+    except Exception:
+        return {"bpm": None}
+
+    if not r.is_success:
+        return {"bpm": None, "err": f"Deezer HTTP {r.status_code}"}
+
+    try:
+        bpm = r.json().get("bpm")
+        if bpm:
+            val = round(float(bpm))
+            if val > 0:
+                return {"bpm": val}
+    except (ValueError, TypeError):
+        pass
+
+    return {"bpm": None}
 
 
 @router.delete("/all")

--- a/frontend/src/bpm.js
+++ b/frontend/src/bpm.js
@@ -41,9 +41,27 @@ async function lookupGetSongBpm(title, artist) {
   }
 }
 
+// ── Tier 3: Deezer (free, no auth) ───────────────────────────
+
+async function lookupDeezer(title, artist) {
+  try {
+    const params = new URLSearchParams({ title, artist })
+    const res = await fetch(`/api/bpm/deezer?${params}`, {
+      signal: AbortSignal.timeout(15000),
+    })
+    const data = await res.json()
+    if (!res.ok) return { bpm: null, err: data?.detail ?? `HTTP ${res.status}` }
+    if (data.err) return { bpm: null, err: data.err }
+    return { bpm: typeof data.bpm === 'number' ? data.bpm : null }
+  } catch (e) {
+    return { bpm: null, err: e.message }
+  }
+}
+
 // ── Main resolution entry point ───────────────────────────────
 
 const GETSONG_DELAY = 400  // ms between getsong.co calls
+const DEEZER_DELAY  = 400  // ms between Deezer calls (2 requests per track internally)
 
 export async function resolveBpms(tracks, onUpdate, onProgress, onLog) {
   // Tier 1: DB batch lookup — real BPM entries used as cache; not_found entries retried
@@ -69,6 +87,7 @@ export async function resolveBpms(tracks, onUpdate, onProgress, onLog) {
     const track  = toResolve[i]
     const artist = track.artists[0]?.name ?? ''
 
+    // Tier 2: getsong.co
     const gResult = await lookupGetSongBpm(track.name, artist)
     onLog?.({ source: 'getsongbpm', name: track.name, bpm: gResult.bpm })
 
@@ -76,8 +95,18 @@ export async function resolveBpms(tracks, onUpdate, onProgress, onLog) {
       onUpdate(track.id, gResult.bpm, 'getsongbpm', false)
       storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm: gResult.bpm, source: 'getsongbpm' })
     } else {
-      onUpdate(track.id, null, 'failed', false)
-      storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm: 0, source: 'not_found' })
+      // Tier 3: Deezer
+      await new Promise(r => setTimeout(r, DEEZER_DELAY))
+      const dResult = await lookupDeezer(track.name, artist)
+      onLog?.({ source: 'deezer', name: track.name, bpm: dResult.bpm, err: dResult.err })
+
+      if (dResult.bpm) {
+        onUpdate(track.id, dResult.bpm, 'deezer', false)
+        storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm: dResult.bpm, source: 'deezer' })
+      } else {
+        onUpdate(track.id, null, 'failed', false)
+        storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm: 0, source: 'not_found' })
+      }
     }
 
     onProgress(++done, toResolve.length)

--- a/frontend/src/pages/SpotifyExplorer.jsx
+++ b/frontend/src/pages/SpotifyExplorer.jsx
@@ -10,14 +10,15 @@ function fmtDuration(ms) {
 
 const BAR_SEGMENTS = [
   { key: 'getsongbpm', color: '#4ade80', label: 'getsong.co' },
+  { key: 'deezer',     color: '#a78bfa', label: 'deezer'     },
   { key: 'notFound',   color: '#f44336', label: 'not found'  },
   { key: 'pending',    color: '#1a2840', label: 'pending'    },
 ]
 
 function BpmBar({ stats }) {
-  const { total, getsongbpm, notFound, pending } = stats
+  const { total, getsongbpm, deezer, notFound, pending } = stats
   if (!total) return null
-  const counts = { getsongbpm, notFound, pending }
+  const counts = { getsongbpm, deezer, notFound, pending }
   const [hovered, setHovered] = useState(null)
 
   return (
@@ -42,7 +43,7 @@ function BpmBar({ stats }) {
       <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px 16px', marginTop: 8 }}>
         {BAR_SEGMENTS.map(seg => {
           const n = counts[seg.key]
-          if (!n && seg.key !== 'getsongbpm' && seg.key !== 'notFound') return null
+          if (!n && seg.key !== 'getsongbpm' && seg.key !== 'deezer' && seg.key !== 'notFound') return null
           const pct = Math.round((n / total) * 100)
           const isHovered = hovered === seg.key
           return (
@@ -186,9 +187,10 @@ export default function SpotifyExplorer() {
   const bpmStats = useMemo(() => {
     if (!tracks || !tracks.length) return null
     const getsongbpm = tracks.filter(t => t.bpmSource === 'getsongbpm').length
+    const deezer     = tracks.filter(t => t.bpmSource === 'deezer').length
     const notFound   = tracks.filter(t => t.bpmSource === 'failed').length
     const pending    = tracks.filter(t => !t.bpmSource).length
-    return { total: tracks.length, getsongbpm, notFound, pending }
+    return { total: tracks.length, getsongbpm, deezer, notFound, pending }
   }, [tracks])
 
   // Sort by BPM ascending; unresolved tracks sink to the bottom
@@ -216,7 +218,7 @@ export default function SpotifyExplorer() {
           <span className="topbar-title">spt</span>
         </div>
         <div className="topbar-right">
-          <span className="topbar-version">v1.0</span>
+          <span className="topbar-version">v1.1</span>
         </div>
       </div>
       <div className="page">
@@ -269,6 +271,7 @@ export default function SpotifyExplorer() {
                 <BpmBar stats={{
                   total:      globalStats.total,
                   getsongbpm: globalStats.getsongbpm,
+                  deezer:     globalStats.deezer,
                   notFound:   globalStats.not_found,
                   pending:    0,
                 }} />
@@ -306,11 +309,21 @@ export default function SpotifyExplorer() {
             {bpmLog.length > 0 && (
               <div style={{ marginTop: 10, maxHeight: 160, overflowY: 'auto', display: 'flex', flexDirection: 'column', gap: 1 }}>
                 {bpmLog.map((e, i) => {
+                  const srcColor = e.source === 'getsongbpm' ? '#4ade80' : '#a78bfa'
+                  const srcLabel = e.source === 'getsongbpm' ? 'getsong.co' : 'deezer    '
+                  const detail = !e.bpm && e.source === 'deezer' && e.err ? e.err : null
                   return (
-                    <div key={i} style={{ display: 'flex', gap: 8, fontSize: 11, fontFamily: 'monospace' }}>
-                      <span style={{ color: '#4ade80', flexShrink: 0 }}>getsong.co</span>
-                      <span style={{ color: '#374d66', flexShrink: 0 }}>{e.bpm ? `${e.bpm} bpm` : '—'}</span>
-                      <span style={{ color: '#9ab0d0', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{e.name}</span>
+                    <div key={i} style={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+                      <div style={{ display: 'flex', gap: 8, fontSize: 11, fontFamily: 'monospace' }}>
+                        <span style={{ color: srcColor, flexShrink: 0 }}>{srcLabel}</span>
+                        <span style={{ color: '#374d66', flexShrink: 0 }}>{e.bpm ? `${e.bpm} bpm` : '—'}</span>
+                        <span style={{ color: '#9ab0d0', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{e.name}</span>
+                      </div>
+                      {detail && (
+                        <div style={{ fontSize: 10, color: '#4d6fa0', fontFamily: 'monospace', paddingLeft: 84, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                          {detail}
+                        </div>
+                      )}
                     </div>
                   )
                 })}
@@ -341,6 +354,7 @@ export default function SpotifyExplorer() {
                           )}
                           <span style={{ fontSize: 14, fontWeight: 600, color:
                             t.bpmSource === 'getsongbpm' ? '#4ade80'
+                            : t.bpmSource === 'deezer'   ? '#a78bfa'
                             : t.bpmSource === 'failed'   ? '#f44336'
                             : '#eef2ff'
                           }}>
@@ -367,6 +381,7 @@ export default function SpotifyExplorer() {
                 <div style={{ display: 'flex', gap: 16, marginTop: 12, flexWrap: 'wrap' }}>
                   {[
                     { color: '#4ade80', label: 'getsong.co' },
+                    { color: '#a78bfa', label: 'deezer' },
                     { color: '#f44336', label: 'not found' },
                     { color: '#eef2ff', label: 'pending' },
                   ].map(({ color, label }) => (


### PR DESCRIPTION
## Summary

**getsong.co improvement (Option 1):**
- Pass 1: search with full title as before
- Pass 2: retry with cleaned title (strips `(feat. X)`, `(Radio Edit)`, `- Remastered 2015`, etc.) when pass 1 returns no results
- Artist matching unchanged — still tries exact match first, falls back to first result with tempo

**Deezer (Option 3):**
- Free public API, no auth or API key required
- 2-step per track: `GET /search?q=track:"..." artist:"..."` → `GET /track/{id}` for the BPM field (BPM is only on the full track object, not in search results)
- Artist matching applied to search results before fetching full track
- Also retries with cleaned title if search returns nothing
- Deezer hits shown in purple in bar chart, track list, and log

**Beatport (Option 4) — skipped:** Their v4 API requires OAuth with a real Beatport account. The only auth-free option is scraping `__NEXT_DATA__` from their HTML, but Cloudflare actively blocks it. Not worth the fragility.

## Resolution order (per track)
1. DB cache
2. getsong.co (full title → cleaned title retry)
3. **Deezer** ← new
4. not_found

https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw

---
_Generated by [Claude Code](https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw)_