### PR TITLE
spt: background scan persists when browser is closed

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -17,7 +17,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 
 from .database import engine, Base, SessionLocal
 from .models import TtsEntry
-from .routers import tts, cal, idx, strings, bpm
+from .routers import tts, cal, idx, strings, bpm, scan
 
 logger = logging.getLogger(__name__)
 
@@ -105,7 +105,8 @@ app.include_router(tts.router, prefix="/api/tts", tags=["tts"])
 app.include_router(cal.router, prefix="/api/cal", tags=["cal"])
 app.include_router(idx.router, prefix="/api/idx", tags=["idx"])
 app.include_router(strings.router, prefix="/api/str", tags=["str"])
-app.include_router(bpm.router,     prefix="/api/bpm", tags=["bpm"])
+app.include_router(bpm.router,      prefix="/api/bpm",      tags=["bpm"])
+app.include_router(scan.router,     prefix="/api/bpm/scan", tags=["scan"])
 
 FRONTEND_DIST = Path(__file__).parent.parent / "frontend" / "dist"
 GAMES_DIR = Path(__file__).parent.parent / "games"

--- a/backend/routers/scan.py
+++ b/backend/routers/scan.py
@@ -1,0 +1,202 @@
+import asyncio
+import os
+import time
+from datetime import datetime
+from typing import Any
+
+import httpx
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel
+
+from ..database import SessionLocal
+from .. import models
+from .bpm import _clean_title, _getsong_results, _pick_best, _deezer_search, _pick_deezer
+
+router = APIRouter()
+
+# ── In-memory scan state (cleared on server restart) ──────────────────────────
+
+_state: dict[str, Any] = {
+    "status":          "idle",   # idle | running | done
+    "tracks_total":    0,
+    "tracks_done":     0,
+    "playlists_total": 0,
+    "playlists_done":  0,
+    "started_at":      None,
+    "finished_at":     None,
+    "log":             [],       # [{source, name, bpm, err?}]
+}
+
+_GETSONG_DELAY = 0.4   # seconds between getsong.co calls
+_DEEZER_DELAY  = 0.4   # seconds before Deezer fallback
+
+
+class ScanTrack(BaseModel):
+    spotify_id: str
+    name: str
+    artist: str
+    album: str = ""
+
+
+class ScanStartRequest(BaseModel):
+    tracks: list[ScanTrack]
+    playlists_total: int = 0
+    playlists_done: int = 0
+
+
+def _append_log(source: str, name: str, bpm, err=None) -> None:
+    entry: dict[str, Any] = {"source": source, "name": name, "bpm": bpm}
+    if err:
+        entry["err"] = err
+    _state["log"].append(entry)
+
+
+def _store_bpm_db(track: ScanTrack, bpm: int, source: str) -> None:
+    db = SessionLocal()
+    try:
+        existing = db.get(models.TrackBpm, track.spotify_id)
+        if existing:
+            if existing.source == "not_found" and source != "not_found":
+                existing.bpm    = bpm
+                existing.source = source
+                existing.title  = track.name
+                existing.artist = track.artist
+                db.commit()
+        else:
+            db.add(models.TrackBpm(
+                spotify_id = track.spotify_id,
+                title      = track.name,
+                artist     = track.artist,
+                album      = track.album,
+                bpm        = bpm,
+                source     = source,
+                created_at = datetime.utcnow(),
+            ))
+            db.commit()
+    except Exception:
+        db.rollback()
+    finally:
+        db.close()
+
+
+def _do_scan(tracks: list[ScanTrack]) -> None:
+    """Resolve BPMs for all tracks. Runs in a thread pool via asyncio.to_thread."""
+    api_key = os.getenv("GETSONGBPM_API_KEY", "")
+
+    # Batch-check DB — skip tracks already resolved with a real source
+    db = SessionLocal()
+    try:
+        ids = [t.spotify_id for t in tracks]
+        cached_ids = {
+            r.spotify_id
+            for r in db.query(models.TrackBpm).filter(
+                models.TrackBpm.spotify_id.in_(ids),
+                models.TrackBpm.source != "not_found",
+            ).all()
+        }
+    finally:
+        db.close()
+
+    to_resolve = [t for t in tracks if t.spotify_id not in cached_ids]
+    _state["tracks_done"] = len(cached_ids)
+
+    for i, track in enumerate(to_resolve):
+        if i > 0:
+            time.sleep(_GETSONG_DELAY)
+
+        # Tier 2: getsong.co
+        bpm = None
+        if api_key:
+            results = _getsong_results(api_key, track.name)
+            cleaned = _clean_title(track.name)
+            if not results and cleaned != track.name:
+                results = _getsong_results(api_key, cleaned)
+            match = _pick_best(results, track.artist) if results else None
+            if match:
+                try:
+                    bpm = round(float(match["tempo"]))
+                except (ValueError, TypeError):
+                    bpm = None
+
+        _append_log("getsongbpm", track.name, bpm)
+
+        if bpm:
+            _store_bpm_db(track, bpm, "getsongbpm")
+        else:
+            # Tier 3: Deezer
+            time.sleep(_DEEZER_DELAY)
+            results = _deezer_search(track.name, track.artist)
+            if not results:
+                cleaned = _clean_title(track.name)
+                if cleaned != track.name:
+                    results = _deezer_search(cleaned, track.artist)
+
+            deezer_bpm = None
+            deezer_err = None
+            if results:
+                deezer_track = _pick_deezer(results, track.artist)
+                if deezer_track:
+                    try:
+                        r = httpx.get(
+                            f"https://api.deezer.com/track/{deezer_track['id']}",
+                            headers={"User-Agent": "endermatx/1.0 (https://matmaxx.org)"},
+                            timeout=10,
+                        )
+                        if r.is_success:
+                            val_raw = r.json().get("bpm")
+                            if val_raw:
+                                val = round(float(val_raw))
+                                if val > 0:
+                                    deezer_bpm = val
+                    except Exception as e:
+                        deezer_err = str(e)
+
+            _append_log("deezer", track.name, deezer_bpm, deezer_err)
+
+            if deezer_bpm:
+                _store_bpm_db(track, deezer_bpm, "deezer")
+            else:
+                _store_bpm_db(track, 0, "not_found")
+
+        _state["tracks_done"] += 1
+
+    _state["status"]      = "done"
+    _state["finished_at"] = datetime.utcnow().isoformat() + "Z"
+
+
+@router.post("/start")
+async def scan_start(body: ScanStartRequest):
+    if _state["status"] == "running":
+        raise HTTPException(409, "Scan already running")
+    _state.update({
+        "status":          "running",
+        "tracks_total":    len(body.tracks),
+        "tracks_done":     0,
+        "playlists_total": body.playlists_total,
+        "playlists_done":  body.playlists_done,
+        "started_at":      datetime.utcnow().isoformat() + "Z",
+        "finished_at":     None,
+        "log":             [],
+    })
+    asyncio.create_task(asyncio.to_thread(_do_scan, list(body.tracks)))
+    return {"status": "started", "tracks": len(body.tracks)}
+
+
+@router.get("/status")
+def scan_status(since: int = Query(0, ge=0), last: int = Query(0, ge=0)):
+    log = _state["log"]
+    if last > 0:
+        log_slice = log[-last:] if len(log) >= last else log[:]
+    else:
+        log_slice = log[since: since + 200]
+    return {
+        "status":          _state["status"],
+        "tracks_total":    _state["tracks_total"],
+        "tracks_done":     _state["tracks_done"],
+        "playlists_total": _state["playlists_total"],
+        "playlists_done":  _state["playlists_done"],
+        "started_at":      _state["started_at"],
+        "finished_at":     _state["finished_at"],
+        "log":             log_slice,
+        "log_count":       len(log),
+    }

--- a/frontend/src/pages/SpotifyExplorer.jsx
+++ b/frontend/src/pages/SpotifyExplorer.jsx
@@ -105,9 +105,12 @@ export default function SpotifyExplorer() {
   const [globalStats, setGlobalStats] = useState(null)
   const [wipeMsg, setWipeMsg]       = useState('')
   const [error, setError]           = useState('')
-  const [scanMode, setScanMode]     = useState(null) // null | 'running' | 'done'
+  // null | 'fetching' | 'running' | 'done'
+  const [scanMode, setScanMode]     = useState(null)
   const [scanProgress, setScanProgress] = useState({ playlistsDone: 0, playlistsTotal: 0, tracksDone: 0, tracksTotal: 0 })
+  const [logOffset, setLogOffset]   = useState(0)
 
+  // Handle Spotify OAuth callback
   useEffect(() => {
     const params     = new URLSearchParams(window.location.search)
     const code       = params.get('code')
@@ -119,6 +122,71 @@ export default function SpotifyExplorer() {
         .catch(e => setError(e.message))
     }
   }, [])
+
+  // On mount: check if a background scan is already running on the server
+  useEffect(() => {
+    fetch('/api/bpm/scan/status?last=200')
+      .then(r => r.json())
+      .then(data => {
+        if (data.status === 'running' || data.status === 'done') {
+          setBpmLog([...data.log].reverse())
+          setLogOffset(data.log_count)
+          setScanProgress({
+            playlistsDone: data.playlists_done,
+            playlistsTotal: data.playlists_total,
+            tracksDone: data.tracks_done,
+            tracksTotal: data.tracks_total,
+          })
+          setScanMode(data.status)
+        }
+      })
+      .catch(() => {})
+  }, [])
+
+  // Poll the backend while a scan is running
+  useEffect(() => {
+    if (scanMode !== 'running') return
+
+    let offset = logOffset
+    let cancelled = false
+
+    async function poll() {
+      if (cancelled) return
+      try {
+        const res = await fetch(`/api/bpm/scan/status?since=${offset}`)
+        if (!res.ok) return
+        const data = await res.json()
+        if (cancelled) return
+
+        if (data.status === 'idle') {
+          // Server restarted mid-scan — scan is gone
+          setScanMode(null)
+          return
+        }
+
+        setScanProgress({
+          playlistsDone: data.playlists_done,
+          playlistsTotal: data.playlists_total,
+          tracksDone: data.tracks_done,
+          tracksTotal: data.tracks_total,
+        })
+
+        if (data.log?.length) {
+          setBpmLog(prev => [...data.log.slice().reverse(), ...prev])
+          offset = data.log_count
+        }
+
+        if (data.status === 'done') {
+          setScanMode('done')
+          refreshGlobalStats()
+        }
+      } catch { /* ignore transient network errors */ }
+    }
+
+    poll()
+    const id = setInterval(poll, 2000)
+    return () => { cancelled = true; clearInterval(id) }
+  }, [scanMode]) // eslint-disable-line react-hooks/exhaustive-deps
 
   async function connect() {
     const id = clientIdInput.trim()
@@ -170,10 +238,12 @@ export default function SpotifyExplorer() {
   }
 
   async function startScanAll() {
-    setScanMode('running')
     setBpmLog([])
+    setLogOffset(0)
     setScanProgress({ playlistsDone: 0, playlistsTotal: playlists.length, tracksDone: 0, tracksTotal: 0 })
+    setScanMode('fetching')
 
+    // Phase 1: fetch all Spotify tracks in the browser (needs OAuth token)
     const seen = new Map()
     for (let i = 0; i < playlists.length; i++) {
       try {
@@ -186,16 +256,33 @@ export default function SpotifyExplorer() {
     const allTracks = Array.from(seen.values())
     setScanProgress(prev => ({ ...prev, tracksTotal: allTracks.length }))
 
-    let resolved = 0
-    await resolveBpms(
-      allTracks,
-      () => { resolved++; setScanProgress(prev => ({ ...prev, tracksDone: resolved })) },
-      () => { refreshGlobalStats() },
-      entry => setBpmLog(prev => [entry, ...prev]),
-    )
+    // Phase 2: hand off to backend for persistent BPM resolution
+    const scanTracks = allTracks.map(t => ({
+      spotify_id: t.id,
+      name:       t.name,
+      artist:     t.artists[0]?.name ?? '',
+      album:      t.album ?? '',
+    }))
 
-    setScanMode('done')
-    refreshGlobalStats()
+    try {
+      const res = await fetch('/api/bpm/scan/start', {
+        method:  'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body:    JSON.stringify({
+          tracks:          scanTracks,
+          playlists_total: playlists.length,
+          playlists_done:  playlists.length,
+        }),
+      })
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        throw new Error(data?.detail ?? `HTTP ${res.status}`)
+      }
+      setScanMode('running')
+    } catch (e) {
+      setError(`Scan failed to start: ${e.message}`)
+      setScanMode(null)
+    }
   }
 
   async function loadTracks(playlistId) {
@@ -256,6 +343,8 @@ export default function SpotifyExplorer() {
     pending:    0,
   } : null
 
+  const scanActive = scanMode !== null
+
   return (
     <div>
       <div className="topbar">
@@ -264,12 +353,55 @@ export default function SpotifyExplorer() {
           <span className="topbar-title">spt</span>
         </div>
         <div className="topbar-right">
-          <span className="topbar-version">v4.2</span>
+          <span className="topbar-version">v4.3</span>
         </div>
       </div>
       <div className="page">
 
-        {!connected ? (
+        {scanActive ? (
+
+          /* ── Scan-all view ─────────────────────────────── */
+          <>
+            {/* Progress — sticky below topbar */}
+            <div style={{ position: 'sticky', top: 32, background: '#07091a', zIndex: 10, paddingBottom: 12, borderBottom: '1px solid #1a2840', marginBottom: 4 }}>
+              <div style={{ display: 'flex', gap: 32, paddingTop: 12 }}>
+                {[
+                  { label: 'playlists done', value: scanProgress.playlistsDone },
+                  { label: 'playlists open', value: Math.max(0, scanProgress.playlistsTotal - scanProgress.playlistsDone) },
+                  { label: 'tracks done',    value: scanProgress.tracksDone },
+                  { label: 'tracks open',    value: Math.max(0, scanProgress.tracksTotal - scanProgress.tracksDone) },
+                ].map(({ label, value }) => (
+                  <div key={label}>
+                    <div style={{ fontSize: 10, color: '#374d66', marginBottom: 2 }}>{label}</div>
+                    <div style={{ fontSize: 24, fontWeight: 600, color: '#eef2ff', lineHeight: 1 }}>{value}</div>
+                  </div>
+                ))}
+              </div>
+              {scanMode === 'fetching' && (
+                <div style={{ fontSize: 11, color: '#9ab0d0', marginTop: 8 }}>fetching playlists from spotify…</div>
+              )}
+              {scanMode === 'running' && (
+                <div style={{ fontSize: 11, color: '#9ab0d0', marginTop: 8 }}>scanning in background — you can close this page</div>
+              )}
+              {scanMode === 'done' && (
+                <div style={{ fontSize: 11, color: '#4ade80', marginTop: 8 }}>scan complete</div>
+              )}
+            </div>
+
+            {/* Global bar */}
+            {globalBarStats && <BpmBar stats={globalBarStats} />}
+
+            {/* Full-height log */}
+            {bpmLog.length > 0 && (
+              <div style={{ marginTop: 12, maxHeight: 'calc(100vh - 280px)', overflowY: 'auto', display: 'flex', flexDirection: 'column', gap: 1 }}>
+                {bpmLog.map((e, i) => <LogEntry key={i} e={e} />)}
+              </div>
+            )}
+          </>
+
+        ) : !connected ? (
+
+          /* ── Connect form ──────────────────────────────── */
           <>
             <div className="section-header">connect spotify</div>
             <div className="card">
@@ -298,40 +430,6 @@ export default function SpotifyExplorer() {
                 </button>
               </div>
             </div>
-          </>
-        ) : scanMode ? (
-
-          /* ── Scan-all view ─────────────────────────────── */
-          <>
-            {/* Progress — sticky below topbar */}
-            <div style={{ position: 'sticky', top: 32, background: '#07091a', zIndex: 10, paddingBottom: 12, borderBottom: '1px solid #1a2840', marginBottom: 4 }}>
-              <div style={{ display: 'flex', gap: 32, paddingTop: 12 }}>
-                {[
-                  { label: 'playlists done', value: scanProgress.playlistsDone },
-                  { label: 'playlists open', value: Math.max(0, scanProgress.playlistsTotal - scanProgress.playlistsDone) },
-                  { label: 'tracks done',    value: scanProgress.tracksDone },
-                  { label: 'tracks open',    value: Math.max(0, scanProgress.tracksTotal - scanProgress.tracksDone) },
-                ].map(({ label, value }) => (
-                  <div key={label}>
-                    <div style={{ fontSize: 10, color: '#374d66', marginBottom: 2 }}>{label}</div>
-                    <div style={{ fontSize: 24, fontWeight: 600, color: '#eef2ff', lineHeight: 1 }}>{value}</div>
-                  </div>
-                ))}
-              </div>
-              {scanMode === 'done' && (
-                <div style={{ fontSize: 11, color: '#4ade80', marginTop: 8 }}>scan complete</div>
-              )}
-            </div>
-
-            {/* Global bar */}
-            {globalBarStats && <BpmBar stats={globalBarStats} />}
-
-            {/* Full-height log */}
-            {bpmLog.length > 0 && (
-              <div style={{ marginTop: 12, maxHeight: 'calc(100vh - 280px)', overflowY: 'auto', display: 'flex', flexDirection: 'column', gap: 1 }}>
-                {bpmLog.map((e, i) => <LogEntry key={i} e={e} />)}
-              </div>
-            )}
           </>
 
         ) : (
@@ -444,13 +542,13 @@ export default function SpotifyExplorer() {
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
               <div style={{ display: 'flex', gap: 8 }}>
                 <button className="btn btn-sm" onClick={disconnect}>disconnect spotify</button>
-                <button className="btn btn-sm" onClick={wipeDb} style={{ color: '#f44336' }} disabled={scanMode === 'running'}>wipe database</button>
+                <button className="btn btn-sm" onClick={wipeDb} style={{ color: '#f44336' }} disabled={scanMode === 'running' || scanMode === 'fetching'}>wipe database</button>
                 <button
                   className="btn btn-sm"
-                  onClick={scanMode ? () => setScanMode(null) : startScanAll}
-                  disabled={scanMode === 'running' || playlists.length === 0}
+                  onClick={scanActive && scanMode !== 'fetching' ? () => { setScanMode(null); setBpmLog([]) } : startScanAll}
+                  disabled={scanMode === 'fetching' || scanMode === 'running' || (!scanActive && playlists.length === 0)}
                 >
-                  {scanMode === 'running' ? 'scanning…' : scanMode === 'done' ? 'close scan' : 'scan all'}
+                  {scanMode === 'fetching' || scanMode === 'running' ? 'scanning…' : scanMode === 'done' ? 'close scan' : 'scan all'}
                 </button>
               </div>
               <a href="https://getsong.co" target="_blank" rel="noopener noreferrer" style={{ fontSize: 10, color: '#374d66', textDecoration: 'none' }}>


### PR DESCRIPTION
## What changed

Moves "scan all" BPM resolution from the browser to the backend so it keeps running when the browser tab is closed. When reopened, the page automatically reconnects and shows the current state.

### How it works

**Phase 1 — browser (unchanged):** Spotify playlist tracks are still fetched in the browser (OAuth token lives in localStorage). The playlist progress counter updates live as each playlist is fetched.

**Phase 2 — backend (new):** Once all tracks are collected, the browser POSTs the full track list to `POST /api/bpm/scan/start`. The backend runs BPM resolution in a thread (`asyncio.to_thread`) — getsong.co → Deezer fallback, same logic as before — completely independent of the browser.

**Polling:** The frontend polls `GET /api/bpm/scan/status?since=N` every 2 seconds to stream progress and log entries into the view.

**Reconnect on reopen:** A mount-time effect checks `/api/bpm/scan/status?last=200`. If a scan is `running` or `done`, the scan view is restored automatically with current progress and the 200 most recent log entries.

### Files changed

| File | Change |
|------|--------|
| `backend/routers/scan.py` | New — `_do_scan` thread, `/start`, `/status` endpoints |
| `backend/main.py` | Register scan router at `/api/bpm/scan` |
| `frontend/src/pages/SpotifyExplorer.jsx` | v4.2 → v4.3 — `fetching`/`running`/`done` scan modes, polling effect, mount reconnect |

### Edge cases handled
- Server restart mid-scan: next poll returns `status: idle` → scan view closes cleanly
- Scan already running when `/start` is called: backend returns 409 (frontend button is disabled during active scan anyway)
- Reconnect mid-scan: shows the most recent 200 log entries and continues appending new ones via polling

https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw

---
_Generated by [Claude Code](https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw)_