### PR TITLE
spt: fix global bar missing during background scan (v4.5)

### DIFF
--- a/frontend/src/pages/SpotifyExplorer.jsx
+++ b/frontend/src/pages/SpotifyExplorer.jsx
@@ -209,6 +209,7 @@ export default function SpotifyExplorer() {
         if (data.log?.length) {
           setBpmLog(prev => [...prev, ...data.log])
           offset = data.log_count
+          refreshGlobalStats()
         }
 
         if (data.status === 'done') {
@@ -391,7 +392,7 @@ export default function SpotifyExplorer() {
           <span className="topbar-title">spt</span>
         </div>
         <div className="topbar-right">
-          <span className="topbar-version">v4.4</span>
+          <span className="topbar-version">v4.5</span>
         </div>
       </div>
       <div className="page">


### PR DESCRIPTION
## Root cause

`refreshGlobalStats()` was only called once — when the scan finished. During the entire scan, the global BPM bar stayed frozen at its value from page load. If the DB was empty at scan start (fresh install or after a wipe), `globalStats.total = 0` → `globalBarStats = null` → bar never appeared at all.

## Fix

Call `refreshGlobalStats()` inside the polling effect whenever new log entries arrive (i.e. whenever the backend has resolved new tracks). The bar now updates roughly every 2 seconds as BPMs are stored, matching the previous behaviour where `resolveBpms` refreshed on every track via `onProgress`.

One-line change + version bump v4.4 → v4.5.

https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw

---
_Generated by [Claude Code](https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw)_