### PR TITLE
Show spotify: fail in log for getsong.co / Deezer entries

### DIFF
--- a/backend/routers/scan.py
+++ b/backend/routers/scan.py
@@ -129,7 +129,7 @@ def _do_scan(tracks: list[ScanTrack]) -> None:
                     bpm = None
 
         if bpm:
-            _append_log(track.name, track.artist, bpm, getsongbpm="pass")
+            _append_log(track.name, track.artist, bpm, spotify="fail", getsongbpm="pass")
             _store_bpm_db(track, bpm, "getsongbpm")
         else:
             # Tier 3: Deezer
@@ -160,10 +160,10 @@ def _do_scan(tracks: list[ScanTrack]) -> None:
                         pass
 
             if deezer_bpm:
-                _append_log(track.name, track.artist, deezer_bpm, getsongbpm="fail", deezer="pass")
+                _append_log(track.name, track.artist, deezer_bpm, spotify="fail", getsongbpm="fail", deezer="pass")
                 _store_bpm_db(track, deezer_bpm, "deezer")
             else:
-                _append_log(track.name, track.artist, None, getsongbpm="fail", deezer="fail")
+                _append_log(track.name, track.artist, None, spotify="fail", getsongbpm="fail", deezer="fail")
                 _store_bpm_db(track, 0, "not_found")
 
         _state["tracks_done"] += 1

--- a/frontend/src/bpm.js
+++ b/frontend/src/bpm.js
@@ -102,7 +102,7 @@ export async function resolveBpms(tracks, onUpdate, onProgress, onLog) {
     const gResult = await lookupGetSongBpm(track.name, artist)
 
     if (gResult.bpm) {
-      onLog?.({ name: track.name, artist, bpm: gResult.bpm, getsongbpm: 'pass' })
+      onLog?.({ name: track.name, artist, bpm: gResult.bpm, spotify: 'fail', getsongbpm: 'pass' })
       onUpdate(track.id, gResult.bpm, 'getsongbpm', false)
       storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm: gResult.bpm, source: 'getsongbpm' })
     } else {
@@ -111,11 +111,11 @@ export async function resolveBpms(tracks, onUpdate, onProgress, onLog) {
       const dResult = await lookupDeezer(track.name, artist)
 
       if (dResult.bpm) {
-        onLog?.({ name: track.name, artist, bpm: dResult.bpm, getsongbpm: 'fail', deezer: 'pass' })
+        onLog?.({ name: track.name, artist, bpm: dResult.bpm, spotify: 'fail', getsongbpm: 'fail', deezer: 'pass' })
         onUpdate(track.id, dResult.bpm, 'deezer', false)
         storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm: dResult.bpm, source: 'deezer' })
       } else {
-        onLog?.({ name: track.name, artist, bpm: null, getsongbpm: 'fail', deezer: 'fail' })
+        onLog?.({ name: track.name, artist, bpm: null, spotify: 'fail', getsongbpm: 'fail', deezer: 'fail' })
         onUpdate(track.id, null, 'failed', false)
         storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm: 0, source: 'not_found' })
       }


### PR DESCRIPTION
Every log entry now shows the full service chain tried.

Previously, tracks resolved by getsong.co or Deezer showed no Spotify result in the log row. Now they include `spotify: fail` before the downstream result, so every entry is consistent:

- Spotify hit: `spotify: pass`
- getsong.co hit: `spotify: fail · getsong.co: pass`
- Deezer hit: `spotify: fail · getsong.co: fail · deezer: pass`
- All failed: `spotify: fail · getsong.co: fail · deezer: fail`

Changes: `frontend/src/bpm.js` (3 `onLog` calls) and `backend/routers/scan.py` (3 `_append_log` calls). No JSX changes needed — `LogEntry` already renders `e.spotify` conditionally.

https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw

---
_Generated by [Claude Code](https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw)_