### PR TITLE
Always show all three sources in log, use — for untried services

### DIFF
--- a/backend/routers/scan.py
+++ b/backend/routers/scan.py
@@ -106,7 +106,7 @@ def _do_scan(tracks: list[ScanTrack]) -> None:
 
         # Tier 0: Spotify Audio Features (pre-fetched by the browser, no external call)
         if track.spotify_bpm:
-            _append_log(track.name, track.artist, track.spotify_bpm, spotify="pass")
+            _append_log(track.name, track.artist, track.spotify_bpm, spotify="pass", getsongbpm="—", deezer="—")
             _store_bpm_db(track, track.spotify_bpm, "spotify")
             _state["tracks_done"] += 1
             continue
@@ -129,7 +129,7 @@ def _do_scan(tracks: list[ScanTrack]) -> None:
                     bpm = None
 
         if bpm:
-            _append_log(track.name, track.artist, bpm, spotify="fail", getsongbpm="pass")
+            _append_log(track.name, track.artist, bpm, spotify="fail", getsongbpm="pass", deezer="—")
             _store_bpm_db(track, bpm, "getsongbpm")
         else:
             # Tier 3: Deezer

--- a/frontend/src/bpm.js
+++ b/frontend/src/bpm.js
@@ -88,7 +88,7 @@ export async function resolveBpms(tracks, onUpdate, onProgress, onLog) {
 
     // Tier 0: Spotify Audio Features (already fetched by loadPlaylistTracks, no API call needed)
     if (track.spotifyBpm) {
-      onLog?.({ name: track.name, artist, bpm: track.spotifyBpm, spotify: 'pass' })
+      onLog?.({ name: track.name, artist, bpm: track.spotifyBpm, spotify: 'pass', getsongbpm: '—', deezer: '—' })
       onUpdate(track.id, track.spotifyBpm, 'spotify', false)
       storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm: track.spotifyBpm, source: 'spotify' })
       onProgress(++done, toResolve.length)
@@ -102,7 +102,7 @@ export async function resolveBpms(tracks, onUpdate, onProgress, onLog) {
     const gResult = await lookupGetSongBpm(track.name, artist)
 
     if (gResult.bpm) {
-      onLog?.({ name: track.name, artist, bpm: gResult.bpm, spotify: 'fail', getsongbpm: 'pass' })
+      onLog?.({ name: track.name, artist, bpm: gResult.bpm, spotify: 'fail', getsongbpm: 'pass', deezer: '—' })
       onUpdate(track.id, gResult.bpm, 'getsongbpm', false)
       storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm: gResult.bpm, source: 'getsongbpm' })
     } else {

--- a/frontend/src/pages/SpotifyExplorer.jsx
+++ b/frontend/src/pages/SpotifyExplorer.jsx
@@ -95,21 +95,16 @@ function LogEntry({ e }) {
         <span style={{ color: e.bpm ? '#4ade80' : '#9ab0d0', fontWeight: 500 }}>{bpmText}</span>
       </div>
       <div style={{ fontSize: 10, fontFamily: 'monospace', display: 'flex', gap: 14 }}>
-        {e.spotify && (
-          <span style={{ color: '#374d66' }}>
-            spotify: <span style={{ color: e.spotify === 'pass' ? '#4ade80' : '#f44336' }}>{e.spotify}</span>
-          </span>
-        )}
-        {e.getsongbpm && (
-          <span style={{ color: '#374d66' }}>
-            getsong.co: <span style={{ color: e.getsongbpm === 'pass' ? '#4ade80' : '#f44336' }}>{e.getsongbpm}</span>
-          </span>
-        )}
-        {e.deezer && (
-          <span style={{ color: '#374d66' }}>
-            deezer: <span style={{ color: e.deezer === 'pass' ? '#4ade80' : '#f44336' }}>{e.deezer}</span>
-          </span>
-        )}
+        {['spotify', 'getsongbpm', 'deezer'].map(key => {
+          const val = e[key]
+          const label = key === 'getsongbpm' ? 'getsong.co' : key
+          const color = val === 'pass' ? '#4ade80' : val === 'fail' ? '#f44336' : '#374d66'
+          return (
+            <span key={key} style={{ color: '#374d66' }}>
+              {label}: <span style={{ color }}>{val ?? '—'}</span>
+            </span>
+          )
+        })}
       </div>
     </div>
   )


### PR DESCRIPTION
Every log entry now renders spotify / getsong.co / deezer regardless of which tier resolved the track. Services that were never tried because an earlier tier succeeded show — in muted colour instead of being hidden.

https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw