### PR TITLE
cal: set lang=en on month picker inputs

### DIFF
--- a/frontend/src/pages/Calendar.jsx
+++ b/frontend/src/pages/Calendar.jsx
@@ -445,13 +445,13 @@ export default function Calendar() {
             <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap', marginBottom: 16 }}>
               <div>
                 <label className="label">from</label>
-                <input type="month" className="input"
+                <input type="month" lang="en" className="input"
                   value={toMonthInput(settings?.start_year, settings?.start_month)}
                   onChange={e => updateRange('start', e.target.value)} />
               </div>
               <div>
                 <label className="label">to</label>
-                <input type="month" className="input"
+                <input type="month" lang="en" className="input"
                   value={toMonthInput(settings?.end_year, settings?.end_month)}
                   onChange={e => updateRange('end', e.target.value)} />
               </div>


### PR DESCRIPTION
## Summary

- Adds `lang="en"` to both `<input type="month">` elements in the settings panel
- The browser's native date picker inherits the `lang` attribute and renders month names/labels in English, overriding the OS/browser locale

https://claude.ai/code/session_0138u48xPLQoym6hUGeyJEU9

---
_Generated by [Claude Code](https://claude.ai/code/session_0138u48xPLQoym6hUGeyJEU9)_