### PR TITLE
Fix 0-track scan bug; add spotify raw BPM as third log line

### DIFF
--- a/backend/routers/scan.py
+++ b/backend/routers/scan.py
@@ -37,6 +37,7 @@ class ScanTrack(BaseModel):
     artist: str
     album: str = ""
     spotify_bpm: int | None = None
+    spotify_raw: int | None = None
 
 
 class ScanStartRequest(BaseModel):
@@ -106,7 +107,7 @@ def _do_scan(tracks: list[ScanTrack]) -> None:
 
         # Tier 0: Spotify Audio Features (pre-fetched by the browser, no external call)
         if track.spotify_bpm:
-            _append_log(track.name, track.artist, track.spotify_bpm, spotify="pass", getsongbpm="—", deezer="—")
+            _append_log(track.name, track.artist, track.spotify_bpm, spotify="pass", getsongbpm="—", deezer="—", spotifyRaw=track.spotify_bpm)
             _store_bpm_db(track, track.spotify_bpm, "spotify")
             _state["tracks_done"] += 1
             continue
@@ -129,7 +130,7 @@ def _do_scan(tracks: list[ScanTrack]) -> None:
                     bpm = None
 
         if bpm:
-            _append_log(track.name, track.artist, bpm, spotify="fail", getsongbpm="pass", deezer="—")
+            _append_log(track.name, track.artist, bpm, spotify="fail", getsongbpm="pass", deezer="—", spotifyRaw=track.spotify_raw)
             _store_bpm_db(track, bpm, "getsongbpm")
         else:
             # Tier 3: Deezer
@@ -160,10 +161,10 @@ def _do_scan(tracks: list[ScanTrack]) -> None:
                         pass
 
             if deezer_bpm:
-                _append_log(track.name, track.artist, deezer_bpm, spotify="fail", getsongbpm="fail", deezer="pass")
+                _append_log(track.name, track.artist, deezer_bpm, spotify="fail", getsongbpm="fail", deezer="pass", spotifyRaw=track.spotify_raw)
                 _store_bpm_db(track, deezer_bpm, "deezer")
             else:
-                _append_log(track.name, track.artist, None, spotify="fail", getsongbpm="fail", deezer="fail")
+                _append_log(track.name, track.artist, None, spotify="fail", getsongbpm="fail", deezer="fail", spotifyRaw=track.spotify_raw)
                 _store_bpm_db(track, 0, "not_found")
 
         _state["tracks_done"] += 1

--- a/frontend/src/bpm.js
+++ b/frontend/src/bpm.js
@@ -88,7 +88,7 @@ export async function resolveBpms(tracks, onUpdate, onProgress, onLog) {
 
     // Tier 0: Spotify Audio Features (already fetched by loadPlaylistTracks, no API call needed)
     if (track.spotifyBpm) {
-      onLog?.({ name: track.name, artist, bpm: track.spotifyBpm, spotify: 'pass', getsongbpm: '—', deezer: '—' })
+      onLog?.({ name: track.name, artist, bpm: track.spotifyBpm, spotify: 'pass', getsongbpm: '—', deezer: '—', spotifyRaw: track.spotifyRaw })
       onUpdate(track.id, track.spotifyBpm, 'spotify', false)
       storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm: track.spotifyBpm, source: 'spotify' })
       onProgress(++done, toResolve.length)
@@ -102,7 +102,7 @@ export async function resolveBpms(tracks, onUpdate, onProgress, onLog) {
     const gResult = await lookupGetSongBpm(track.name, artist)
 
     if (gResult.bpm) {
-      onLog?.({ name: track.name, artist, bpm: gResult.bpm, spotify: 'fail', getsongbpm: 'pass', deezer: '—' })
+      onLog?.({ name: track.name, artist, bpm: gResult.bpm, spotify: 'fail', getsongbpm: 'pass', deezer: '—', spotifyRaw: track.spotifyRaw ?? null })
       onUpdate(track.id, gResult.bpm, 'getsongbpm', false)
       storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm: gResult.bpm, source: 'getsongbpm' })
     } else {
@@ -111,11 +111,11 @@ export async function resolveBpms(tracks, onUpdate, onProgress, onLog) {
       const dResult = await lookupDeezer(track.name, artist)
 
       if (dResult.bpm) {
-        onLog?.({ name: track.name, artist, bpm: dResult.bpm, spotify: 'fail', getsongbpm: 'fail', deezer: 'pass' })
+        onLog?.({ name: track.name, artist, bpm: dResult.bpm, spotify: 'fail', getsongbpm: 'fail', deezer: 'pass', spotifyRaw: track.spotifyRaw ?? null })
         onUpdate(track.id, dResult.bpm, 'deezer', false)
         storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm: dResult.bpm, source: 'deezer' })
       } else {
-        onLog?.({ name: track.name, artist, bpm: null, spotify: 'fail', getsongbpm: 'fail', deezer: 'fail' })
+        onLog?.({ name: track.name, artist, bpm: null, spotify: 'fail', getsongbpm: 'fail', deezer: 'fail', spotifyRaw: track.spotifyRaw ?? null })
         onUpdate(track.id, null, 'failed', false)
         storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm: 0, source: 'not_found' })
       }

--- a/frontend/src/pages/SpotifyExplorer.jsx
+++ b/frontend/src/pages/SpotifyExplorer.jsx
@@ -106,6 +106,13 @@ function LogEntry({ e }) {
           )
         })}
       </div>
+      {'spotifyRaw' in e && (
+        <div style={{ fontSize: 10, fontFamily: 'monospace', color: '#374d66' }}>
+          spotify raw: <span style={{ color: e.spotifyRaw > 0 ? '#4ade80' : e.spotifyRaw === 0 ? '#f44336' : '#9ab0d0' }}>
+            {e.spotifyRaw != null ? `${e.spotifyRaw} bpm` : 'null'}
+          </span>
+        </div>
+      )}
     </div>
   )
 }
@@ -303,6 +310,7 @@ export default function SpotifyExplorer() {
     const tempoMap = new Map(
       features.filter(f => f?.tempo > 0).map(f => [f.id, Math.round(f.tempo)])
     )
+    const rawMap = new Map(features.filter(Boolean).map(f => [f.id, f.tempo ? Math.round(f.tempo) : 0]))
 
     // Phase 2: hand off to backend for persistent BPM resolution
     const scanTracks = allTracks.map(t => ({
@@ -311,6 +319,7 @@ export default function SpotifyExplorer() {
       artist:      t.artists[0]?.name ?? '',
       album:       t.album?.name ?? '',
       spotify_bpm: tempoMap.get(t.id) ?? null,
+      spotify_raw: rawMap.has(t.id) ? rawMap.get(t.id) : null,
     }))
 
     try {

--- a/frontend/src/spotify.js
+++ b/frontend/src/spotify.js
@@ -147,7 +147,7 @@ export async function getPlaylistTracks(playlistId, onProgress) {
   let url = `/playlists/${encodeURIComponent(playlistId)}/items?limit=100`
   while (url) {
     const data = await apiGet(url)
-    const valid = data.items.map(i => i?.item).filter(t => t?.id && !t.is_local)
+    const valid = data.items.map(i => i?.track).filter(t => t?.id && !t.is_local)
     tracks.push(...valid)
     onProgress?.('tracks', tracks.length)
     url = data.next
@@ -164,6 +164,7 @@ export async function loadPlaylistTracks(playlistId, onProgress) {
   const tempoMap = new Map(
     features.filter(f => f?.tempo > 0).map(f => [f.id, Math.round(f.tempo)])
   )
+  const rawMap = new Map(features.filter(Boolean).map(f => [f.id, f.tempo ? Math.round(f.tempo) : 0]))
   return tracks.map(t => ({
     id:          t.id,
     name:        t.name,
@@ -174,5 +175,6 @@ export async function loadPlaylistTracks(playlistId, onProgress) {
     bpmSource:   null,
     bpmCached:   false,
     spotifyBpm:  tempoMap.get(t.id) ?? null,
+    spotifyRaw:  rawMap.has(t.id) ? rawMap.get(t.id) : null,
   }))
 }


### PR DESCRIPTION
## Root cause fix

`getPlaylistTracks` was using `i?.item` to unwrap each playlist item — the correct property is `i?.track`. This meant every playlist returned 0 valid tracks, so the scan was always sending an empty list to the backend.

## Third log line

Each log entry now shows a `spotify raw:` line with the value directly from Spotify's audio features endpoint:

| Value | Meaning | Colour |
|-------|---------|--------|
| `142 bpm` | Spotify has a real BPM for this track | green |
| `0 bpm` | Feature object returned but `tempo = 0` | red |
| `null` | Track not in Spotify's audio features DB | muted |

This makes it easy to tell whether the Spotify tier is failing because audio features are missing entirely vs. returning 0.

## Files changed
- `frontend/src/spotify.js` — `i?.item` → `i?.track`; `loadPlaylistTracks` now also builds `rawMap` and sets `spotifyRaw` on each track
- `frontend/src/pages/SpotifyExplorer.jsx` — `startScanAll` passes `spotify_raw`; `LogEntry` renders third line
- `frontend/src/bpm.js` — all `onLog` calls pass `spotifyRaw`
- `backend/routers/scan.py` — `ScanTrack` accepts `spotify_raw`; all `_append_log` calls pass it through

https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw

---
_Generated by [Claude Code](https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw)_