### PR TITLE
Diagnose 0-track scan failures with per-playlist error count

### DIFF
--- a/frontend/src/pages/SpotifyExplorer.jsx
+++ b/frontend/src/pages/SpotifyExplorer.jsx
@@ -297,12 +297,17 @@ export default function SpotifyExplorer() {
     try {
       // Phase 1: fetch raw tracks from all playlists in the browser (needs OAuth token)
       const seen = new Map()  // spotify_id → raw Spotify track object
+      let fetchErrors = 0
+      let firstError = ''
       for (let i = 0; i < playlists.length; i++) {
         if (scanCancelRef.current) { setScanMode(null); return }
         try {
           const raw = await spotify.getPlaylistTracks(playlists[i].id)
           for (const t of raw) { if (!seen.has(t.id)) seen.set(t.id, t) }
-        } catch { /* skip failed playlist */ }
+        } catch (e) {
+          fetchErrors++
+          if (!firstError) firstError = e.message
+        }
         setScanProgress(prev => ({ ...prev, playlistsDone: i + 1, tracksTotal: seen.size }))
       }
 
@@ -312,7 +317,10 @@ export default function SpotifyExplorer() {
       setScanProgress(prev => ({ ...prev, tracksTotal: allTracks.length }))
 
       if (!allTracks.length) {
-        setError('No tracks found — make sure your playlists contain tracks and your Spotify session is active')
+        const detail = fetchErrors
+          ? `${fetchErrors}/${playlists.length} playlists failed (${firstError}) — your Spotify session may have expired, try reconnecting`
+          : 'all playlists appear to be empty'
+        setError(`No tracks found — ${detail}`)
         setScanMode(null)
         return
       }

--- a/frontend/src/spotify.js
+++ b/frontend/src/spotify.js
@@ -147,7 +147,7 @@ export async function getPlaylistTracks(playlistId, onProgress) {
   let url = `/playlists/${encodeURIComponent(playlistId)}/items?limit=100`
   while (url) {
     const data = await apiGet(url)
-    const valid = data.items.map(i => i?.track).filter(t => t?.id && !t.is_local)
+    const valid = (data.items ?? []).map(i => i?.track).filter(t => t?.id && !t.is_local)
     tracks.push(...valid)
     onProgress?.('tracks', tracks.length)
     url = data.next


### PR DESCRIPTION
The "No tracks found" error was too generic to diagnose. This PR makes the failure visible:

- Counts how many playlists threw errors vs succeeded
- Captures the first error message (e.g. "Not authenticated", "Session expired", "Spotify error 403")
- Error now reads: `No tracks found — X/Y playlists failed (Not authenticated) — your Spotify session may have expired, try reconnecting`
- Or if no errors but still 0 tracks: `No tracks found — all playlists appear to be empty`

Also adds `(data.items ?? [])` null guard in `getPlaylistTracks` — Spotify can return `items: null` for empty/unavailable playlists, which previously threw a silent TypeError.

https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw

---
_Generated by [Claude Code](https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw)_