### PR TITLE
Bump SpotifyExplorer to v4.7

### DIFF
--- a/frontend/src/pages/SpotifyExplorer.jsx
+++ b/frontend/src/pages/SpotifyExplorer.jsx
@@ -441,7 +441,7 @@ export default function SpotifyExplorer() {
           <span className="topbar-title">spt</span>
         </div>
         <div className="topbar-right">
-          <span className="topbar-version">v4.6</span>
+          <span className="topbar-version">v4.7</span>
         </div>
       </div>
       <div className="page">


### PR DESCRIPTION
Bumps the topbar version from v4.6 to v4.7 to reflect the changes landed since #160.

https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw

---
_Generated by [Claude Code](https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw)_