### PR TITLE
Serve index.html with no-cache to prevent stale JS after deploy

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -115,12 +115,14 @@ GAMES_DIR = Path(__file__).parent.parent / "games"
 # mount.  Starlette stops at the first full match in registration order, so
 # without these the mount would intercept /games/ and serve the old static
 # games/index.html instead of the React SPA.
+NO_CACHE = {"Cache-Control": "no-cache, no-store, must-revalidate"}
+
 @app.get("/games")
 @app.get("/games/")
 async def games_page():
     index = FRONTEND_DIST / "index.html"
     if index.exists():
-        return FileResponse(index)
+        return FileResponse(index, headers=NO_CACHE)
     return {"status": "api running"}
 
 
@@ -152,7 +154,7 @@ async def info():
 async def root():
     index = FRONTEND_DIST / "index.html"
     if index.exists():
-        return FileResponse(index)
+        return FileResponse(index, headers=NO_CACHE)
     return {"status": "api running"}
 
 
@@ -168,5 +170,5 @@ async def spa_fallback(full_path: str):
         pass  # path traversal attempt — fall through to index.html
     index = FRONTEND_DIST / "index.html"
     if index.exists():
-        return FileResponse(index)
+        return FileResponse(index, headers=NO_CACHE)
     return {"status": "api running"}


### PR DESCRIPTION
Vite JS/CSS assets use content hashes in filenames so they're safe to cache forever. But index.html (which references those hashes) must always be fetched fresh, otherwise browsers run old code after a redeploy. Add Cache-Control: no-cache on all three FileResponse(index) paths in main.py.

https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw