### PR TITLE
Add raw Spotify diagnostic when scan finds 0 tracks

### DIFF
--- a/frontend/src/pages/SpotifyExplorer.jsx
+++ b/frontend/src/pages/SpotifyExplorer.jsx
@@ -317,9 +317,17 @@ export default function SpotifyExplorer() {
       setScanProgress(prev => ({ ...prev, tracksTotal: allTracks.length }))
 
       if (!allTracks.length) {
-        const detail = fetchErrors
-          ? `${fetchErrors}/${playlists.length} playlists failed (${firstError}) — your Spotify session may have expired, try reconnecting`
-          : 'all playlists appear to be empty'
+        let detail
+        if (fetchErrors) {
+          detail = `${fetchErrors}/${playlists.length} playlists failed — ${firstError}`
+        } else if (playlists.length > 0) {
+          const diag = await spotify.getPlaylistDiag(playlists[0].id)
+          detail = diag.error
+            ? `0 errors but 0 tracks; diagnostic on playlist[0] failed: ${diag.error}`
+            : `0 errors but 0 tracks; diagnostic on playlist[0]: total=${diag.total}, items_returned=${diag.items_returned}, item0_keys=[${diag.item0_keys}], track_id=${diag.track_id}, track_is_local=${diag.track_is_local}`
+        } else {
+          detail = 'playlist list is empty'
+        }
         setError(`No tracks found — ${detail}`)
         setScanMode(null)
         return

--- a/frontend/src/spotify.js
+++ b/frontend/src/spotify.js
@@ -120,6 +120,22 @@ export async function getMe() {
   return apiGet('/me')
 }
 
+export async function getPlaylistDiag(playlistId) {
+  try {
+    const data = await apiGet(`/playlists/${encodeURIComponent(playlistId)}/items?limit=3`)
+    const item0 = data.items?.[0] ?? null
+    return {
+      total:          data.total,
+      items_returned: data.items?.length ?? 0,
+      item0_keys:     item0 ? Object.keys(item0).join(', ') : '(no items)',
+      track_id:       item0?.track?.id ?? null,
+      track_is_local: item0?.track?.is_local ?? null,
+    }
+  } catch (e) {
+    return { error: e.message }
+  }
+}
+
 export async function getAudioFeatures(ids) {
   const features = []
   for (let i = 0; i < ids.length; i += 100) {


### PR DESCRIPTION
When the scan finishes with 0 tracks and no fetch errors, it now runs a raw diagnostic call on the first playlist and shows the full API response shape in the error message:

```
No tracks found — 0 errors but 0 tracks; diagnostic on playlist[0]:
  total=47, items_returned=3, item0_keys=[added_at, added_by, is_local, track, ...],
  track_id=3n3Ppam7vgaVa1iaRUIOKE, track_is_local=false
```

This will tell us immediately whether:
- The `track` field exists and has the right shape → the filter condition is wrong
- `track` is null for all items → Spotify returning unavailable tracks
- The field is named differently → need to update the mapping
- `items_returned=0` despite `total>0` → paging/API issue
- The diagnostic itself throws → auth/network error

https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw

---
_Generated by [Claude Code](https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw)_