### PR TITLE
Fix playlist track extraction: use i?.item not i?.track

### DIFF
--- a/frontend/src/spotify.js
+++ b/frontend/src/spotify.js
@@ -128,8 +128,8 @@ export async function getPlaylistDiag(playlistId) {
       total:          data.total,
       items_returned: data.items?.length ?? 0,
       item0_keys:     item0 ? Object.keys(item0).join(', ') : '(no items)',
-      track_id:       item0?.track?.id ?? null,
-      track_is_local: item0?.track?.is_local ?? null,
+      track_id:       item0?.item?.id ?? null,
+      track_is_local: item0?.item?.is_local ?? null,
     }
   } catch (e) {
     return { error: e.message }
@@ -163,7 +163,7 @@ export async function getPlaylistTracks(playlistId, onProgress) {
   let url = `/playlists/${encodeURIComponent(playlistId)}/items?limit=100`
   while (url) {
     const data = await apiGet(url)
-    const valid = (data.items ?? []).map(i => i?.track).filter(t => t?.id && !t.is_local)
+    const valid = (data.items ?? []).map(i => i?.item).filter(t => t?.id && !t.is_local)
     tracks.push(...valid)
     onProgress?.('tracks', tracks.length)
     url = data.next


### PR DESCRIPTION
## Root cause confirmed

The diagnostic added in PR #174 revealed the actual Spotify API response shape:

```
item0_keys=[added_at, added_by, is_local, primary_color, item, video_thumbnail]
```

The track is in the `item` field, **not** `track`. PR #168 changed `i?.item` → `i?.track` which was wrong — `i?.item` was correct all along for the `/playlists/{id}/items` endpoint.

## Fix

Reverts `i?.track` back to `i?.item` in `getPlaylistTracks`.

Also fixes the `getPlaylistDiag` function to check `item0?.item?.id` instead of `item0?.track?.id` so it correctly reports the track ID in future diagnostics.

https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw

---
_Generated by [Claude Code](https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw)_