### PR TITLE
spt: remove Spotify audio features tier (deprecated)

### DIFF
--- a/backend/routers/bpm.py
+++ b/backend/routers/bpm.py
@@ -25,14 +25,12 @@ def bpm_stats(db: Session = Depends(get_db)):
     from sqlalchemy import func, case
     row = db.query(
         func.count().label("total"),
-        func.sum(case((models.TrackBpm.source == "spotify",    1), else_=0)).label("spotify"),
         func.sum(case((models.TrackBpm.source == "getsongbpm", 1), else_=0)).label("getsongbpm"),
         func.sum(case((models.TrackBpm.source == "deezer",     1), else_=0)).label("deezer"),
         func.sum(case((models.TrackBpm.source == "not_found",  1), else_=0)).label("not_found"),
     ).one()
     return {
         "total":      row.total      or 0,
-        "spotify":    row.spotify    or 0,
         "getsongbpm": row.getsongbpm or 0,
         "deezer":     row.deezer     or 0,
         "not_found":  row.not_found  or 0,

--- a/backend/routers/scan.py
+++ b/backend/routers/scan.py
@@ -36,8 +36,6 @@ class ScanTrack(BaseModel):
     name: str
     artist: str
     album: str = ""
-    spotify_bpm: int | None = None
-    spotify_raw: int | None = None
 
 
 class ScanStartRequest(BaseModel):
@@ -105,14 +103,7 @@ def _do_scan(tracks: list[ScanTrack]) -> None:
 
     for track in to_resolve:
 
-        # Tier 0: Spotify Audio Features (pre-fetched by the browser, no external call)
-        if track.spotify_bpm:
-            _append_log(track.name, track.artist, track.spotify_bpm, spotify="pass", getsongbpm="—", deezer="—", spotifyRaw=track.spotify_bpm)
-            _store_bpm_db(track, track.spotify_bpm, "spotify")
-            _state["tracks_done"] += 1
-            continue
-
-        # Tier 2: getsong.co (rate-limited)
+        # Tier 1: getsong.co (rate-limited)
         if need_delay:
             time.sleep(_GETSONG_DELAY)
         need_delay = True
@@ -130,10 +121,10 @@ def _do_scan(tracks: list[ScanTrack]) -> None:
                     bpm = None
 
         if bpm:
-            _append_log(track.name, track.artist, bpm, spotify="fail", getsongbpm="pass", deezer="—", spotifyRaw=track.spotify_raw)
+            _append_log(track.name, track.artist, bpm, getsongbpm="pass", deezer="—")
             _store_bpm_db(track, bpm, "getsongbpm")
         else:
-            # Tier 3: Deezer
+            # Tier 2: Deezer
             time.sleep(_DEEZER_DELAY)
             results = _deezer_search(track.name, track.artist)
             if not results:
@@ -161,10 +152,10 @@ def _do_scan(tracks: list[ScanTrack]) -> None:
                         pass
 
             if deezer_bpm:
-                _append_log(track.name, track.artist, deezer_bpm, spotify="fail", getsongbpm="fail", deezer="pass", spotifyRaw=track.spotify_raw)
+                _append_log(track.name, track.artist, deezer_bpm, getsongbpm="fail", deezer="pass")
                 _store_bpm_db(track, deezer_bpm, "deezer")
             else:
-                _append_log(track.name, track.artist, None, spotify="fail", getsongbpm="fail", deezer="fail", spotifyRaw=track.spotify_raw)
+                _append_log(track.name, track.artist, None, getsongbpm="fail", deezer="fail")
                 _store_bpm_db(track, 0, "not_found")
 
         _state["tracks_done"] += 1

--- a/frontend/src/bpm.js
+++ b/frontend/src/bpm.js
@@ -86,36 +86,27 @@ export async function resolveBpms(tracks, onUpdate, onProgress, onLog) {
   for (const track of toResolve) {
     const artist = track.artists[0]?.name ?? ''
 
-    // Tier 0: Spotify Audio Features (already fetched by loadPlaylistTracks, no API call needed)
-    if (track.spotifyBpm) {
-      onLog?.({ name: track.name, artist, bpm: track.spotifyBpm, spotify: 'pass', getsongbpm: '—', deezer: '—', spotifyRaw: track.spotifyRaw })
-      onUpdate(track.id, track.spotifyBpm, 'spotify', false)
-      storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm: track.spotifyBpm, source: 'spotify' })
-      onProgress(++done, toResolve.length)
-      continue
-    }
-
-    // Tier 2: getsong.co (rate-limited)
+    // Tier 1: getsong.co (rate-limited)
     if (needDelay) await new Promise(r => setTimeout(r, GETSONG_DELAY))
     needDelay = true
 
     const gResult = await lookupGetSongBpm(track.name, artist)
 
     if (gResult.bpm) {
-      onLog?.({ name: track.name, artist, bpm: gResult.bpm, spotify: 'fail', getsongbpm: 'pass', deezer: '—', spotifyRaw: track.spotifyRaw ?? null })
+      onLog?.({ name: track.name, artist, bpm: gResult.bpm, getsongbpm: 'pass', deezer: '—' })
       onUpdate(track.id, gResult.bpm, 'getsongbpm', false)
       storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm: gResult.bpm, source: 'getsongbpm' })
     } else {
-      // Tier 3: Deezer
+      // Tier 2: Deezer
       await new Promise(r => setTimeout(r, DEEZER_DELAY))
       const dResult = await lookupDeezer(track.name, artist)
 
       if (dResult.bpm) {
-        onLog?.({ name: track.name, artist, bpm: dResult.bpm, spotify: 'fail', getsongbpm: 'fail', deezer: 'pass', spotifyRaw: track.spotifyRaw ?? null })
+        onLog?.({ name: track.name, artist, bpm: dResult.bpm, getsongbpm: 'fail', deezer: 'pass' })
         onUpdate(track.id, dResult.bpm, 'deezer', false)
         storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm: dResult.bpm, source: 'deezer' })
       } else {
-        onLog?.({ name: track.name, artist, bpm: null, spotify: 'fail', getsongbpm: 'fail', deezer: 'fail', spotifyRaw: track.spotifyRaw ?? null })
+        onLog?.({ name: track.name, artist, bpm: null, getsongbpm: 'fail', deezer: 'fail' })
         onUpdate(track.id, null, 'failed', false)
         storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm: 0, source: 'not_found' })
       }

--- a/frontend/src/pages/SpotifyExplorer.jsx
+++ b/frontend/src/pages/SpotifyExplorer.jsx
@@ -17,7 +17,6 @@ function fmtElapsed(ms) {
 }
 
 const BAR_SEGMENTS = [
-  { key: 'spotify',    color: '#1db954', label: 'spotify'    },
   { key: 'getsongbpm', color: '#4ade80', label: 'getsong.co' },
   { key: 'deezer',     color: '#a78bfa', label: 'deezer'     },
   { key: 'notFound',   color: '#f44336', label: 'not found'  },
@@ -25,9 +24,9 @@ const BAR_SEGMENTS = [
 ]
 
 function BpmBar({ stats }) {
-  const { total, spotify, getsongbpm, deezer, notFound, pending } = stats
+  const { total, getsongbpm, deezer, notFound, pending } = stats
   if (!total) return null
-  const counts = { spotify, getsongbpm, deezer, notFound, pending }
+  const counts = { getsongbpm, deezer, notFound, pending }
   const [hovered, setHovered] = useState(null)
 
   return (
@@ -50,7 +49,7 @@ function BpmBar({ stats }) {
       <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px 16px', marginTop: 8 }}>
         {BAR_SEGMENTS.map(seg => {
           const n = counts[seg.key]
-          if (!n && seg.key !== 'spotify' && seg.key !== 'getsongbpm' && seg.key !== 'deezer' && seg.key !== 'notFound') return null
+          if (!n && seg.key !== 'getsongbpm' && seg.key !== 'deezer' && seg.key !== 'notFound') return null
           const pct = Math.round((n / total) * 100)
           const isHovered = hovered === seg.key
           return (
@@ -82,7 +81,6 @@ function BpmBar({ stats }) {
   )
 }
 
-// One log entry per track: { name, artist, bpm, getsongbpm: 'pass'|'fail', deezer?: 'pass'|'fail' }
 function LogEntry({ e }) {
   const bpmText = e.bpm ? `${e.bpm} bpm` : '—'
   return (
@@ -95,7 +93,7 @@ function LogEntry({ e }) {
         <span style={{ color: e.bpm ? '#4ade80' : '#9ab0d0', fontWeight: 500 }}>{bpmText}</span>
       </div>
       <div style={{ fontSize: 10, fontFamily: 'monospace', display: 'flex', gap: 14 }}>
-        {['spotify', 'getsongbpm', 'deezer'].map(key => {
+        {['getsongbpm', 'deezer'].map(key => {
           const val = e[key]
           const label = key === 'getsongbpm' ? 'getsong.co' : key
           const color = val === 'pass' ? '#4ade80' : val === 'fail' ? '#f44336' : '#374d66'
@@ -106,13 +104,6 @@ function LogEntry({ e }) {
           )
         })}
       </div>
-      {'spotifyRaw' in e && (
-        <div style={{ fontSize: 10, fontFamily: 'monospace', color: '#374d66' }}>
-          spotify raw: <span style={{ color: e.spotifyRaw > 0 ? '#4ade80' : e.spotifyRaw === 0 ? '#f44336' : '#9ab0d0' }}>
-            {e.spotifyRaw != null ? `${e.spotifyRaw} bpm` : 'null'}
-          </span>
-        </div>
-      )}
     </div>
   )
 }
@@ -333,24 +324,12 @@ export default function SpotifyExplorer() {
         return
       }
 
-      // Phase 1.5: batch-fetch Spotify audio features for all unique tracks (one call per 100)
-      const features = await spotify.getAudioFeatures(allTracks.map(t => t.id))
-
-      if (scanCancelRef.current) { setScanMode(null); return }
-
-      const tempoMap = new Map(
-        features.filter(f => f?.tempo > 0).map(f => [f.id, Math.round(f.tempo)])
-      )
-      const rawMap = new Map(features.filter(Boolean).map(f => [f.id, f.tempo ? Math.round(f.tempo) : 0]))
-
       // Phase 2: hand off to backend for persistent BPM resolution
       const scanTracks = allTracks.map(t => ({
-        spotify_id:  t.id,
-        name:        t.name,
-        artist:      t.artists[0]?.name ?? '',
-        album:       t.album?.name ?? '',
-        spotify_bpm: tempoMap.get(t.id) ?? null,
-        spotify_raw: rawMap.has(t.id) ? rawMap.get(t.id) : null,
+        spotify_id: t.id,
+        name:       t.name,
+        artist:     t.artists[0]?.name ?? '',
+        album:      t.album?.name ?? '',
       }))
 
       const res = await fetch('/api/bpm/scan/start', {
@@ -409,12 +388,11 @@ export default function SpotifyExplorer() {
 
   const bpmStats = useMemo(() => {
     if (!tracks || !tracks.length) return null
-    const spotify    = tracks.filter(t => t.bpmSource === 'spotify').length
     const getsongbpm = tracks.filter(t => t.bpmSource === 'getsongbpm').length
     const deezer     = tracks.filter(t => t.bpmSource === 'deezer').length
     const notFound   = tracks.filter(t => t.bpmSource === 'failed').length
     const pending    = tracks.filter(t => !t.bpmSource).length
-    return { total: tracks.length, spotify, getsongbpm, deezer, notFound, pending }
+    return { total: tracks.length, getsongbpm, deezer, notFound, pending }
   }, [tracks])
 
   const displayedTracks = useMemo(() => {
@@ -432,7 +410,6 @@ export default function SpotifyExplorer() {
 
   const globalBarStats = globalStats?.total > 0 ? {
     total:      globalStats.total,
-    spotify:    globalStats.spotify    ?? 0,
     getsongbpm: globalStats.getsongbpm ?? 0,
     deezer:     globalStats.deezer     ?? 0,
     notFound:   globalStats.not_found  ?? 0,
@@ -449,7 +426,7 @@ export default function SpotifyExplorer() {
           <span className="topbar-title">spt</span>
         </div>
         <div className="topbar-right">
-          <span className="topbar-version">v4.7</span>
+          <span className="topbar-version">v4.8</span>
         </div>
       </div>
       <div className="page">
@@ -625,7 +602,6 @@ export default function SpotifyExplorer() {
                 </div>
                 <div style={{ display: 'flex', gap: 16, marginTop: 12, flexWrap: 'wrap' }}>
                   {[
-                    { color: '#1db954', label: 'spotify' },
                     { color: '#4ade80', label: 'getsong.co' },
                     { color: '#a78bfa', label: 'deezer' },
                     { color: '#f44336', label: 'not found' },

--- a/frontend/src/spotify.js
+++ b/frontend/src/spotify.js
@@ -136,17 +136,6 @@ export async function getPlaylistDiag(playlistId) {
   }
 }
 
-export async function getAudioFeatures(ids) {
-  const features = []
-  for (let i = 0; i < ids.length; i += 100) {
-    try {
-      const data = await apiGet(`/audio-features?ids=${ids.slice(i, i + 100).join(',')}`)
-      features.push(...(data.audio_features ?? []))
-    } catch { /* skip failed batch */ }
-  }
-  return features
-}
-
 export async function getPlaylists(max = Infinity) {
   const items = []
   let url = `/me/playlists?limit=${Math.min(max, 50)}`
@@ -173,14 +162,8 @@ export async function getPlaylistTracks(playlistId, onProgress) {
 
 // ── High-level helpers ────────────────────────────────────────
 
-// Returns track metadata including Spotify tempo as spotifyBpm.
 export async function loadPlaylistTracks(playlistId, onProgress) {
   const tracks = await getPlaylistTracks(playlistId, onProgress)
-  const features = await getAudioFeatures(tracks.map(t => t.id))
-  const tempoMap = new Map(
-    features.filter(f => f?.tempo > 0).map(f => [f.id, Math.round(f.tempo)])
-  )
-  const rawMap = new Map(features.filter(Boolean).map(f => [f.id, f.tempo ? Math.round(f.tempo) : 0]))
   return tracks.map(t => ({
     id:          t.id,
     name:        t.name,
@@ -190,7 +173,5 @@ export async function loadPlaylistTracks(playlistId, onProgress) {
     bpm:         null,
     bpmSource:   null,
     bpmCached:   false,
-    spotifyBpm:  tempoMap.get(t.id) ?? null,
-    spotifyRaw:  rawMap.has(t.id) ? rawMap.get(t.id) : null,
   }))
 }


### PR DESCRIPTION
## Summary

- Removes the Spotify `/audio-features` BPM tier entirely — the endpoint is unavailable for apps created after November 2024 and returned `null` for every track
- BPM resolution now goes directly: DB cache → getsong.co → Deezer → not found
- Cleans up all related dead code: `getAudioFeatures`, `loadPlaylistTracks` audio feature fields, `spotify_bpm`/`spotify_raw` scan fields, the spotify segment in the progress bar, the spotify line in log entries, and the spotify counter in the stats endpoint
- Bumps spt to v4.8

https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw

---
_Generated by [Claude Code](https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw)_