### PR TITLE
spt: try Deezer before getsong.co

### DIFF
--- a/backend/routers/scan.py
+++ b/backend/routers/scan.py
@@ -103,59 +103,60 @@ def _do_scan(tracks: list[ScanTrack]) -> None:
 
     for track in to_resolve:
 
-        # Tier 1: getsong.co (rate-limited)
+        # Tier 2: Deezer (rate-limited)
         if need_delay:
-            time.sleep(_GETSONG_DELAY)
+            time.sleep(_DEEZER_DELAY)
         need_delay = True
         bpm = None
-        if api_key:
-            results = _getsong_results(api_key, track.name)
+
+        results = _deezer_search(track.name, track.artist)
+        if not results:
             cleaned = _clean_title(track.name)
-            if not results and cleaned != track.name:
-                results = _getsong_results(api_key, cleaned)
-            match = _pick_best(results, track.artist) if results else None
-            if match:
+            if cleaned != track.name:
+                results = _deezer_search(cleaned, track.artist)
+
+        deezer_bpm = None
+        if results:
+            deezer_track = _pick_deezer(results, track.artist)
+            if deezer_track:
                 try:
-                    bpm = round(float(match["tempo"]))
-                except (ValueError, TypeError):
-                    bpm = None
+                    r = httpx.get(
+                        f"https://api.deezer.com/track/{deezer_track['id']}",
+                        headers={"User-Agent": "endermatx/1.0 (https://matmaxx.org)"},
+                        timeout=10,
+                    )
+                    if r.is_success:
+                        val_raw = r.json().get("bpm")
+                        if val_raw:
+                            val = round(float(val_raw))
+                            if val > 0:
+                                deezer_bpm = val
+                except Exception:
+                    pass
 
-        if bpm:
-            _append_log(track.name, track.artist, bpm, getsongbpm="pass", deezer="—")
-            _store_bpm_db(track, bpm, "getsongbpm")
+        if deezer_bpm:
+            _append_log(track.name, track.artist, deezer_bpm, deezer="pass", getsongbpm="—")
+            _store_bpm_db(track, deezer_bpm, "deezer")
         else:
-            # Tier 2: Deezer
-            time.sleep(_DEEZER_DELAY)
-            results = _deezer_search(track.name, track.artist)
-            if not results:
+            # Tier 3: getsong.co
+            time.sleep(_GETSONG_DELAY)
+            if api_key:
+                results = _getsong_results(api_key, track.name)
                 cleaned = _clean_title(track.name)
-                if cleaned != track.name:
-                    results = _deezer_search(cleaned, track.artist)
-
-            deezer_bpm = None
-            if results:
-                deezer_track = _pick_deezer(results, track.artist)
-                if deezer_track:
+                if not results and cleaned != track.name:
+                    results = _getsong_results(api_key, cleaned)
+                match = _pick_best(results, track.artist) if results else None
+                if match:
                     try:
-                        r = httpx.get(
-                            f"https://api.deezer.com/track/{deezer_track['id']}",
-                            headers={"User-Agent": "endermatx/1.0 (https://matmaxx.org)"},
-                            timeout=10,
-                        )
-                        if r.is_success:
-                            val_raw = r.json().get("bpm")
-                            if val_raw:
-                                val = round(float(val_raw))
-                                if val > 0:
-                                    deezer_bpm = val
-                    except Exception:
-                        pass
+                        bpm = round(float(match["tempo"]))
+                    except (ValueError, TypeError):
+                        bpm = None
 
-            if deezer_bpm:
-                _append_log(track.name, track.artist, deezer_bpm, getsongbpm="fail", deezer="pass")
-                _store_bpm_db(track, deezer_bpm, "deezer")
+            if bpm:
+                _append_log(track.name, track.artist, bpm, deezer="fail", getsongbpm="pass")
+                _store_bpm_db(track, bpm, "getsongbpm")
             else:
-                _append_log(track.name, track.artist, None, getsongbpm="fail", deezer="fail")
+                _append_log(track.name, track.artist, None, deezer="fail", getsongbpm="fail")
                 _store_bpm_db(track, 0, "not_found")
 
         _state["tracks_done"] += 1

--- a/frontend/src/bpm.js
+++ b/frontend/src/bpm.js
@@ -24,24 +24,7 @@ async function storeBpm(entry) {
   } catch { /* non-fatal */ }
 }
 
-// ── Tier 2: GetSongBPM via backend proxy ─────────────────────
-
-async function lookupGetSongBpm(title, artist) {
-  try {
-    const params = new URLSearchParams({ title, artist })
-    const res = await fetch(`/api/bpm/getsongbpm?${params}`, {
-      signal: AbortSignal.timeout(12000),
-    })
-    const data = await res.json()
-    if (!res.ok) return { bpm: null, err: data?.detail ?? `HTTP ${res.status}` }
-    if (data.err) return { bpm: null, err: data.err, raw: data }
-    return { bpm: typeof data.bpm === 'number' ? data.bpm : null, raw: data }
-  } catch (e) {
-    return { bpm: null, err: e.message }
-  }
-}
-
-// ── Tier 3: Deezer (free, no auth) ───────────────────────────
+// ── Tier 2: Deezer (free, no auth) ───────────────────────────
 
 async function lookupDeezer(title, artist) {
   try {
@@ -58,10 +41,27 @@ async function lookupDeezer(title, artist) {
   }
 }
 
+// ── Tier 3: GetSongBPM via backend proxy ─────────────────────
+
+async function lookupGetSongBpm(title, artist) {
+  try {
+    const params = new URLSearchParams({ title, artist })
+    const res = await fetch(`/api/bpm/getsongbpm?${params}`, {
+      signal: AbortSignal.timeout(12000),
+    })
+    const data = await res.json()
+    if (!res.ok) return { bpm: null, err: data?.detail ?? `HTTP ${res.status}` }
+    if (data.err) return { bpm: null, err: data.err, raw: data }
+    return { bpm: typeof data.bpm === 'number' ? data.bpm : null, raw: data }
+  } catch (e) {
+    return { bpm: null, err: e.message }
+  }
+}
+
 // ── Main resolution entry point ───────────────────────────────
 
-const GETSONG_DELAY = 400  // ms between getsong.co calls
-const DEEZER_DELAY  = 400  // ms between Deezer calls
+const DEEZER_DELAY   = 400  // ms between Deezer calls
+const GETSONG_DELAY  = 400  // ms between getsong.co calls
 
 export async function resolveBpms(tracks, onUpdate, onProgress, onLog) {
   // Tier 1: DB batch lookup — real BPM entries used as cache; not_found entries retried
@@ -81,32 +81,32 @@ export async function resolveBpms(tracks, onUpdate, onProgress, onLog) {
   if (!toResolve.length) return
 
   let done = 0
-  let needDelay = false  // only delay before getsong.co/Deezer calls
+  let needDelay = false  // only delay before Deezer/getsong.co calls
 
   for (const track of toResolve) {
     const artist = track.artists[0]?.name ?? ''
 
-    // Tier 1: getsong.co (rate-limited)
-    if (needDelay) await new Promise(r => setTimeout(r, GETSONG_DELAY))
+    // Tier 2: Deezer (rate-limited)
+    if (needDelay) await new Promise(r => setTimeout(r, DEEZER_DELAY))
     needDelay = true
 
-    const gResult = await lookupGetSongBpm(track.name, artist)
+    const dResult = await lookupDeezer(track.name, artist)
 
-    if (gResult.bpm) {
-      onLog?.({ name: track.name, artist, bpm: gResult.bpm, getsongbpm: 'pass', deezer: '—' })
-      onUpdate(track.id, gResult.bpm, 'getsongbpm', false)
-      storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm: gResult.bpm, source: 'getsongbpm' })
+    if (dResult.bpm) {
+      onLog?.({ name: track.name, artist, bpm: dResult.bpm, deezer: 'pass', getsongbpm: '—' })
+      onUpdate(track.id, dResult.bpm, 'deezer', false)
+      storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm: dResult.bpm, source: 'deezer' })
     } else {
-      // Tier 2: Deezer
-      await new Promise(r => setTimeout(r, DEEZER_DELAY))
-      const dResult = await lookupDeezer(track.name, artist)
+      // Tier 3: getsong.co
+      await new Promise(r => setTimeout(r, GETSONG_DELAY))
+      const gResult = await lookupGetSongBpm(track.name, artist)
 
-      if (dResult.bpm) {
-        onLog?.({ name: track.name, artist, bpm: dResult.bpm, getsongbpm: 'fail', deezer: 'pass' })
-        onUpdate(track.id, dResult.bpm, 'deezer', false)
-        storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm: dResult.bpm, source: 'deezer' })
+      if (gResult.bpm) {
+        onLog?.({ name: track.name, artist, bpm: gResult.bpm, deezer: 'fail', getsongbpm: 'pass' })
+        onUpdate(track.id, gResult.bpm, 'getsongbpm', false)
+        storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm: gResult.bpm, source: 'getsongbpm' })
       } else {
-        onLog?.({ name: track.name, artist, bpm: null, getsongbpm: 'fail', deezer: 'fail' })
+        onLog?.({ name: track.name, artist, bpm: null, deezer: 'fail', getsongbpm: 'fail' })
         onUpdate(track.id, null, 'failed', false)
         storeBpm({ spotify_id: track.id, title: track.name, artist, album: track.album, bpm: 0, source: 'not_found' })
       }

--- a/frontend/src/pages/SpotifyExplorer.jsx
+++ b/frontend/src/pages/SpotifyExplorer.jsx
@@ -17,8 +17,8 @@ function fmtElapsed(ms) {
 }
 
 const BAR_SEGMENTS = [
-  { key: 'getsongbpm', color: '#4ade80', label: 'getsong.co' },
   { key: 'deezer',     color: '#a78bfa', label: 'deezer'     },
+  { key: 'getsongbpm', color: '#4ade80', label: 'getsong.co' },
   { key: 'notFound',   color: '#f44336', label: 'not found'  },
   { key: 'pending',    color: '#1a2840', label: 'pending'    },
 ]
@@ -49,7 +49,7 @@ function BpmBar({ stats }) {
       <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px 16px', marginTop: 8 }}>
         {BAR_SEGMENTS.map(seg => {
           const n = counts[seg.key]
-          if (!n && seg.key !== 'getsongbpm' && seg.key !== 'deezer' && seg.key !== 'notFound') return null
+          if (!n && seg.key !== 'deezer' && seg.key !== 'getsongbpm' && seg.key !== 'notFound') return null
           const pct = Math.round((n / total) * 100)
           const isHovered = hovered === seg.key
           return (
@@ -93,7 +93,7 @@ function LogEntry({ e }) {
         <span style={{ color: e.bpm ? '#4ade80' : '#9ab0d0', fontWeight: 500 }}>{bpmText}</span>
       </div>
       <div style={{ fontSize: 10, fontFamily: 'monospace', display: 'flex', gap: 14 }}>
-        {['getsongbpm', 'deezer'].map(key => {
+        {['deezer', 'getsongbpm'].map(key => {
           const val = e[key]
           const label = key === 'getsongbpm' ? 'getsong.co' : key
           const color = val === 'pass' ? '#4ade80' : val === 'fail' ? '#f44336' : '#374d66'
@@ -426,7 +426,7 @@ export default function SpotifyExplorer() {
           <span className="topbar-title">spt</span>
         </div>
         <div className="topbar-right">
-          <span className="topbar-version">v4.8</span>
+          <span className="topbar-version">v4.9</span>
         </div>
       </div>
       <div className="page">
@@ -602,8 +602,8 @@ export default function SpotifyExplorer() {
                 </div>
                 <div style={{ display: 'flex', gap: 16, marginTop: 12, flexWrap: 'wrap' }}>
                   {[
-                    { color: '#4ade80', label: 'getsong.co' },
                     { color: '#a78bfa', label: 'deezer' },
+                    { color: '#4ade80', label: 'getsong.co' },
                     { color: '#f44336', label: 'not found' },
                     { color: '#eef2ff', label: 'pending' },
                   ].map(({ color, label }) => (


### PR DESCRIPTION
## Summary

- Swaps BPM resolution order: Deezer is now tried first, getsong.co is the fallback
- Deezer is free with no API key requirement; getsong.co needs a key and has stricter rate limits, so it makes more sense as the fallback
- Log entries and progress bar now show `deezer` before `getsong.co`
- Bumps spt to v4.9

https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw

---
_Generated by [Claude Code](https://claude.ai/code/session_011nFPDSS9kawkfm1ThcQ1dw)_