### PR TITLE
block-hero: reduce medium and hard note density

### DIFF
--- a/frontend/src/pages/BlockHero.jsx
+++ b/frontend/src/pages/BlockHero.jsx
@@ -4,10 +4,10 @@ import { Link } from 'react-router-dom'
 // ─── Constants ────────────────────────────────────────────────────────────────
 const LOOK_AHEAD_S   = 2.1
 const HIT_PERFECT_S  = 0.065
-const HIT_GOOD_S     = 0.130
+const HIT_GOOD_S     = 0.150
 const SCORE_PERFECT  = 300
 const SCORE_GOOD     = 100
-const MISS_LIMITS    = { easy: 20, medium: 12, hard: 8 }
+const MISS_LIMITS    = { easy: 20, medium: 18, hard: 12 }
 const LANE_KEYS      = ['d', 'f', 'j', 'k']
 
 // Minecraft block colours: grass, dirt, stone, diamond
@@ -142,8 +142,8 @@ function generateChart(track) {
   const { beats, d } = track
   const cfg = {
     easy:   { step: 1.00, onProb: 0.58, dualProb: 0.05, minLaneGap: 2.0 },
-    medium: { step: 0.50, onProb: 0.62, dualProb: 0.22, minLaneGap: 1.0 },
-    hard:   { step: 0.25, onProb: 0.72, dualProb: 0.38, minLaneGap: 0.5 },
+    medium: { step: 0.75, onProb: 0.52, dualProb: 0.10, minLaneGap: 1.5 },
+    hard:   { step: 0.50, onProb: 0.62, dualProb: 0.22, minLaneGap: 0.75 },
   }[d]
 
   const notes = []


### PR DESCRIPTION
Hard was generating ~9 notes/sec (step=0.25 at 140 BPM) — unplayable on touch. Medium had frequent simultaneous presses (dualProb=0.22) on top of already dense 2.8 notes/sec.

- Hard: step 0.25→0.50, onProb 0.72→0.62, dualProb 0.38→0.22, minLaneGap 0.5→0.75 — now ~3.5 notes/sec with fewer doubles
- Medium: step 0.50→0.75, onProb 0.62→0.52, dualProb 0.22→0.10, minLaneGap 1.0→1.5 — now ~1.5 notes/sec, single-note focused
- Hit window: ±130ms→±150ms for all (touch friendlier)
- Miss limits: medium 12→18, hard 8→12