### PR TITLE
wmt: WM 2026 Tipp-Assistent

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import os
 from contextlib import asynccontextmanager
-from datetime import datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 
 _startup_time = datetime.now(timezone.utc)
@@ -17,11 +17,45 @@ from starlette.middleware.base import BaseHTTPMiddleware
 
 from .database import engine, Base, SessionLocal
 from .models import TtsEntry
-from .routers import tts, cal, idx, strings, bpm, scan
+from .routers import tts, cal, idx, strings, bpm, scan, wmt
+from .routers.wmt import do_refresh as _wmt_do_refresh, do_generate_summary as _wmt_do_summary
 
 logger = logging.getLogger(__name__)
 
 db_ready = False
+
+
+def _wmt_refresh() -> None:
+    """Refresh WM 2026 data every 30 minutes."""
+    db = SessionLocal()
+    try:
+        n = _wmt_do_refresh(db)
+        if n:
+            logger.info("WMT refresh: %d matches updated", n)
+        else:
+            logger.debug("WMT refresh: no changes")
+    except Exception as exc:
+        logger.error("WMT refresh failed: %s", exc)
+        db.rollback()
+    finally:
+        db.close()
+
+
+def _wmt_morning_summary() -> None:
+    """Generate morning summary at 06:00 for yesterday's matches."""
+    db = SessionLocal()
+    try:
+        yesterday = date.today() - timedelta(days=1)
+        content = _wmt_do_summary(db, yesterday)
+        if content:
+            logger.info("WMT morning summary generated for %s", yesterday)
+        else:
+            logger.debug("WMT morning summary: no finished matches for %s", yesterday)
+    except Exception as exc:
+        logger.error("WMT morning summary failed: %s", exc)
+        db.rollback()
+    finally:
+        db.close()
 
 
 def _close_open_tts_entries() -> None:
@@ -67,10 +101,21 @@ async def lifespan(app: FastAPI):
     scheduler.add_job(
         _close_open_tts_entries,
         CronTrigger(hour=23, minute=0),
-        misfire_grace_time=3600,  # run immediately on startup if missed within the last hour
+        misfire_grace_time=3600,
+    )
+    scheduler.add_job(
+        _wmt_refresh,
+        "interval",
+        minutes=30,
+        misfire_grace_time=3600,
+    )
+    scheduler.add_job(
+        _wmt_morning_summary,
+        CronTrigger(hour=6, minute=0),
+        misfire_grace_time=3600,
     )
     scheduler.start()
-    logger.info("EOD scheduler started — TTS entries will auto-close at 23:00")
+    logger.info("Scheduler started — TTS EOD at 23:00, WMT refresh every 30 min, WMT summary at 06:00")
 
     yield
 
@@ -107,6 +152,7 @@ app.include_router(idx.router, prefix="/api/idx", tags=["idx"])
 app.include_router(strings.router, prefix="/api/str", tags=["str"])
 app.include_router(bpm.router,      prefix="/api/bpm",      tags=["bpm"])
 app.include_router(scan.router,     prefix="/api/bpm/scan", tags=["scan"])
+app.include_router(wmt.router,      prefix="/api/wmt",      tags=["wmt"])
 
 FRONTEND_DIST = Path(__file__).parent.parent / "frontend" / "dist"
 GAMES_DIR = Path(__file__).parent.parent / "games"

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from sqlalchemy import BigInteger, Boolean, Column, DateTime, ForeignKey, Integer, String
+from sqlalchemy import BigInteger, Boolean, Column, Date, DateTime, Float, ForeignKey, Integer, String
 from sqlalchemy.dialects.postgresql import JSONB
 from .database import Base
 
@@ -81,3 +81,54 @@ class TrackBpm(Base):
     created_at = Column(DateTime, default=datetime.utcnow)
 
 
+# ── wmt ───────────────────────────────────────────────────────────────────────
+
+class WmtTeam(Base):
+    __tablename__ = "wmt_teams"
+    id             = Column(Integer, primary_key=True, autoincrement=True)
+    api_id         = Column(Integer, nullable=True, unique=True)
+    name           = Column(String, nullable=False)
+    short_name     = Column(String, nullable=True)
+    tla            = Column(String(5), nullable=True)
+    elo            = Column(Float, default=1700.0)
+    matches_played = Column(Integer, default=0)
+
+
+class WmtMatch(Base):
+    __tablename__ = "wmt_matches"
+    id           = Column(Integer, primary_key=True, autoincrement=True)
+    api_id       = Column(Integer, nullable=True, unique=True)
+    matchday     = Column(Integer, nullable=False)
+    stage        = Column(String, nullable=False)
+    group_name   = Column(String(10), nullable=True)
+    utc_date     = Column(DateTime, nullable=False)
+    home_team_id = Column(Integer, ForeignKey("wmt_teams.id"), nullable=True)
+    away_team_id = Column(Integer, ForeignKey("wmt_teams.id"), nullable=True)
+    status       = Column(String, default="SCHEDULED")
+    score_home   = Column(Integer, nullable=True)
+    score_away   = Column(Integer, nullable=True)
+    last_fetched = Column(DateTime, nullable=True)
+
+
+class WmtPrediction(Base):
+    __tablename__ = "wmt_predictions"
+    id              = Column(Integer, primary_key=True, autoincrement=True)
+    match_id        = Column(Integer, ForeignKey("wmt_matches.id"), nullable=False)
+    created_at      = Column(DateTime, default=datetime.utcnow)
+    home_win_prob   = Column(Float, nullable=False)
+    draw_prob       = Column(Float, nullable=False)
+    away_win_prob   = Column(Float, nullable=False)
+    pred_home_goals = Column(Float, nullable=False)
+    pred_away_goals = Column(Float, nullable=False)
+    home_elo        = Column(Float, nullable=True)
+    away_elo        = Column(Float, nullable=True)
+    reasoning       = Column(String, nullable=True)
+
+
+class WmtSummary(Base):
+    __tablename__ = "wmt_summaries"
+    id            = Column(Integer, primary_key=True, autoincrement=True)
+    date          = Column(Date, nullable=False, unique=True)
+    content       = Column(String, nullable=False)
+    matches_count = Column(Integer, default=0)
+    created_at    = Column(DateTime, default=datetime.utcnow)

--- a/backend/routers/wmt.py
+++ b/backend/routers/wmt.py
@@ -1,0 +1,555 @@
+"""
+WMT – WM 2026 Tipp-Assistent
+Data source: football-data.org free tier (env: FOOTBALL_DATA_API_KEY)
+Prediction model: ELO-based win probabilities + expected goals
+"""
+
+import logging
+import math
+import os
+from datetime import date, datetime, timedelta
+from typing import Optional
+
+import httpx
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from .. import models, schemas
+from ..database import get_db
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+FOOTBALL_API_KEY = os.getenv("FOOTBALL_DATA_API_KEY", "")
+FOOTBALL_API_BASE = "https://api.football-data.org/v4"
+
+ELO_K = 60          # WC tournament K-factor
+WC_AVG_GOALS = 1.35  # average goals per team per WC game
+
+
+# Initial ELO estimates for likely WC 2026 participants (calibrated ~June 2026)
+INITIAL_ELO: dict[str, float] = {
+    "ARG": 2090, "FRA": 2020, "BRA": 2000, "ESP": 1980, "ENG": 1960,
+    "POR": 1940, "NED": 1900, "GER": 1890, "BEL": 1880, "ITA": 1870,
+    "MAR": 1860, "CRO": 1850, "JPN": 1840, "USA": 1830, "MEX": 1820,
+    "COL": 1810, "URU": 1800, "SUI": 1800, "DEN": 1790, "UKR": 1790,
+    "AUT": 1780, "SEN": 1780, "KOR": 1780, "TUR": 1770, "CAN": 1770,
+    "CZE": 1760, "SCO": 1760, "WAL": 1750, "NGA": 1750, "CIV": 1740,
+    "SRB": 1740, "HUN": 1740, "POL": 1730, "ROU": 1730, "EGY": 1720,
+    "IRN": 1720, "GRE": 1720, "ECU": 1710, "AUS": 1710, "SVK": 1740,
+    "CMR": 1700, "ALG": 1700, "GHA": 1700, "SAU": 1680, "PAN": 1680,
+    "VEN": 1680, "PAR": 1680, "ALB": 1680, "JOR": 1680, "IRQ": 1670,
+    "UZB": 1650, "CRC": 1660, "RSA": 1660, "TUN": 1690, "JAM": 1620,
+    "NZL": 1600, "QAT": 1620, "HON": 1640,
+}
+DEFAULT_ELO = 1700.0
+
+
+# ── prediction engine ────────────────────────────────────────────────────────
+
+def elo_to_win_prob(home_elo: float, away_elo: float) -> tuple[float, float, float]:
+    diff = home_elo - away_elo
+    home_expected = 1.0 / (1.0 + 10.0 ** (-diff / 400.0))
+    draw_prob = 0.28 * math.exp(-0.0015 * diff ** 2)
+    draw_prob = max(0.05, min(0.38, draw_prob))
+    home_win = home_expected * (1.0 - draw_prob)
+    away_win = (1.0 - home_expected) * (1.0 - draw_prob)
+    total = home_win + draw_prob + away_win
+    return home_win / total, draw_prob / total, away_win / total
+
+
+def elo_to_expected_goals(home_elo: float, away_elo: float) -> tuple[float, float]:
+    diff = (home_elo - away_elo) / 400.0
+    factor = 10.0 ** (diff * 0.3)
+    home_xg = WC_AVG_GOALS * factor
+    away_xg = WC_AVG_GOALS / factor
+    return max(0.3, min(5.0, home_xg)), max(0.3, min(5.0, away_xg))
+
+
+def update_elo_after_match(
+    home_elo: float, away_elo: float, score_home: int, score_away: int
+) -> tuple[float, float]:
+    expected_home = 1.0 / (1.0 + 10.0 ** ((away_elo - home_elo) / 400.0))
+    if score_home > score_away:
+        actual_home = 1.0
+    elif score_home < score_away:
+        actual_home = 0.0
+    else:
+        actual_home = 0.5
+    gd = abs(score_home - score_away)
+    gd_mult = 1.0 if gd <= 1 else (1.5 if gd == 2 else (1.75 + (gd - 3) * 0.1))
+    delta = ELO_K * gd_mult * (actual_home - expected_home)
+    return home_elo + delta, away_elo - delta
+
+
+def _stage_de(stage: str) -> str:
+    mapping = {
+        "GROUP_STAGE":    "Gruppenphase",
+        "ROUND_OF_32":    "Rd. 32",
+        "ROUND_OF_16":    "Achtelfinale",
+        "QUARTER_FINALS": "Viertelfinale",
+        "SEMI_FINALS":    "Halbfinale",
+        "THIRD_PLACE":    "Spiel um Platz 3",
+        "FINAL":          "Finale",
+    }
+    return mapping.get(stage, stage.replace("_", " ").title())
+
+
+def build_reasoning(
+    home_name: str, away_name: str, home_tla: str, away_tla: str,
+    home_elo: float, away_elo: float,
+    home_win: float, draw: float, away_win: float,
+    home_xg: float, away_xg: float,
+) -> str:
+    diff = home_elo - away_elo
+    if abs(diff) < 30:
+        strength = "Die Teams sind nahezu gleichwertig"
+    elif diff > 0:
+        label = "leichter" if diff < 100 else ("klarer" if diff < 200 else "deutlicher")
+        strength = f"{home_name} ist {label} Favorit (+{diff:.0f} ELO)"
+    else:
+        label = "leichter" if abs(diff) < 100 else ("klarer" if abs(diff) < 200 else "deutlicher")
+        strength = f"{away_name} ist {label} Favorit ({diff:.0f} ELO)"
+
+    tip_home = max(0, round(home_xg))
+    tip_away = max(0, round(away_xg))
+    # Avoid draw tips when one team is clearly favored
+    if tip_home == tip_away:
+        if home_win > away_win + 0.1:
+            tip_home += 1
+        elif away_win > home_win + 0.1:
+            tip_away += 1
+
+    return (
+        f"{strength}. "
+        f"ELO: {home_tla} {home_elo:.0f} vs. {away_tla} {away_elo:.0f}. "
+        f"Gewinnchancen: {home_tla} {home_win*100:.0f}% | "
+        f"Remis {draw*100:.0f}% | {away_tla} {away_win*100:.0f}%. "
+        f"Empfohlener Tipp: {tip_home}:{tip_away}."
+    )
+
+
+# ── football-data.org helpers ────────────────────────────────────────────────
+
+def _api_headers() -> dict:
+    return {"X-Auth-Token": FOOTBALL_API_KEY} if FOOTBALL_API_KEY else {}
+
+
+def _fetch_wc_teams() -> Optional[dict]:
+    if not FOOTBALL_API_KEY:
+        return None
+    try:
+        with httpx.Client(timeout=20.0) as client:
+            r = client.get(
+                f"{FOOTBALL_API_BASE}/competitions/WC/teams",
+                headers=_api_headers(),
+                params={"season": "2026"},
+            )
+            if r.status_code == 200:
+                return r.json()
+            logger.warning("teams fetch returned %d: %s", r.status_code, r.text[:200])
+    except Exception as exc:
+        logger.error("WMT teams fetch error: %s", exc)
+    return None
+
+
+def _fetch_wc_matches() -> Optional[dict]:
+    if not FOOTBALL_API_KEY:
+        return None
+    try:
+        with httpx.Client(timeout=20.0) as client:
+            r = client.get(
+                f"{FOOTBALL_API_BASE}/competitions/WC/matches",
+                headers=_api_headers(),
+                params={"season": "2026"},
+            )
+            if r.status_code == 200:
+                return r.json()
+            logger.warning("matches fetch returned %d: %s", r.status_code, r.text[:200])
+    except Exception as exc:
+        logger.error("WMT matches fetch error: %s", exc)
+    return None
+
+
+# ── core business logic (sync, runs from scheduler or API endpoint) ──────────
+
+def do_refresh(db: Session) -> int:
+    """
+    Fetch latest WC 2026 data, upsert teams/matches, update ELO from new results,
+    create prediction snapshots for all unplayed matches.
+    Returns count of matches inserted or result-updated.
+    """
+    teams_data  = _fetch_wc_teams()
+    matches_data = _fetch_wc_matches()
+
+    if not matches_data:
+        if not FOOTBALL_API_KEY:
+            logger.warning("WMT: no FOOTBALL_DATA_API_KEY set — skipping refresh")
+        return 0
+
+    # ── upsert teams ──────────────────────────────────────────────────────────
+    if teams_data:
+        for t in teams_data.get("teams", []):
+            api_id = t.get("id")
+            if not api_id:
+                continue
+            tla = (t.get("tla") or "").upper().strip()
+            team = db.query(models.WmtTeam).filter_by(api_id=api_id).first()
+            if not team:
+                team = models.WmtTeam(
+                    api_id=api_id,
+                    name=t.get("name", "Unknown"),
+                    short_name=t.get("shortName") or t.get("name"),
+                    tla=tla or None,
+                    elo=INITIAL_ELO.get(tla, DEFAULT_ELO),
+                    matches_played=0,
+                )
+                db.add(team)
+            else:
+                team.name = t.get("name", team.name)
+                team.short_name = t.get("shortName") or team.short_name
+                if not team.tla and tla:
+                    team.tla = tla
+        db.commit()
+
+    # ── upsert matches + ELO updates ──────────────────────────────────────────
+    updated = 0
+    newly_finished: list[models.WmtMatch] = []
+
+    for m in matches_data.get("matches", []):
+        api_id = m.get("id")
+        if not api_id:
+            continue
+        status = m.get("status", "SCHEDULED")
+        home_api_id = (m.get("homeTeam") or {}).get("id")
+        away_api_id = (m.get("awayTeam") or {}).get("id")
+        ft = (m.get("score") or {}).get("fullTime") or {}
+        score_home = ft.get("home")
+        score_away = ft.get("away")
+
+        home_team = db.query(models.WmtTeam).filter_by(api_id=home_api_id).first() if home_api_id else None
+        away_team = db.query(models.WmtTeam).filter_by(api_id=away_api_id).first() if away_api_id else None
+
+        match = db.query(models.WmtMatch).filter_by(api_id=api_id).first()
+        if not match:
+            raw_date = m.get("utcDate", "")
+            try:
+                utc_date = datetime.fromisoformat(raw_date.replace("Z", "+00:00")).replace(tzinfo=None)
+            except Exception:
+                utc_date = datetime.utcnow()
+
+            # Strip "GROUP_" prefix from group label
+            raw_group = m.get("group") or ""
+            group_name = raw_group.replace("GROUP_", "") if raw_group else None
+
+            match = models.WmtMatch(
+                api_id=api_id,
+                matchday=m.get("matchday") or 0,
+                stage=m.get("stage", "GROUP_STAGE"),
+                group_name=group_name,
+                utc_date=utc_date,
+                home_team_id=home_team.id if home_team else None,
+                away_team_id=away_team.id if away_team else None,
+                status=status,
+                last_fetched=datetime.utcnow(),
+            )
+            db.add(match)
+            db.flush()
+            updated += 1
+        else:
+            was_finished = match.status == "FINISHED"
+            match.status = status
+            match.last_fetched = datetime.utcnow()
+            if home_team:
+                match.home_team_id = home_team.id
+            if away_team:
+                match.away_team_id = away_team.id
+
+            if status == "FINISHED" and score_home is not None and score_away is not None:
+                if not was_finished:
+                    match.score_home = score_home
+                    match.score_away = score_away
+                    newly_finished.append(match)
+                    updated += 1
+                else:
+                    match.score_home = score_home
+                    match.score_away = score_away
+
+    db.commit()
+
+    # ── update ELO for newly finished matches (in chronological order) ────────
+    newly_finished.sort(key=lambda x: x.utc_date)
+    for match in newly_finished:
+        home = db.get(models.WmtTeam, match.home_team_id)
+        away = db.get(models.WmtTeam, match.away_team_id)
+        if home and away and match.score_home is not None and match.score_away is not None:
+            new_h, new_a = update_elo_after_match(home.elo, away.elo, match.score_home, match.score_away)
+            home.elo = new_h
+            away.elo = new_a
+            home.matches_played = (home.matches_played or 0) + 1
+            away.matches_played = (away.matches_played or 0) + 1
+    db.commit()
+
+    # ── create/update predictions for upcoming matches ─────────────────────────
+    upcoming = (
+        db.query(models.WmtMatch)
+        .filter(models.WmtMatch.status.in_(["SCHEDULED", "TIMED"]))
+        .all()
+    )
+    for match in upcoming:
+        home = db.get(models.WmtTeam, match.home_team_id) if match.home_team_id else None
+        away = db.get(models.WmtTeam, match.away_team_id) if match.away_team_id else None
+        if not home or not away:
+            continue
+
+        home_win, draw, away_win = elo_to_win_prob(home.elo, away.elo)
+        home_xg, away_xg = elo_to_expected_goals(home.elo, away.elo)
+
+        # Only create new snapshot if ELO changed significantly since last prediction
+        latest = (
+            db.query(models.WmtPrediction)
+            .filter_by(match_id=match.id)
+            .order_by(models.WmtPrediction.created_at.desc())
+            .first()
+        )
+        if latest:
+            if (abs((latest.home_elo or 0) - home.elo) < 5.0 and
+                    abs((latest.away_elo or 0) - away.elo) < 5.0):
+                continue
+
+        home_tla = home.tla or home.short_name or home.name
+        away_tla = away.tla or away.short_name or away.name
+        reasoning = build_reasoning(
+            home.name, away.name, home_tla, away_tla,
+            home.elo, away.elo, home_win, draw, away_win, home_xg, away_xg,
+        )
+        pred = models.WmtPrediction(
+            match_id=match.id,
+            home_win_prob=home_win,
+            draw_prob=draw,
+            away_win_prob=away_win,
+            pred_home_goals=home_xg,
+            pred_away_goals=away_xg,
+            home_elo=home.elo,
+            away_elo=away.elo,
+            reasoning=reasoning,
+        )
+        db.add(pred)
+
+    db.commit()
+    return updated
+
+
+def do_generate_summary(db: Session, for_date: Optional[date] = None) -> str:
+    """Generate and store a morning summary for the given date's finished matches."""
+    target = for_date or (date.today() - timedelta(days=1))
+
+    day_start = datetime(target.year, target.month, target.day)
+    day_end   = day_start + timedelta(days=1)
+
+    finished = (
+        db.query(models.WmtMatch)
+        .filter(
+            models.WmtMatch.status == "FINISHED",
+            models.WmtMatch.utc_date >= day_start,
+            models.WmtMatch.utc_date < day_end,
+        )
+        .order_by(models.WmtMatch.utc_date)
+        .all()
+    )
+    if not finished:
+        return ""
+
+    lines = [f"## Spieltag-Zusammenfassung — {target.strftime('%d.%m.%Y')}"]
+    lines.append(f"\n{len(finished)} Spiel{'e' if len(finished) != 1 else ''} gestern:\n")
+
+    upsets: list[str] = []
+    correct = 0
+
+    for m in finished:
+        home = db.get(models.WmtTeam, m.home_team_id)
+        away = db.get(models.WmtTeam, m.away_team_id)
+        home_name = (home.short_name if home else None) or "?"
+        away_name = (away.short_name if away else None) or "?"
+        score = f"{m.score_home}:{m.score_away}"
+
+        group_info = f"Gr. {m.group_name}" if m.group_name else _stage_de(m.stage)
+        line = f"**{home_name} {score} {away_name}** ({group_info})"
+
+        pred = (
+            db.query(models.WmtPrediction)
+            .filter_by(match_id=m.id)
+            .order_by(models.WmtPrediction.created_at.desc())
+            .first()
+        )
+        if pred and m.score_home is not None and m.score_away is not None:
+            ph = round(pred.pred_home_goals)
+            pa = round(pred.pred_away_goals)
+            pred_correct = (
+                (m.score_home > m.score_away  and pred.pred_home_goals > pred.pred_away_goals) or
+                (m.score_home < m.score_away  and pred.pred_home_goals < pred.pred_away_goals) or
+                (m.score_home == m.score_away and abs(pred.pred_home_goals - pred.pred_away_goals) < 0.5)
+            )
+            marker = "✓" if pred_correct else "✗"
+            if pred_correct:
+                correct += 1
+            line += f" — Prognose {ph}:{pa} {marker}"
+
+            if m.score_home < m.score_away and pred.home_win_prob > 0.55 and away:
+                upsets.append(f"{away.short_name} schlug {home.short_name}")
+            elif m.score_home > m.score_away and pred.away_win_prob > 0.55 and home:
+                upsets.append(f"{home.short_name} schlug {away.short_name}")
+
+        lines.append(f"- {line}")
+
+    total = len(finished)
+    lines.append(f"\nTreffgenauigkeit (Tendenz): **{correct}/{total}** Spiele richtig vorhergesagt.")
+    if upsets:
+        lines.append(f"\n**Überraschungen:** {', '.join(upsets)}.")
+
+    content = "\n".join(lines)
+
+    existing = db.query(models.WmtSummary).filter_by(date=target).first()
+    if existing:
+        existing.content = content
+        existing.matches_count = total
+    else:
+        db.add(models.WmtSummary(
+            date=target,
+            content=content,
+            matches_count=total,
+        ))
+    db.commit()
+    return content
+
+
+# ── helpers for API response assembly ────────────────────────────────────────
+
+def _team_out(team: Optional[models.WmtTeam]) -> Optional[schemas.WmtTeamOut]:
+    if not team:
+        return None
+    return schemas.WmtTeamOut(
+        id=team.id,
+        api_id=team.api_id,
+        name=team.name,
+        short_name=team.short_name,
+        tla=team.tla,
+        elo=team.elo,
+        matches_played=team.matches_played or 0,
+    )
+
+
+def _pred_out(pred: Optional[models.WmtPrediction]) -> Optional[schemas.WmtPredictionOut]:
+    if not pred:
+        return None
+    return schemas.WmtPredictionOut(
+        id=pred.id,
+        match_id=pred.match_id,
+        created_at=pred.created_at,
+        home_win_prob=pred.home_win_prob,
+        draw_prob=pred.draw_prob,
+        away_win_prob=pred.away_win_prob,
+        pred_home_goals=pred.pred_home_goals,
+        pred_away_goals=pred.pred_away_goals,
+        home_elo=pred.home_elo,
+        away_elo=pred.away_elo,
+        reasoning=pred.reasoning,
+    )
+
+
+def _match_out(match: models.WmtMatch, db: Session) -> schemas.WmtMatchOut:
+    home = db.get(models.WmtTeam, match.home_team_id) if match.home_team_id else None
+    away = db.get(models.WmtTeam, match.away_team_id) if match.away_team_id else None
+    pred = (
+        db.query(models.WmtPrediction)
+        .filter_by(match_id=match.id)
+        .order_by(models.WmtPrediction.created_at.desc())
+        .first()
+    )
+    return schemas.WmtMatchOut(
+        id=match.id,
+        api_id=match.api_id,
+        matchday=match.matchday,
+        stage=match.stage,
+        group_name=match.group_name,
+        utc_date=match.utc_date,
+        status=match.status,
+        score_home=match.score_home,
+        score_away=match.score_away,
+        home_team=_team_out(home),
+        away_team=_team_out(away),
+        prediction=_pred_out(pred),
+    )
+
+
+# ── API endpoints ─────────────────────────────────────────────────────────────
+
+@router.get("/matches", response_model=list[schemas.WmtMatchOut])
+def list_matches(db: Session = Depends(get_db)):
+    matches = (
+        db.query(models.WmtMatch)
+        .order_by(models.WmtMatch.utc_date)
+        .all()
+    )
+    return [_match_out(m, db) for m in matches]
+
+
+@router.get("/matches/{mid}/predictions", response_model=list[schemas.WmtPredictionOut])
+def match_predictions(mid: int, db: Session = Depends(get_db)):
+    return (
+        db.query(models.WmtPrediction)
+        .filter_by(match_id=mid)
+        .order_by(models.WmtPrediction.created_at.desc())
+        .all()
+    )
+
+
+@router.get("/teams", response_model=list[schemas.WmtTeamOut])
+def list_teams(db: Session = Depends(get_db)):
+    return (
+        db.query(models.WmtTeam)
+        .order_by(models.WmtTeam.elo.desc())
+        .all()
+    )
+
+
+@router.get("/summaries", response_model=list[schemas.WmtSummaryOut])
+def list_summaries(db: Session = Depends(get_db)):
+    rows = (
+        db.query(models.WmtSummary)
+        .order_by(models.WmtSummary.date.desc())
+        .all()
+    )
+    return [
+        schemas.WmtSummaryOut(
+            id=r.id,
+            date=r.date.isoformat(),
+            content=r.content,
+            matches_count=r.matches_count,
+            created_at=r.created_at,
+        )
+        for r in rows
+    ]
+
+
+@router.post("/refresh", response_model=schemas.WmtRefreshOut)
+def manual_refresh(db: Session = Depends(get_db)):
+    if not FOOTBALL_API_KEY:
+        return schemas.WmtRefreshOut(
+            message="Kein API-Schlüssel konfiguriert. Bitte FOOTBALL_DATA_API_KEY als Umgebungsvariable setzen.",
+            updated=0,
+        )
+    n = do_refresh(db)
+    return schemas.WmtRefreshOut(
+        message=f"Aktualisierung abgeschlossen. {n} Spiel{'e' if n != 1 else ''} neu/aktualisiert.",
+        updated=n,
+    )
+
+
+@router.post("/summary/generate", response_model=schemas.WmtRefreshOut)
+def generate_summary_now(db: Session = Depends(get_db)):
+    yesterday = date.today() - timedelta(days=1)
+    content = do_generate_summary(db, yesterday)
+    if content:
+        return schemas.WmtRefreshOut(message="Zusammenfassung erstellt.", updated=1)
+    return schemas.WmtRefreshOut(message="Keine abgeschlossenen Spiele für gestern gefunden.", updated=0)

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -166,3 +166,60 @@ class TrackBpmOut(TrackBpmIn):
 class BatchLookupRequest(BaseModel):
     spotify_ids: list[str]
 
+
+# ── wmt ───────────────────────────────────────────────────────────────────────
+
+class WmtTeamOut(BaseModel):
+    id: int
+    api_id: Optional[int]
+    name: str
+    short_name: Optional[str]
+    tla: Optional[str]
+    elo: float
+    matches_played: int
+    model_config = {"from_attributes": True}
+
+
+class WmtPredictionOut(BaseModel):
+    id: int
+    match_id: int
+    created_at: UtcDt
+    home_win_prob: float
+    draw_prob: float
+    away_win_prob: float
+    pred_home_goals: float
+    pred_away_goals: float
+    home_elo: Optional[float]
+    away_elo: Optional[float]
+    reasoning: Optional[str]
+    model_config = {"from_attributes": True}
+
+
+class WmtMatchOut(BaseModel):
+    id: int
+    api_id: Optional[int]
+    matchday: int
+    stage: str
+    group_name: Optional[str]
+    utc_date: UtcDt
+    status: str
+    score_home: Optional[int]
+    score_away: Optional[int]
+    home_team: Optional[WmtTeamOut]
+    away_team: Optional[WmtTeamOut]
+    prediction: Optional[WmtPredictionOut]
+
+
+class WmtSummaryOut(BaseModel):
+    id: int
+    date: str
+    content: str
+    matches_count: int
+    created_at: UtcDt
+    model_config = {"from_attributes": True}
+
+
+class WmtRefreshOut(BaseModel):
+    message: str
+    updated: int
+

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,6 +10,7 @@ import StringTracker from './pages/StringTracker'
 import BpmCounter from './pages/BpmCounter'
 import SpotifyExplorer from './pages/SpotifyExplorer'
 import BlockHero from './pages/BlockHero'
+import Wmt from './pages/Wmt'
 
 export default function App() {
   return (
@@ -26,6 +27,7 @@ export default function App() {
         <Route path="/bpm" element={<BpmCounter />} />
         <Route path="/spt" element={<SpotifyExplorer />} />
         <Route path="/block-hero" element={<BlockHero />} />
+        <Route path="/wmt" element={<Wmt />} />
       </Routes>
     </BrowserRouter>
   )

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -58,3 +58,13 @@ export const str = {
   undoChange: (id)           => del(`/str/guitars/${id}/change`),
 }
 
+// ── wmt ───────────────────────────────────────────────────────
+export const wmt = {
+  getMatches: ()             => get('/wmt/matches'),
+  getMatchPredictions: (id)  => get(`/wmt/matches/${id}/predictions`),
+  getTeams: ()               => get('/wmt/teams'),
+  getSummaries: ()           => get('/wmt/summaries'),
+  refresh: ()                => post('/wmt/refresh'),
+  generateSummary: ()        => post('/wmt/summary/generate'),
+}
+

--- a/frontend/src/pages/Personal.jsx
+++ b/frontend/src/pages/Personal.jsx
@@ -4,6 +4,7 @@ const TOOLS = [
   { path: '/str', label: '01', name: 'str', desc: 'string tracker' },
   { path: '/bpm', label: '02', name: 'bpm', desc: 'bpm counter' },
   { path: '/spt', label: '03', name: 'spt', desc: 'spotify explorer' },
+  { path: '/wmt', label: '04', name: 'wmt', desc: 'wm 2026 tipp-assistent' },
 ]
 
 export default function Personal() {

--- a/frontend/src/pages/Wmt.jsx
+++ b/frontend/src/pages/Wmt.jsx
@@ -1,0 +1,479 @@
+import { useState, useEffect, useCallback } from 'react'
+import { Link } from 'react-router-dom'
+import { wmt } from '../api'
+
+// ── constants & helpers ───────────────────────────────────────────────────────
+
+const STAGE_LABELS = {
+  GROUP_STAGE:    'Gruppenphase',
+  ROUND_OF_32:    'Rd. 32',
+  ROUND_OF_16:    'Achtelfinale',
+  QUARTER_FINALS: 'Viertelfinale',
+  SEMI_FINALS:    'Halbfinale',
+  THIRD_PLACE:    'Spiel um Platz 3',
+  FINAL:          'Finale',
+}
+
+const STATUS_LABELS = {
+  SCHEDULED: 'Ausstehend',
+  TIMED:     'Ausstehend',
+  IN_PLAY:   'Läuft',
+  PAUSED:    'Halbzeit',
+  FINISHED:  'Abgeschlossen',
+  POSTPONED: 'Verschoben',
+  CANCELLED: 'Abgesagt',
+  SUSPENDED: 'Unterbrochen',
+}
+
+const STATUS_COLORS = {
+  IN_PLAY: '#4d8a4d',
+  PAUSED:  '#9ab0d0',
+  FINISHED:'#374d66',
+  default: '#9ab0d0',
+}
+
+function statusColor(s) { return STATUS_COLORS[s] ?? STATUS_COLORS.default }
+
+function stageLabel(s) { return STAGE_LABELS[s] ?? s.replace(/_/g, ' ') }
+
+function formatDate(utcStr) {
+  if (!utcStr) return ''
+  const d = new Date(utcStr)
+  return d.toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit' }) +
+    ' · ' + d.toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' })
+}
+
+function formatDateLong(utcStr) {
+  if (!utcStr) return ''
+  const d = new Date(utcStr)
+  return d.toLocaleDateString('de-DE', { weekday: 'short', day: '2-digit', month: '2-digit', year: 'numeric' })
+}
+
+function groupMatchesByMatchday(matches) {
+  const map = {}
+  for (const m of matches) {
+    const key = m.matchday
+    if (!map[key]) map[key] = []
+    map[key].push(m)
+  }
+  return map
+}
+
+function matchdayLabel(matchday, matches) {
+  if (!matches?.length) return `MD ${matchday}`
+  const stage = matches[0].stage
+  if (stage !== 'GROUP_STAGE') return stageLabel(stage)
+  return `MD ${matchday}`
+}
+
+function renderMarkdown(text) {
+  if (!text) return null
+  return text.split('\n').map((line, i) => {
+    // bold
+    const parts = line.split(/\*\*(.*?)\*\*/g).map((p, j) =>
+      j % 2 === 1 ? <strong key={j}>{p}</strong> : p
+    )
+    if (line.startsWith('## '))
+      return <div key={i} style={{ fontSize: 13, fontWeight: 600, color: '#eef2ff', marginBottom: 6 }}>{line.slice(3)}</div>
+    if (line.startsWith('- '))
+      return <div key={i} style={{ paddingLeft: 12, marginBottom: 3 }}>• {parts.slice(1)}</div>
+    if (line === '')
+      return <div key={i} style={{ height: 8 }} />
+    return <div key={i}>{parts}</div>
+  })
+}
+
+// ── sub-components ────────────────────────────────────────────────────────────
+
+function ProbBar({ home, draw, away, homeTla, awayTla }) {
+  const hw = (home * 100).toFixed(0)
+  const dw = (draw * 100).toFixed(0)
+  const aw = (away * 100).toFixed(0)
+  return (
+    <div>
+      <div style={{ display: 'flex', height: 6, borderRadius: 3, overflow: 'hidden', gap: 2 }}>
+        <div style={{ width: `${hw}%`, background: '#4d6fa0', transition: 'width 0.4s' }} />
+        <div style={{ width: `${dw}%`, background: '#2a3d5c', transition: 'width 0.4s' }} />
+        <div style={{ width: `${aw}%`, background: '#1a2840', transition: 'width 0.4s' }} />
+      </div>
+      <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 10, color: '#9ab0d0', marginTop: 4 }}>
+        <span>{homeTla} {hw}%</span>
+        <span>Rem {dw}%</span>
+        <span>{aw}% {awayTla}</span>
+      </div>
+    </div>
+  )
+}
+
+function MatchCard({ match, predHistory, onTogglePred, isExpanded }) {
+  const p = match.prediction
+  const isFinished = match.status === 'FINISHED'
+  const isLive = match.status === 'IN_PLAY' || match.status === 'PAUSED'
+  const homeName = match.home_team?.name ?? 'TBD'
+  const awayName = match.away_team?.name ?? 'TBD'
+  const homeTla  = match.home_team?.tla ?? '?'
+  const awayTla  = match.away_team?.tla ?? '?'
+  const tipHome  = p ? Math.max(0, Math.round(p.pred_home_goals)) : null
+  const tipAway  = p ? Math.max(0, Math.round(p.pred_away_goals)) : null
+
+  const tipBgColor = isFinished ? '#0d1221' : 'rgba(77,111,160,0.06)'
+
+  return (
+    <div style={{
+      background: '#0d1221',
+      border: '1px solid #1a2840',
+      borderRadius: 10,
+      padding: '14px 16px',
+      marginBottom: 10,
+    }}>
+      {/* header row */}
+      <div style={{
+        display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+        fontSize: 10, color: '#374d66', marginBottom: 12, letterSpacing: '0.05em',
+      }}>
+        <span>
+          {match.group_name ? `GR. ${match.group_name}` : stageLabel(match.stage)}
+          {' · '}{formatDate(match.utc_date)}
+        </span>
+        <span style={{ color: isLive ? STATUS_COLORS.IN_PLAY : statusColor(match.status) }}>
+          {STATUS_LABELS[match.status] ?? match.status}
+        </span>
+      </div>
+
+      {/* teams + score row */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 14 }}>
+        <div style={{ flex: 1, textAlign: 'right' }}>
+          <div style={{ fontSize: 15, fontWeight: 600, color: '#eef2ff' }}>{homeName}</div>
+          <div style={{ fontSize: 10, color: '#9ab0d0', marginTop: 2 }}>{homeTla}</div>
+        </div>
+
+        <div style={{ minWidth: 56, textAlign: 'center' }}>
+          {isFinished || isLive ? (
+            <div style={{ fontSize: 22, fontWeight: 600, color: '#eef2ff', fontVariantNumeric: 'tabular-nums' }}>
+              {match.score_home ?? 0}&nbsp;:&nbsp;{match.score_away ?? 0}
+            </div>
+          ) : (
+            <div style={{ fontSize: 13, color: '#374d66' }}>vs</div>
+          )}
+        </div>
+
+        <div style={{ flex: 1, textAlign: 'left' }}>
+          <div style={{ fontSize: 15, fontWeight: 600, color: '#eef2ff' }}>{awayName}</div>
+          <div style={{ fontSize: 10, color: '#9ab0d0', marginTop: 2 }}>{awayTla}</div>
+        </div>
+      </div>
+
+      {/* prediction block */}
+      {p ? (
+        <div style={{
+          background: tipBgColor,
+          border: '1px solid #1a2840',
+          borderRadius: 6,
+          padding: '10px 12px',
+        }}>
+          <div style={{ fontSize: 11, color: '#9ab0d0', marginBottom: 8 }}>
+            {isFinished ? 'Prognose war' : 'Tipp-Empfehlung'}:{' '}
+            <span style={{ fontWeight: 600, color: '#eef2ff' }}>{tipHome}:{tipAway}</span>
+            {isFinished && match.score_home !== null && (
+              <span style={{ marginLeft: 8, color: resultColor(tipHome, tipAway, match.score_home, match.score_away) }}>
+                {resultMark(tipHome, tipAway, match.score_home, match.score_away)}
+              </span>
+            )}
+          </div>
+          <ProbBar
+            home={p.home_win_prob} draw={p.draw_prob} away={p.away_win_prob}
+            homeTla={homeTla} awayTla={awayTla}
+          />
+
+          <button
+            onClick={() => onTogglePred(match.id)}
+            style={{
+              marginTop: 10, background: 'none', border: 'none',
+              color: '#4d6fa0', fontSize: 11, cursor: 'pointer',
+              padding: 0, fontFamily: 'inherit',
+            }}>
+            {isExpanded ? 'Begründung ▲' : 'Begründung ▼'}
+            {predHistory && predHistory.length > 1 && ` · ${predHistory.length} Versionen`}
+          </button>
+
+          {isExpanded && (
+            <div style={{ marginTop: 10, borderTop: '1px solid #1a2840', paddingTop: 10 }}>
+              <div style={{ fontSize: 12, color: '#9ab0d0', lineHeight: 1.65, marginBottom: p.home_elo ? 10 : 0 }}>
+                {p.reasoning}
+              </div>
+              {p.home_elo && (
+                <div style={{ fontSize: 11, color: '#374d66', marginTop: 6 }}>
+                  ELO: {homeTla} {p.home_elo.toFixed(0)} · {awayTla} {p.away_elo?.toFixed(0)}
+                  {match.home_team && ` · Spiele: ${match.home_team.matches_played}`}
+                </div>
+              )}
+
+              {predHistory && predHistory.length > 1 && (
+                <div style={{ marginTop: 12 }}>
+                  <div style={{ fontSize: 10, color: '#374d66', letterSpacing: '0.1em', marginBottom: 6 }}>
+                    VERLAUF ({predHistory.length} VERSIONEN)
+                  </div>
+                  {predHistory.map((ph, i) => (
+                    <div key={ph.id} style={{
+                      padding: '6px 0',
+                      borderTop: '1px solid #1a2840',
+                      fontSize: 11,
+                      color: i === 0 ? '#9ab0d0' : '#374d66',
+                    }}>
+                      <span style={{ marginRight: 8 }}>{formatDateLong(ph.created_at)}</span>
+                      <span style={{ fontVariantNumeric: 'tabular-nums' }}>
+                        {Math.round(ph.pred_home_goals)}:{Math.round(ph.pred_away_goals)}
+                        {' '}({(ph.home_win_prob * 100).toFixed(0)}%/
+                        {(ph.draw_prob * 100).toFixed(0)}%/
+                        {(ph.away_win_prob * 100).toFixed(0)}%)
+                      </span>
+                      {i === 0 && <span style={{ color: '#4d6fa0', marginLeft: 6 }}>aktuell</span>}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      ) : (
+        <div style={{ fontSize: 11, color: '#374d66' }}>Noch keine Prognose verfügbar.</div>
+      )}
+    </div>
+  )
+}
+
+function resultMark(tipH, tipA, actH, actA) {
+  const tipWinner = tipH > tipA ? 'home' : tipH < tipA ? 'away' : 'draw'
+  const actWinner = actH > actA ? 'home' : actH < actA ? 'away' : 'draw'
+  return tipWinner === actWinner ? '✓ Tendenz richtig' : '✗ Tendenz falsch'
+}
+function resultColor(tipH, tipA, actH, actA) {
+  const tipWinner = tipH > tipA ? 'home' : tipH < tipA ? 'away' : 'draw'
+  const actWinner = actH > actA ? 'home' : actH < actA ? 'away' : 'draw'
+  return tipWinner === actWinner ? '#4d8a4d' : '#8a4d4d'
+}
+
+// ── main page ─────────────────────────────────────────────────────────────────
+
+export default function Wmt() {
+  const [matches, setMatches]       = useState([])
+  const [summaries, setSummaries]   = useState([])
+  const [view, setView]             = useState('spieltage')
+  const [selectedMd, setSelectedMd] = useState(null)
+  const [expandedId, setExpandedId] = useState(null)
+  const [predHistory, setPredHistory] = useState({})   // { matchId: [...] }
+  const [loading, setLoading]       = useState(true)
+  const [refreshing, setRefreshing] = useState(false)
+  const [statusMsg, setStatusMsg]   = useState('')
+
+  const loadAll = useCallback(async () => {
+    try {
+      const [ms, ss] = await Promise.all([wmt.getMatches(), wmt.getSummaries()])
+      setMatches(ms)
+      setSummaries(ss)
+
+      // Auto-select current or next matchday
+      const now = Date.now()
+      const byMd = groupMatchesByMatchday(ms)
+      const mdKeys = Object.keys(byMd).map(Number).sort((a, b) => a - b)
+      const activeMd = mdKeys.find(md => byMd[md].some(m =>
+        m.status === 'IN_PLAY' || m.status === 'PAUSED' ||
+        m.status === 'SCHEDULED' || m.status === 'TIMED'
+      )) ?? mdKeys[mdKeys.length - 1] ?? mdKeys[0]
+      setSelectedMd(prev => prev ?? activeMd ?? null)
+    } catch (e) {
+      console.error(e)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => { loadAll() }, [loadAll])
+
+  async function handleRefresh() {
+    setRefreshing(true)
+    setStatusMsg('')
+    try {
+      const res = await wmt.refresh()
+      setStatusMsg(res.message)
+      await loadAll()
+    } catch (e) {
+      setStatusMsg('Fehler beim Aktualisieren.')
+    } finally {
+      setRefreshing(false)
+      setTimeout(() => setStatusMsg(''), 5000)
+    }
+  }
+
+  async function handleTogglePred(matchId) {
+    if (expandedId === matchId) {
+      setExpandedId(null)
+      return
+    }
+    setExpandedId(matchId)
+    if (!predHistory[matchId]) {
+      try {
+        const hist = await wmt.getMatchPredictions(matchId)
+        setPredHistory(prev => ({ ...prev, [matchId]: hist }))
+      } catch (e) {
+        console.error(e)
+      }
+    }
+  }
+
+  const byMatchday = groupMatchesByMatchday(matches)
+  const mdKeys = Object.keys(byMatchday).map(Number).sort((a, b) => a - b)
+  const currentMatches = selectedMd !== null ? (byMatchday[selectedMd] ?? []) : []
+
+  const hasData = matches.length > 0
+
+  return (
+    <div>
+      {/* topbar */}
+      <div className="topbar">
+        <div className="topbar-left">
+          <Link to="/personal"><button className="topbar-back btn btn-sm">←</button></Link>
+          <span className="topbar-title">wmt</span>
+        </div>
+        <div className="topbar-right">
+          <button
+            onClick={handleRefresh}
+            disabled={refreshing}
+            style={{
+              background: 'none', border: 'none', color: '#4d6fa0',
+              fontSize: 14, cursor: 'pointer', marginRight: 10, fontFamily: 'inherit',
+              opacity: refreshing ? 0.5 : 1,
+            }}>
+            {refreshing ? '…' : '↻'}
+          </button>
+          <span className="topbar-version">v1.0</span>
+        </div>
+      </div>
+
+      <div className="page">
+        {/* status message */}
+        {statusMsg && (
+          <div style={{ fontSize: 12, color: '#9ab0d0', marginBottom: 14, padding: '8px 12px',
+            background: '#0d1221', border: '1px solid #1a2840', borderRadius: 6 }}>
+            {statusMsg}
+          </div>
+        )}
+
+        {/* view tabs */}
+        <div style={{ display: 'flex', gap: 6, marginBottom: 20 }}>
+          {[['spieltage', 'Spieltage'], ['zusammenfassung', 'Morgenberichte']].map(([key, label]) => (
+            <button
+              key={key}
+              onClick={() => setView(key)}
+              style={{
+                background: view === key ? '#1a2840' : 'none',
+                border: `1px solid ${view === key ? '#2a3d5c' : '#1a2840'}`,
+                color: view === key ? '#eef2ff' : '#374d66',
+                borderRadius: 6, padding: '5px 12px', fontSize: 12,
+                cursor: 'pointer', fontFamily: 'inherit',
+              }}>
+              {label}
+            </button>
+          ))}
+        </div>
+
+        {loading && <div style={{ color: '#374d66', fontSize: 13 }}>Lade…</div>}
+
+        {/* ── Spieltage view ─────────────────────────────────────────────── */}
+        {!loading && view === 'spieltage' && (
+          <>
+            {!hasData ? (
+              <NoDataPlaceholder />
+            ) : (
+              <>
+                {/* matchday selector */}
+                <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginBottom: 20 }}>
+                  {mdKeys.map(md => {
+                    const mdMatches = byMatchday[md] ?? []
+                    const hasLive = mdMatches.some(m => m.status === 'IN_PLAY' || m.status === 'PAUSED')
+                    const allDone = mdMatches.every(m => m.status === 'FINISHED')
+                    const isSelected = selectedMd === md
+                    return (
+                      <button
+                        key={md}
+                        onClick={() => setSelectedMd(md)}
+                        style={{
+                          background: isSelected ? '#1a2840' : 'none',
+                          border: `1px solid ${hasLive ? '#4d8a4d' : isSelected ? '#2a3d5c' : '#1a2840'}`,
+                          color: isSelected ? '#eef2ff' : allDone ? '#374d66' : '#9ab0d0',
+                          borderRadius: 6, padding: '4px 10px', fontSize: 11,
+                          cursor: 'pointer', fontFamily: 'inherit',
+                        }}>
+                        {matchdayLabel(md, mdMatches)}
+                      </button>
+                    )
+                  })}
+                </div>
+
+                {/* match cards */}
+                {currentMatches.length === 0 ? (
+                  <div style={{ color: '#374d66', fontSize: 13 }}>Keine Spiele.</div>
+                ) : (
+                  currentMatches.map(m => (
+                    <MatchCard
+                      key={m.id}
+                      match={m}
+                      predHistory={predHistory[m.id]}
+                      onTogglePred={handleTogglePred}
+                      isExpanded={expandedId === m.id}
+                    />
+                  ))
+                )}
+              </>
+            )}
+          </>
+        )}
+
+        {/* ── Morgenberichte view ────────────────────────────────────────── */}
+        {!loading && view === 'zusammenfassung' && (
+          <>
+            {summaries.length === 0 ? (
+              <div style={{ color: '#374d66', fontSize: 13 }}>
+                Noch keine Zusammenfassungen vorhanden. Die erste erscheint am Morgen nach dem ersten Spieltag.
+              </div>
+            ) : (
+              summaries.map(s => (
+                <div key={s.id} style={{
+                  background: '#0d1221', border: '1px solid #1a2840',
+                  borderRadius: 10, padding: '16px', marginBottom: 12,
+                }}>
+                  <div style={{ fontSize: 10, color: '#374d66', letterSpacing: '0.1em', marginBottom: 10 }}>
+                    {new Date(s.date).toLocaleDateString('de-DE', { weekday: 'long', day: '2-digit', month: '2-digit', year: 'numeric' }).toUpperCase()}
+                    {' · '}{s.matches_count} SPIEL{s.matches_count !== 1 ? 'E' : ''}
+                  </div>
+                  <div style={{ fontSize: 12, color: '#9ab0d0', lineHeight: 1.7 }}>
+                    {renderMarkdown(s.content)}
+                  </div>
+                </div>
+              ))
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function NoDataPlaceholder() {
+  return (
+    <div style={{
+      background: '#0d1221', border: '1px solid #1a2840', borderRadius: 10,
+      padding: '24px', textAlign: 'center',
+    }}>
+      <div style={{ fontSize: 13, color: '#9ab0d0', marginBottom: 12 }}>
+        Noch keine Spieldaten vorhanden.
+      </div>
+      <div style={{ fontSize: 12, color: '#374d66', lineHeight: 1.6 }}>
+        Bitte <code style={{ color: '#4d6fa0' }}>FOOTBALL_DATA_API_KEY</code> als Railway-Umgebungsvariable setzen
+        (kostenlose Registrierung auf{' '}
+        <span style={{ color: '#4d6fa0' }}>football-data.org</span>), dann{' '}
+        ↻ drücken.
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- New **wmt** tool in the Personal category — a full-stack WM 2026 betting prediction assistant
- ELO-based prediction engine that updates ratings after each match result and regenerates forecasts for all remaining games
- Data sourced from **football-data.org** (free tier, requires `FOOTBALL_DATA_API_KEY` env var on Railway)
- Full prediction history stored per match so you can see how forecasts changed over the tournament

## What was built

**Backend**
- 4 new DB tables: `wmt_teams`, `wmt_matches`, `wmt_predictions`, `wmt_summaries`
- ELO engine: win probabilities + expected goals, K-factor 60, goal-difference multiplier
- APScheduler jobs: data refresh every 30 min, daily morning summary at 06:00
- Endpoints: `GET /api/wmt/matches`, `GET /api/wmt/matches/{id}/predictions`, `GET /api/wmt/teams`, `GET /api/wmt/summaries`, `POST /api/wmt/refresh`

**Frontend (`/wmt`)**
- Matchday tabs with auto-selection of the current/next active matchday
- Match cards: score (if available), Tipp-Empfehlung (recommended bet), probability bar, expandable German-language reasoning
- Prediction history view showing each version with timestamp
- Morgenberichte tab for daily match summaries — the "Kaffeetisch-version"

## Setup required

Set `FOOTBALL_DATA_API_KEY` as a Railway environment variable (free registration at football-data.org → My Account → API Keys). After deploy, press **↻** in the app to trigger the first data load.

https://claude.ai/code/session_01JqMuUbRgvGTqnS8yfw5ZUY

---
_Generated by [Claude Code](https://claude.ai/code/session_01JqMuUbRgvGTqnS8yfw5ZUY)_