### PR TITLE
wmt: bump version to v1.1

### DIFF
--- a/frontend/src/pages/Wmt.jsx
+++ b/frontend/src/pages/Wmt.jsx
@@ -349,7 +349,7 @@ export default function Wmt() {
             }}>
             {refreshing ? '…' : '↻'}
           </button>
-          <span className="topbar-version">v1.0</span>
+          <span className="topbar-version">v1.1</span>
         </div>
       </div>
 


### PR DESCRIPTION
Bumps wmt topbar version from v1.0 → v1.1 to reflect the stage code and rate-limit fixes shipped in #184.

https://claude.ai/code/session_01JqMuUbRgvGTqnS8yfw5ZUY

---
_Generated by [Claude Code](https://claude.ai/code/session_01JqMuUbRgvGTqnS8yfw5ZUY)_