### PR TITLE
wmt: increase xG sensitivity and show raw xG values (v1.2)

### DIFF
--- a/backend/routers/wmt.py
+++ b/backend/routers/wmt.py
@@ -60,7 +60,7 @@ def elo_to_win_prob(home_elo: float, away_elo: float) -> tuple[float, float, flo
 
 def elo_to_expected_goals(home_elo: float, away_elo: float) -> tuple[float, float]:
     diff = (home_elo - away_elo) / 400.0
-    factor = 10.0 ** (diff * 0.3)
+    factor = 10.0 ** (diff * 0.5)
     home_xg = WC_AVG_GOALS * factor
     away_xg = WC_AVG_GOALS / factor
     return max(0.3, min(5.0, home_xg)), max(0.3, min(5.0, away_xg))

--- a/frontend/src/pages/Wmt.jsx
+++ b/frontend/src/pages/Wmt.jsx
@@ -177,6 +177,9 @@ function MatchCard({ match, predHistory, onTogglePred, isExpanded }) {
           <div style={{ fontSize: 11, color: '#9ab0d0', marginBottom: 8 }}>
             {isFinished ? 'Prognose war' : 'Tipp-Empfehlung'}:{' '}
             <span style={{ fontWeight: 600, color: '#eef2ff' }}>{tipHome}:{tipAway}</span>
+            <span style={{ color: '#374d66', marginLeft: 6 }}>
+              (xG {p.pred_home_goals.toFixed(1)} : {p.pred_away_goals.toFixed(1)})
+            </span>
             {isFinished && match.score_home !== null && (
               <span style={{ marginLeft: 8, color: resultColor(tipHome, tipAway, match.score_home, match.score_away) }}>
                 {resultMark(tipHome, tipAway, match.score_home, match.score_away)}
@@ -226,6 +229,9 @@ function MatchCard({ match, predHistory, onTogglePred, isExpanded }) {
                       <span style={{ marginRight: 8 }}>{formatDateLong(ph.created_at)}</span>
                       <span style={{ fontVariantNumeric: 'tabular-nums' }}>
                         {Math.round(ph.pred_home_goals)}:{Math.round(ph.pred_away_goals)}
+                        {' '}<span style={{ color: '#374d66' }}>
+                          (xG {ph.pred_home_goals.toFixed(1)}:{ph.pred_away_goals.toFixed(1)})
+                        </span>
                         {' '}({(ph.home_win_prob * 100).toFixed(0)}%/
                         {(ph.draw_prob * 100).toFixed(0)}%/
                         {(ph.away_win_prob * 100).toFixed(0)}%)
@@ -349,7 +355,7 @@ export default function Wmt() {
             }}>
             {refreshing ? '…' : '↻'}
           </button>
-          <span className="topbar-version">v1.1</span>
+          <span className="topbar-version">v1.2</span>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

- **ELO-to-xG exponent raised 0.3 → 0.5** — breaks out of the 1:1/2:1/1:2 cluster for stronger mismatches:
  - 100 ELO gap: xG 1.8 : 1.0 → tip **2:1** (same, but now visible in the UI)
  - 300 ELO gap: xG 3.2 : 0.6 → tip **3:1** (was 2:1)
  - 500 ELO gap: capped at **5:0** for extreme mismatches (e.g. ARG vs NZL)
- **Raw xG shown alongside every tip** — "Tipp: 2:1 (xG 1.8 : 1.0)" — so borderline cases (1.48 vs 1.32) are visible and you can apply your own rounding instinct
- xG also shown in the prediction history view for every version

The clustering will still be present for evenly-matched group-stage games (where it's actually correct), but clear favourites now produce 3:1 / 4:0 tips instead of defaulting to 2:1.

https://claude.ai/code/session_01JqMuUbRgvGTqnS8yfw5ZUY

---
_Generated by [Claude Code](https://claude.ai/code/session_01JqMuUbRgvGTqnS8yfw5ZUY)_