### PR TITLE
wmt: Bonus-Tipps tab with Monte Carlo simulation (#191)

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -132,3 +132,15 @@ class WmtSummary(Base):
     content       = Column(String, nullable=False)
     matches_count = Column(Integer, default=0)
     created_at    = Column(DateTime, default=datetime.utcnow)
+
+
+class WmtBonusPrediction(Base):
+    __tablename__ = "wmt_bonus_predictions"
+    id            = Column(Integer, primary_key=True, autoincrement=True)
+    generated_at  = Column(DateTime, default=datetime.utcnow)
+    group_winners = Column(JSONB)   # {"A": {"team": "...", "tla": "...", "prob": 0.45}}
+    semifinalists = Column(JSONB)   # [{"team": "...", "tla": "...", "prob": 0.32}, ...]
+    finalists     = Column(JSONB)   # [{"team": "...", "tla": "...", "prob": 0.20}, ...]
+    winner        = Column(JSONB)   # {"team": "...", "tla": "...", "prob": 0.15}
+    top_scorer    = Column(JSONB)   # {"player": "...", "team": "...", "tla": "...", "goals": 4.2, "source": "..."}
+    n_simulations = Column(Integer, default=10000)

--- a/backend/routers/wmt.py
+++ b/backend/routers/wmt.py
@@ -7,11 +7,13 @@ Prediction model: ELO-based win probabilities + expected goals
 import logging
 import math
 import os
+import random
+from collections import defaultdict
 from datetime import date, datetime, timedelta
 from typing import Optional
 
 import httpx
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
 from .. import models, schemas
@@ -443,6 +445,329 @@ def do_generate_summary(db: Session, for_date: Optional[date] = None) -> str:
     return content
 
 
+# ── bonus prediction: Monte Carlo tournament simulation ───────────────────────
+
+# Known top international strikers per team – fallback when API scorer data is missing
+TOP_PLAYERS: dict[str, tuple[str, float]] = {
+    "ARG": ("Lautaro Martínez",  0.52),
+    "FRA": ("Kylian Mbappé",     0.58),
+    "BRA": ("Vinicius Jr.",      0.42),
+    "ENG": ("Harry Kane",        0.50),
+    "POR": ("Cristiano Ronaldo", 0.46),
+    "GER": ("Kai Havertz",       0.38),
+    "ESP": ("Álvaro Morata",     0.34),
+    "NED": ("Donyell Malen",     0.35),
+    "BEL": ("Romelu Lukaku",     0.40),
+    "URU": ("Darwin Núñez",      0.42),
+    "COL": ("Luis Díaz",         0.35),
+    "USA": ("Christian Pulisic", 0.32),
+    "MAR": ("Youssef En-Nesyri", 0.36),
+    "CRO": ("Andrej Kramarić",   0.35),
+    "JPN": ("Ayase Ueda",        0.38),
+    "SEN": ("Sadio Mané",        0.30),
+    "ITA": ("Gianluca Scamacca", 0.30),
+    "MEX": ("Hirving Lozano",    0.30),
+    "CAN": ("Alphonso Davies",   0.28),
+    "TUR": ("Arda Güler",        0.32),
+}
+
+
+def _sample_goals_poisson(lam: float) -> int:
+    """Knuth Poisson sampler."""
+    L = math.exp(-max(0.01, min(15.0, lam)))
+    k, p = 0, 1.0
+    while p > L:
+        k += 1
+        p *= random.random()
+    return k - 1
+
+
+def _fetch_ec_scorers() -> list[dict]:
+    """Fetch Euro 2024 top scorers from football-data.org (free tier)."""
+    if not FOOTBALL_API_KEY:
+        return []
+    try:
+        with httpx.Client(timeout=20.0) as client:
+            r = client.get(
+                f"{FOOTBALL_API_BASE}/competitions/EC/scorers",
+                headers=_api_headers(),
+                params={"season": "2024", "limit": 20},
+            )
+            _log_rate_limit(r)
+            if r.status_code == 200:
+                return r.json().get("scorers", [])
+            logger.warning("EC scorers fetch returned %d", r.status_code)
+    except Exception as exc:
+        logger.error("EC scorers fetch error: %s", exc)
+    return []
+
+
+def _compute_top_scorer(db: Session) -> dict:
+    """
+    Predict top WC 2026 scorer.
+    Uses Euro 2024 scorer data (football-data.org) weighted by team ELO and
+    expected tournament depth; falls back to TOP_PLAYERS dict.
+    """
+    ec_scorers  = _fetch_ec_scorers()
+    all_teams   = {t.id: t for t in db.query(models.WmtTeam).all()}
+    tla_to_team = {t.tla: t for t in all_teams.values() if t.tla}
+
+    candidates: list[dict] = []
+
+    if ec_scorers:
+        best_per_tla: dict[str, dict] = {}
+        for s in ec_scorers:
+            player = s.get("player") or {}
+            team   = s.get("team") or {}
+            goals  = s.get("goals") or 0
+            tla    = (team.get("tla") or "").upper()
+            name   = (player.get("name") or "").strip()
+            if not name or not tla or goals == 0:
+                continue
+            if tla not in best_per_tla or best_per_tla[tla]["goals_src"] < goals:
+                best_per_tla[tla] = {
+                    "player":    name,
+                    "team_name": team.get("shortName") or team.get("name", tla),
+                    "tla":       tla,
+                    "goals_src": goals,
+                    "played":    s.get("playedMatches") or 6,
+                    "source":    "EC 2024",
+                }
+        for tla, data in best_per_tla.items():
+            wc_team = tla_to_team.get(tla)
+            if not wc_team:
+                continue
+            rate  = data["goals_src"] / data["played"]
+            exp_m = 3.0 + 3.5 * min(1.0, max(0.0, (wc_team.elo - 1600) / 400))
+            candidates.append({
+                "player": data["player"],
+                "team":   wc_team.short_name or wc_team.name,
+                "tla":    tla,
+                "goals":  round(rate * exp_m, 1),
+                "source": data["source"],
+                "_score": rate * exp_m,
+            })
+
+    # Static fallback for teams not covered by EC 2024 data
+    covered = {c["tla"] for c in candidates}
+    for tla, (player, rate) in TOP_PLAYERS.items():
+        if tla in covered:
+            continue
+        wc_team = tla_to_team.get(tla)
+        if not wc_team:
+            continue
+        exp_m = 3.0 + 3.5 * min(1.0, max(0.0, (wc_team.elo - 1600) / 400))
+        candidates.append({
+            "player": player,
+            "team":   wc_team.short_name or wc_team.name,
+            "tla":    tla,
+            "goals":  round(rate * exp_m, 1),
+            "source": "ELO-Schätzung",
+            "_score": rate * exp_m,
+        })
+
+    if not candidates:
+        return {"player": "unbekannt", "team": "?", "tla": "?", "goals": 0.0, "source": "keine Daten"}
+
+    best = max(candidates, key=lambda x: x["_score"])
+    return {k: v for k, v in best.items() if k != "_score"}
+
+
+def do_generate_bonus(db: Session, n_sims: int = 10000) -> Optional[models.WmtBonusPrediction]:
+    """
+    Monte Carlo simulation of WC 2026: group stage + knockout.
+    Returns a persisted WmtBonusPrediction, or None if no group data exists.
+    """
+    all_teams = {t.id: t for t in db.query(models.WmtTeam).all()}
+    if not all_teams:
+        return None
+
+    group_matches_q = (
+        db.query(models.WmtMatch)
+        .filter(models.WmtMatch.stage == "GROUP_STAGE")
+        .all()
+    )
+
+    group_to_matches: dict[str, list] = defaultdict(list)
+    for m in group_matches_q:
+        if m.group_name:
+            group_to_matches[m.group_name].append(m)
+
+    if not group_to_matches:
+        return None
+
+    group_to_teams: dict[str, set] = defaultdict(set)
+    for group, matches in group_to_matches.items():
+        for m in matches:
+            if m.home_team_id: group_to_teams[group].add(m.home_team_id)
+            if m.away_team_id: group_to_teams[group].add(m.away_team_id)
+
+    # Counters
+    group_win_count: dict[int, int] = defaultdict(int)
+    semi_count:      dict[int, int] = defaultdict(int)
+    final_count:     dict[int, int] = defaultdict(int)
+    win_count:       dict[int, int] = defaultdict(int)
+
+    for _ in range(n_sims):
+        third_pool: list[tuple] = []  # (pts, gd, gf, tid, elo)
+        qualifiers: list[tuple] = []  # (tid, elo)
+
+        for group_name in sorted(group_to_matches.keys()):
+            team_ids = list(group_to_teams[group_name])
+            matches  = group_to_matches[group_name]
+
+            pts: dict[int, int] = defaultdict(int)
+            gd:  dict[int, int] = defaultdict(int)
+            gf:  dict[int, int] = defaultdict(int)
+
+            for m in matches:
+                if not m.home_team_id or not m.away_team_id:
+                    continue
+                ht = all_teams.get(m.home_team_id)
+                at = all_teams.get(m.away_team_id)
+                if not ht or not at:
+                    continue
+
+                if m.status == "FINISHED" and m.score_home is not None:
+                    h, a = m.score_home, m.score_away
+                else:
+                    h_xg, a_xg = elo_to_expected_goals(ht.elo, at.elo)
+                    h = _sample_goals_poisson(h_xg)
+                    a = _sample_goals_poisson(a_xg)
+
+                if h > a:   pts[m.home_team_id] += 3
+                elif h < a: pts[m.away_team_id] += 3
+                else:
+                    pts[m.home_team_id] += 1
+                    pts[m.away_team_id] += 1
+                gd[m.home_team_id] += h - a
+                gd[m.away_team_id] += a - h
+                gf[m.home_team_id] += h
+                gf[m.away_team_id] += a
+
+            sorted_ids = sorted(
+                team_ids,
+                key=lambda t: (
+                    pts[t], gd[t], gf[t],
+                    all_teams[t].elo if t in all_teams else DEFAULT_ELO,
+                    random.random(),
+                ),
+                reverse=True,
+            )
+
+            for rank, tid in enumerate(sorted_ids):
+                elo = all_teams[tid].elo if tid in all_teams else DEFAULT_ELO
+                if rank == 0:
+                    group_win_count[tid] += 1
+                    qualifiers.append((tid, elo))
+                elif rank == 1:
+                    qualifiers.append((tid, elo))
+                elif rank == 2:
+                    third_pool.append((pts[tid], gd[tid], gf[tid], tid, elo))
+
+        # Best 8 third-place teams (by points, then GD, then GF)
+        third_pool.sort(key=lambda x: (x[0], x[1], x[2]), reverse=True)
+        for _, _, _, tid, elo in third_pool[:8]:
+            qualifiers.append((tid, elo))
+
+        if len(qualifiers) < 4:
+            continue
+
+        # Random bracket seeding for knockout (avoids deterministic outcomes)
+        bracket = qualifiers[:]
+        random.shuffle(bracket)
+
+        current = bracket
+        while len(current) > 1:
+            if len(current) == 4:
+                for tid, _ in current:
+                    semi_count[tid] += 1
+            elif len(current) == 2:
+                for tid, _ in current:
+                    final_count[tid] += 1
+
+            next_round: list[tuple] = []
+            for i in range(0, len(current) - 1, 2):
+                t1, e1 = current[i]
+                t2, e2 = current[i + 1]
+                h_xg, a_xg = elo_to_expected_goals(e1, e2)
+                h = _sample_goals_poisson(h_xg)
+                a = _sample_goals_poisson(a_xg)
+                if h > a:
+                    winner = (t1, e1)
+                elif a > h:
+                    winner = (t2, e2)
+                else:
+                    hw, _, aw = elo_to_win_prob(e1, e2)
+                    winner = (t1, e1) if random.random() < hw / (hw + aw) else (t2, e2)
+                next_round.append(winner)
+            if len(current) % 2 == 1:
+                next_round.append(current[-1])
+            current = next_round
+
+        if current:
+            win_count[current[0][0]] += 1
+
+    # ── assemble result ───────────────────────────────────────────────────────
+    all_ids = list(all_teams.keys())
+
+    group_winners: dict[str, dict] = {}
+    for group_name in sorted(group_to_teams.keys()):
+        tids = list(group_to_teams[group_name])
+        if not tids:
+            continue
+        best_id = max(tids, key=lambda t: group_win_count.get(t, 0))
+        t = all_teams.get(best_id)
+        if t:
+            group_winners[group_name] = {
+                "team": t.short_name or t.name,
+                "tla":  t.tla or "?",
+                "prob": round(group_win_count.get(best_id, 0) / n_sims, 3),
+            }
+
+    semifinalists = sorted(
+        [{"team": all_teams[t].short_name or all_teams[t].name,
+          "tla":  all_teams[t].tla or "?",
+          "prob": round(semi_count[t] / n_sims, 3)}
+         for t in all_ids if semi_count.get(t, 0) > 0],
+        key=lambda x: -x["prob"],
+    )[:4]
+
+    finalists = sorted(
+        [{"team": all_teams[t].short_name or all_teams[t].name,
+          "tla":  all_teams[t].tla or "?",
+          "prob": round(final_count[t] / n_sims, 3)}
+         for t in all_ids if final_count.get(t, 0) > 0],
+        key=lambda x: -x["prob"],
+    )[:2]
+
+    if win_count:
+        winner_id = max(all_ids, key=lambda t: win_count.get(t, 0))
+        w = all_teams[winner_id]
+        winner = {
+            "team": w.short_name or w.name,
+            "tla":  w.tla or "?",
+            "prob": round(win_count.get(winner_id, 0) / n_sims, 3),
+        }
+    else:
+        winner = {"team": "?", "tla": "?", "prob": 0.0}
+
+    top_scorer = _compute_top_scorer(db)
+
+    record = models.WmtBonusPrediction(
+        group_winners=group_winners,
+        semifinalists=semifinalists,
+        finalists=finalists,
+        winner=winner,
+        top_scorer=top_scorer,
+        n_simulations=n_sims,
+    )
+    db.add(record)
+    db.commit()
+    db.refresh(record)
+    return record
+
+
 # ── helpers for API response assembly ────────────────────────────────────────
 
 def _team_out(team: Optional[models.WmtTeam]) -> Optional[schemas.WmtTeamOut]:
@@ -573,3 +898,29 @@ def generate_summary_now(db: Session = Depends(get_db)):
     if content:
         return schemas.WmtRefreshOut(message="Zusammenfassung erstellt.", updated=1)
     return schemas.WmtRefreshOut(message="Keine abgeschlossenen Spiele für gestern gefunden.", updated=0)
+
+
+@router.get("/bonus", response_model=schemas.WmtBonusPredictionOut)
+def get_bonus(db: Session = Depends(get_db)):
+    record = (
+        db.query(models.WmtBonusPrediction)
+        .order_by(models.WmtBonusPrediction.generated_at.desc())
+        .first()
+    )
+    if not record:
+        raise HTTPException(status_code=404, detail="Noch keine Bonus-Prognose generiert.")
+    return record
+
+
+@router.post("/bonus/generate", response_model=schemas.WmtRefreshOut)
+def generate_bonus(db: Session = Depends(get_db)):
+    result = do_generate_bonus(db)
+    if result is None:
+        return schemas.WmtRefreshOut(
+            message="Keine Spielplan-Daten gefunden. Bitte zuerst ↻ klicken um Spielplan zu laden.",
+            updated=0,
+        )
+    return schemas.WmtRefreshOut(
+        message=f"Bonus-Prognose erstellt ({result.n_simulations:,} Simulationen).",
+        updated=1,
+    )

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -223,3 +223,15 @@ class WmtRefreshOut(BaseModel):
     message: str
     updated: int
 
+
+class WmtBonusPredictionOut(BaseModel):
+    id: int
+    generated_at: UtcDt
+    group_winners: Any
+    semifinalists: Any
+    finalists: Any
+    winner: Any
+    top_scorer: Any
+    n_simulations: int
+    model_config = {"from_attributes": True}
+

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -66,5 +66,7 @@ export const wmt = {
   getSummaries: ()           => get('/wmt/summaries'),
   refresh: ()                => post('/wmt/refresh'),
   generateSummary: ()        => post('/wmt/summary/generate'),
+  getBonus: ()               => get('/wmt/bonus'),
+  generateBonus: ()          => post('/wmt/bonus/generate'),
 }
 

--- a/frontend/src/pages/Wmt.jsx
+++ b/frontend/src/pages/Wmt.jsx
@@ -283,12 +283,14 @@ function resultColor(tipH, tipA, actH, actA) {
 export default function Wmt() {
   const [matches, setMatches]           = useState([])
   const [summaries, setSummaries]       = useState([])
+  const [bonus, setBonus]               = useState(null)
   const [view, setView]                 = useState('spieltage')
   const [selectedKey, setSelectedKey]   = useState(null)
   const [expandedId, setExpandedId]     = useState(null)
   const [predHistory, setPredHistory]   = useState({})
   const [loading, setLoading]           = useState(true)
   const [refreshing, setRefreshing]     = useState(false)
+  const [generatingBonus, setGeneratingBonus] = useState(false)
   const [logs, setLogs]                 = useState([])
   const logRef                          = useRef(null)
 
@@ -322,6 +324,11 @@ export default function Wmt() {
       setSummaries(ss)
       if (!silent) addLog(`${ss.length} Morgenberichte geladen`, 'done')
 
+      try {
+        const b = await wmt.getBonus()
+        setBonus(b)
+      } catch { /* 404 = not generated yet */ }
+
       const grouped   = groupMatches(ms)
       const gKeys     = sortGroupKeys(Object.keys(grouped))
       const activeKey = gKeys.find(k => grouped[k].some(m =>
@@ -338,6 +345,25 @@ export default function Wmt() {
   }, [addLog])
 
   useEffect(() => { loadAll() }, [loadAll])
+
+  async function handleGenerateBonus() {
+    setGeneratingBonus(true)
+    addLog('Bonus-Prognose wird berechnet (Monte-Carlo-Simulation)…')
+    const t0 = Date.now()
+    try {
+      const res = await wmt.generateBonus()
+      const elapsed = ((Date.now() - t0) / 1000).toFixed(1)
+      addLog(`${res.message} (${elapsed}s)`, res.updated ? 'done' : 'error')
+      if (res.updated) {
+        const b = await wmt.getBonus()
+        setBonus(b)
+      }
+    } catch (e) {
+      addLog('Fehler bei Bonus-Prognose', 'error')
+    } finally {
+      setGeneratingBonus(false)
+    }
+  }
 
   async function handleRefresh() {
     setRefreshing(true)
@@ -397,14 +423,14 @@ export default function Wmt() {
             }}>
             {refreshing ? '…' : '↻'}
           </button>
-          <span className="topbar-version">v1.5</span>
+          <span className="topbar-version">v1.6</span>
         </div>
       </div>
 
       <div className="page">
         {/* view tabs */}
-        <div style={{ display: 'flex', gap: 6, marginBottom: 20 }}>
-          {[['spieltage', 'Spieltage'], ['zusammenfassung', 'Morgenberichte'], ['log', 'Log']].map(([key, label]) => (
+        <div style={{ display: 'flex', gap: 6, marginBottom: 20, flexWrap: 'wrap' }}>
+          {[['spieltage', 'Spieltage'], ['bonus', 'Bonus-Tipps'], ['zusammenfassung', 'Morgenberichte'], ['log', 'Log']].map(([key, label]) => (
             <button
               key={key}
               onClick={() => setView(key)}
@@ -500,6 +526,15 @@ export default function Wmt() {
           </div>
         )}
 
+        {/* ── Bonus-Tipps view ──────────────────────────────────────────── */}
+        {!loading && view === 'bonus' && (
+          <BonusView
+            bonus={bonus}
+            generating={generatingBonus}
+            onGenerate={handleGenerateBonus}
+          />
+        )}
+
         {/* ── Morgenberichte view ────────────────────────────────────────── */}
         {!loading && view === 'zusammenfassung' && (
           <>
@@ -525,6 +560,155 @@ export default function Wmt() {
             )}
           </>
         )}
+      </div>
+    </div>
+  )
+}
+
+function BonusView({ bonus, generating, onGenerate }) {
+  const cardStyle = {
+    background: '#0d1221', border: '1px solid #1a2840',
+    borderRadius: 10, padding: '16px', marginBottom: 12,
+  }
+  const labelStyle = { fontSize: 10, color: '#374d66', letterSpacing: '0.1em', marginBottom: 8 }
+  const teamChip = (item, rank) => (
+    <div key={rank} style={{
+      display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+      padding: '7px 0', borderTop: rank > 0 ? '1px solid #1a2840' : 'none',
+    }}>
+      <div>
+        <span style={{ fontSize: 13, fontWeight: 600, color: '#eef2ff', marginRight: 8 }}>{item.tla}</span>
+        <span style={{ fontSize: 12, color: '#9ab0d0' }}>{item.team}</span>
+      </div>
+      <span style={{ fontSize: 12, color: '#4d6fa0', fontVariantNumeric: 'tabular-nums' }}>
+        {(item.prob * 100).toFixed(0)}%
+      </span>
+    </div>
+  )
+
+  const generateBtn = (
+    <button
+      onClick={onGenerate}
+      disabled={generating}
+      style={{
+        background: 'none', border: '1px solid #1a2840', color: '#4d6fa0',
+        borderRadius: 6, padding: '6px 14px', fontSize: 12,
+        cursor: generating ? 'not-allowed' : 'pointer',
+        fontFamily: 'inherit', opacity: generating ? 0.5 : 1,
+        marginBottom: 20,
+      }}>
+      {generating ? '… wird berechnet' : bonus ? '↻ Prognose neu berechnen' : '▶ Prognose berechnen'}
+    </button>
+  )
+
+  if (!bonus) {
+    return (
+      <div>
+        {generateBtn}
+        <div style={{ ...cardStyle, textAlign: 'center' }}>
+          <div style={{ fontSize: 13, color: '#9ab0d0', marginBottom: 8 }}>
+            Noch keine Bonus-Prognose vorhanden.
+          </div>
+          <div style={{ fontSize: 12, color: '#374d66', lineHeight: 1.6 }}>
+            Bitte zuerst ↻ klicken um den Spielplan zu laden, dann Prognose berechnen.
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  const groups = Object.entries(bonus.group_winners || {}).sort(([a], [b]) => a.localeCompare(b))
+  const generatedDate = new Date(bonus.generated_at).toLocaleDateString('de-DE',
+    { day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit' })
+
+  return (
+    <div>
+      {generateBtn}
+
+      {/* Turniersieger */}
+      {bonus.winner && (
+        <div style={{ ...cardStyle, borderColor: '#2a3d5c' }}>
+          <div style={labelStyle}>TURNIERSIEGER</div>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <div>
+              <span style={{ fontSize: 18, fontWeight: 700, color: '#eef2ff', marginRight: 10 }}>
+                {bonus.winner.tla}
+              </span>
+              <span style={{ fontSize: 14, color: '#9ab0d0' }}>{bonus.winner.team}</span>
+            </div>
+            <span style={{ fontSize: 16, fontWeight: 600, color: '#4d6fa0' }}>
+              {(bonus.winner.prob * 100).toFixed(0)}%
+            </span>
+          </div>
+        </div>
+      )}
+
+      {/* Finalisten */}
+      {bonus.finalists?.length > 0 && (
+        <div style={cardStyle}>
+          <div style={labelStyle}>FINALISTEN</div>
+          {bonus.finalists.map((item, i) => teamChip(item, i))}
+        </div>
+      )}
+
+      {/* Halbfinalisten */}
+      {bonus.semifinalists?.length > 0 && (
+        <div style={cardStyle}>
+          <div style={labelStyle}>HALBFINALISTEN</div>
+          {bonus.semifinalists.map((item, i) => teamChip(item, i))}
+        </div>
+      )}
+
+      {/* Torschützenkönig */}
+      {bonus.top_scorer && (
+        <div style={cardStyle}>
+          <div style={labelStyle}>TORSCHÜTZENKÖNIG</div>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+            <div>
+              <div style={{ fontSize: 14, fontWeight: 600, color: '#eef2ff', marginBottom: 3 }}>
+                {bonus.top_scorer.player}
+              </div>
+              <div style={{ fontSize: 12, color: '#9ab0d0' }}>
+                {bonus.top_scorer.tla} · {bonus.top_scorer.team}
+              </div>
+            </div>
+            <div style={{ textAlign: 'right' }}>
+              <div style={{ fontSize: 14, fontWeight: 600, color: '#4d6fa0' }}>
+                ~{bonus.top_scorer.goals} Tore
+              </div>
+              <div style={{ fontSize: 10, color: '#374d66', marginTop: 3 }}>
+                {bonus.top_scorer.source}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Gruppensieger */}
+      {groups.length > 0 && (
+        <div style={cardStyle}>
+          <div style={labelStyle}>GRUPPENSIEGER</div>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 8 }}>
+            {groups.map(([group, data]) => (
+              <div key={group} style={{
+                background: '#07091a', border: '1px solid #1a2840', borderRadius: 6,
+                padding: '8px 10px',
+              }}>
+                <div style={{ fontSize: 9, color: '#374d66', letterSpacing: '0.1em', marginBottom: 5 }}>
+                  GRUPPE {group}
+                </div>
+                <div style={{ fontSize: 13, fontWeight: 600, color: '#eef2ff' }}>{data.tla}</div>
+                <div style={{ fontSize: 10, color: '#4d6fa0', marginTop: 2 }}>
+                  {(data.prob * 100).toFixed(0)}%
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div style={{ fontSize: 10, color: '#374d66', textAlign: 'right', marginTop: 4 }}>
+        {bonus.n_simulations.toLocaleString('de-DE')} Simulationen · {generatedDate}
       </div>
     </div>
   )


### PR DESCRIPTION
Closes #191

## Summary

- **Monte Carlo simulation** (10,000 iterations) covering the full WC 2026 bracket: Poisson goal sampling per match using ELO, group standings by points → GD → GF, best-8 third-place selection, random bracket seeding for 5 knockout rounds
- **Top scorer prediction** using Euro 2024 scorer data from football-data.org (`/competitions/EC/scorers?season=2024`, free tier) — goals/match rate × expected tournament depth (ELO-derived); falls back to a static list of known international strikers
- **New DB table** `wmt_bonus_predictions` (JSONB columns: group_winners, semifinalists, finalists, winner, top_scorer)
- **New endpoints**: `GET /wmt/bonus`, `POST /wmt/bonus/generate`
- **New "Bonus-Tipps" tab** between Spieltage and Morgenberichte, showing: tournament winner, finalists, semifinalists, top scorer (with expected goals + source), group winners A–L in a 3-column grid
- All generate progress goes to the Log tab
- Bumped to **v1.6**

## Usage

1. Hit ↻ to load the match schedule (needed to build groups)
2. Switch to **Bonus-Tipps** → **▶ Prognose berechnen**
3. Results appear; regenerate any time with ↻ Prognose neu berechnen

https://claude.ai/code/session_01JqMuUbRgvGTqnS8yfw5ZUY

---
_Generated by [Claude Code](https://claude.ai/code/session_01JqMuUbRgvGTqnS8yfw5ZUY)_