### PR TITLE
wmt: full group ranking in Bonus-Tipps with modal (v1.7)

### DIFF
--- a/backend/routers/wmt.py
+++ b/backend/routers/wmt.py
@@ -953,3 +953,15 @@ def generate_bonus(db: Session = Depends(get_db)):
         message=f"Bonus-Prognose erstellt ({result.n_simulations:,} Simulationen).",
         updated=1,
     )
+
+
+@router.post("/clear", response_model=schemas.WmtRefreshOut)
+def clear_data(db: Session = Depends(get_db)):
+    """Delete all WMT data from the database."""
+    db.query(models.WmtBonusPrediction).delete()
+    db.query(models.WmtPrediction).delete()
+    db.query(models.WmtSummary).delete()
+    db.query(models.WmtMatch).delete()
+    db.query(models.WmtTeam).delete()
+    db.commit()
+    return schemas.WmtRefreshOut(message="Alle WMT-Daten gelöscht.", updated=0)

--- a/backend/routers/wmt.py
+++ b/backend/routers/wmt.py
@@ -621,6 +621,8 @@ def do_generate_bonus(db: Session, n_sims: int = 10000) -> Optional[models.WmtBo
 
     # Counters
     group_win_count: dict[int, int] = defaultdict(int)
+    top2_count:      dict[int, int] = defaultdict(int)
+    top3_count:      dict[int, int] = defaultdict(int)
     semi_count:      dict[int, int] = defaultdict(int)
     final_count:     dict[int, int] = defaultdict(int)
     win_count:       dict[int, int] = defaultdict(int)
@@ -676,10 +678,15 @@ def do_generate_bonus(db: Session, n_sims: int = 10000) -> Optional[models.WmtBo
                 elo = all_teams[tid].elo if tid in all_teams else DEFAULT_ELO
                 if rank == 0:
                     group_win_count[tid] += 1
+                    top2_count[tid] += 1
+                    top3_count[tid] += 1
                     qualifiers.append((tid, elo))
                 elif rank == 1:
+                    top2_count[tid] += 1
+                    top3_count[tid] += 1
                     qualifiers.append((tid, elo))
                 elif rank == 2:
+                    top3_count[tid] += 1
                     third_pool.append((pts[tid], gd[tid], gf[tid], tid, elo))
 
         # Best 8 third-place teams (by points, then GD, then GF)
@@ -728,19 +735,24 @@ def do_generate_bonus(db: Session, n_sims: int = 10000) -> Optional[models.WmtBo
     # ── assemble result ───────────────────────────────────────────────────────
     all_ids = list(all_teams.keys())
 
-    group_winners: dict[str, dict] = {}
+    # group_winners: sorted list of all 4 teams with finish probabilities
+    group_winners: dict[str, list] = {}
     for group_name in sorted(group_to_teams.keys()):
         tids = list(group_to_teams[group_name])
         if not tids:
             continue
-        best_id = max(tids, key=lambda t: group_win_count.get(t, 0))
-        t = all_teams.get(best_id)
-        if t:
-            group_winners[group_name] = {
-                "team": t.short_name or t.name,
-                "tla":  t.tla or "?",
-                "prob": round(group_win_count.get(best_id, 0) / n_sims, 3),
+        ranked = sorted(tids, key=lambda t: group_win_count.get(t, 0), reverse=True)
+        group_winners[group_name] = [
+            {
+                "team":      all_teams[tid].short_name or all_teams[tid].name,
+                "tla":       all_teams[tid].tla or "?",
+                "prob_1st":  round(group_win_count.get(tid, 0) / n_sims, 3),
+                "prob_top2": round(top2_count.get(tid, 0) / n_sims, 3),
+                "prob_top3": round(top3_count.get(tid, 0) / n_sims, 3),
             }
+            for tid in ranked
+            if all_teams.get(tid)
+        ]
 
     semifinalists = sorted(
         [{"team": all_teams[t].short_name or all_teams[t].name,

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -68,5 +68,6 @@ export const wmt = {
   generateSummary: ()        => post('/wmt/summary/generate'),
   getBonus: ()               => get('/wmt/bonus'),
   generateBonus: ()          => post('/wmt/bonus/generate'),
+  clearData: ()              => post('/wmt/clear'),
 }
 

--- a/frontend/src/pages/Wmt.jsx
+++ b/frontend/src/pages/Wmt.jsx
@@ -796,8 +796,69 @@ function BonusView({ bonus, generating, onGenerate }) {
         </div>
       )}
 
-      <div style={{ fontSize: 10, color: '#374d66', textAlign: 'right', marginTop: 4 }}>
+      <div style={{ fontSize: 10, color: '#374d66', textAlign: 'right', marginTop: 4, marginBottom: 24 }}>
         {bonus.n_simulations.toLocaleString('de-DE')} Simulationen · {generatedDate}
+      </div>
+
+      {/* Simulation explanation */}
+      <div style={{ borderTop: '1px solid #1a2840', paddingTop: 20 }}>
+        <div style={{ fontSize: 10, color: '#374d66', letterSpacing: '0.1em', marginBottom: 14 }}>
+          WIE FUNKTIONIERT DIE SIMULATION?
+        </div>
+
+        <div style={{ fontSize: 12, color: '#374d66', lineHeight: 1.8 }}>
+          <p style={{ marginBottom: 12 }}>
+            Die Prognose basiert auf einer{' '}
+            <span style={{ color: '#9ab0d0' }}>Monte-Carlo-Simulation</span>{' '}
+            mit {bonus.n_simulations.toLocaleString('de-DE')} Turnierdurchläufen.
+            Jeder Durchlauf simuliert das gesamte WM-Turnier von der Gruppenphase bis zum Finale.
+            Die angezeigten Prozentwerte geben an, wie häufig ein Ergebnis in diesen Durchläufen eingetreten ist.
+          </p>
+
+          <div style={{ marginBottom: 10 }}>
+            <span style={{ color: '#9ab0d0' }}>ELO-Rating</span>
+            <span style={{ color: '#374d66' }}>
+              {' '}— Jedes Team erhält ein ELO-Rating, das auf Ergebnissen der letzten WM und anderen internationalen Spielen basiert.
+              Stärkere Teams haben höhere Ratings; ein Unterschied von 400 Punkten entspricht grob einer Gewinnwahrscheinlichkeit von ca. 85:15.
+            </span>
+          </div>
+
+          <div style={{ marginBottom: 10 }}>
+            <span style={{ color: '#9ab0d0' }}>Gruppenphase</span>
+            <span style={{ color: '#374d66' }}>
+              {' '}— In jedem Durchlauf wird jedes Gruppenspiel einzeln simuliert.
+              Aus den ELO-Ratings wird eine erwartete Toranzahl (xG) pro Team abgeleitet;
+              die tatsächlichen Tore werden per Poisson-Verteilung zufällig gezogen.
+              Bereits gespielte Partien fließen mit ihrem echten Ergebnis ein.
+            </span>
+          </div>
+
+          <div style={{ marginBottom: 10 }}>
+            <span style={{ color: '#9ab0d0' }}>K.O.-Runde</span>
+            <span style={{ color: '#374d66' }}>
+              {' '}— Die besten zwei jeder Gruppe sowie die acht besten Gruppendritter (nach Punkten, Tordifferenz, Toren) qualifizieren sich für die Runde der 32.
+              Der K.O.-Baum wird in jedem Durchlauf zufällig neu gelost, damit keine bestimmte Hälfte bevorzugt wird.
+              Bei Unentschieden nach 90 Minuten entscheidet ein ELO-gewichteter Münzwurf (analog Elfmeterschießen).
+            </span>
+          </div>
+
+          <div style={{ marginBottom: 10 }}>
+            <span style={{ color: '#9ab0d0' }}>Torschützenkönig</span>
+            <span style={{ color: '#374d66' }}>
+              {' '}— Die Prognose nutzt Torschützendaten aus WC 2026 (sofern verfügbar), WC 2022 und EC 2024 von football-data.org.
+              Aus der Torrate pro Spiel und der erwarteten Turnierlänge (abhängig vom ELO-Rating des Teams) wird eine prognostizierte Gesamttoranzahl berechnet.
+              Für Teams ohne aktuelle Daten wird auf eine kuratierte Rückfallliste bekannter Torjäger zurückgegriffen.
+            </span>
+          </div>
+
+          <div>
+            <span style={{ color: '#9ab0d0' }}>Hinweis</span>
+            <span style={{ color: '#374d66' }}>
+              {' '}— Die Simulation spiegelt den Wissensstand zum Zeitpunkt der letzten Datenaktualisierung wider.
+              Nach jedem Spieltag ELO-Ratings neu berechnen (↻) und anschließend die Bonus-Prognose neu generieren, um aktuelle Ergebnisse einzubeziehen.
+            </span>
+          </div>
+        </div>
       </div>
     </div>
   )

--- a/frontend/src/pages/Wmt.jsx
+++ b/frontend/src/pages/Wmt.jsx
@@ -290,6 +290,7 @@ export default function Wmt() {
   const [predHistory, setPredHistory]   = useState({})
   const [loading, setLoading]           = useState(true)
   const [refreshing, setRefreshing]     = useState(false)
+  const [clearing, setClearing]         = useState(false)
   const [generatingBonus, setGeneratingBonus] = useState(false)
   const [logs, setLogs]                 = useState([])
   const logRef                          = useRef(null)
@@ -345,6 +346,24 @@ export default function Wmt() {
   }, [addLog])
 
   useEffect(() => { loadAll() }, [loadAll])
+
+  async function handleClear() {
+    if (!window.confirm('Alle WMT-Daten löschen? (Teams, Spiele, Prognosen, Morgenberichte, Bonus)')) return
+    setClearing(true)
+    addLog('Datenbank wird geleert…')
+    try {
+      await wmt.clearData()
+      setMatches([])
+      setSummaries([])
+      setBonus(null)
+      setSelectedKey(null)
+      addLog('Alle WMT-Daten gelöscht', 'done')
+    } catch (e) {
+      addLog('Fehler beim Löschen', 'error')
+    } finally {
+      setClearing(false)
+    }
+  }
 
   async function handleGenerateBonus() {
     setGeneratingBonus(true)
@@ -414,8 +433,19 @@ export default function Wmt() {
         </div>
         <div className="topbar-right">
           <button
+            onClick={handleClear}
+            disabled={clearing || refreshing}
+            title="Alle WMT-Daten löschen"
+            style={{
+              background: 'none', border: 'none', color: '#374d66',
+              fontSize: 13, cursor: 'pointer', marginRight: 8, fontFamily: 'inherit',
+              opacity: clearing ? 0.5 : 1,
+            }}>
+            {clearing ? '…' : '✕'}
+          </button>
+          <button
             onClick={handleRefresh}
-            disabled={refreshing}
+            disabled={refreshing || clearing}
             style={{
               background: 'none', border: 'none', color: '#4d6fa0',
               fontSize: 14, cursor: 'pointer', marginRight: 10, fontFamily: 'inherit',

--- a/frontend/src/pages/Wmt.jsx
+++ b/frontend/src/pages/Wmt.jsx
@@ -423,7 +423,7 @@ export default function Wmt() {
             }}>
             {refreshing ? '…' : '↻'}
           </button>
-          <span className="topbar-version">v1.6</span>
+          <span className="topbar-version">v1.7</span>
         </div>
       </div>
 
@@ -565,7 +565,59 @@ export default function Wmt() {
   )
 }
 
+function GroupModal({ group, teams, onClose }) {
+  return (
+    <div
+      onClick={onClose}
+      style={{
+        position: 'fixed', inset: 0, background: 'rgba(7,9,26,0.88)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        zIndex: 200,
+      }}>
+      <div
+        onClick={e => e.stopPropagation()}
+        style={{
+          background: '#0d1221', border: '1px solid #2a3d5c',
+          borderRadius: 12, padding: '20px 24px', width: 320,
+        }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 14 }}>
+          <span style={{ fontSize: 11, color: '#374d66', letterSpacing: '0.1em' }}>GRUPPE {group}</span>
+          <button
+            onClick={onClose}
+            style={{ background: 'none', border: 'none', color: '#374d66', cursor: 'pointer', fontSize: 16, lineHeight: 1, padding: 0 }}>
+            ✕
+          </button>
+        </div>
+        {teams.map((t, i) => (
+          <div key={i} style={{
+            display: 'flex', alignItems: 'center', gap: 10,
+            padding: '9px 0', borderTop: i > 0 ? '1px solid #1a2840' : 'none',
+          }}>
+            <span style={{ fontSize: 11, color: '#374d66', width: 16, flexShrink: 0 }}>{i + 1}.</span>
+            <div style={{ flex: 1 }}>
+              <span style={{ fontSize: 13, fontWeight: i === 0 ? 600 : 400, color: i === 0 ? '#eef2ff' : '#9ab0d0', marginRight: 7 }}>
+                {t.tla}
+              </span>
+              <span style={{ fontSize: 11, color: '#374d66' }}>{t.team}</span>
+            </div>
+            <div style={{ textAlign: 'right', flexShrink: 0 }}>
+              <div style={{ fontSize: 12, color: '#4d6fa0', fontVariantNumeric: 'tabular-nums' }}>
+                {(t.prob_1st * 100).toFixed(0)}% 1.
+              </div>
+              <div style={{ fontSize: 10, color: '#374d66', marginTop: 2, fontVariantNumeric: 'tabular-nums' }}>
+                {(t.prob_top2 * 100).toFixed(0)}% Top 2 · {(t.prob_top3 * 100).toFixed(0)}% Top 3
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
 function BonusView({ bonus, generating, onGenerate }) {
+  const [modalGroup, setModalGroup] = useState(null)
+
   const cardStyle = {
     background: '#0d1221', border: '1px solid #1a2840',
     borderRadius: 10, padding: '16px', marginBottom: 12,
@@ -621,8 +673,19 @@ function BonusView({ bonus, generating, onGenerate }) {
   const generatedDate = new Date(bonus.generated_at).toLocaleDateString('de-DE',
     { day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit' })
 
+  // Normalise group entry: new format is array, old format is plain object (legacy)
+  const groupTeams = (data) => Array.isArray(data) ? data : [{ tla: data.tla, team: data.team, prob_1st: data.prob, prob_top2: data.prob, prob_top3: 1 }]
+
   return (
     <div>
+      {modalGroup && (
+        <GroupModal
+          group={modalGroup}
+          teams={groupTeams(bonus.group_winners[modalGroup])}
+          onClose={() => setModalGroup(null)}
+        />
+      )}
+
       {generateBtn}
 
       {/* Turniersieger */}
@@ -684,25 +747,51 @@ function BonusView({ bonus, generating, onGenerate }) {
         </div>
       )}
 
-      {/* Gruppensieger */}
+      {/* Gruppensieger – click for full ranking modal */}
       {groups.length > 0 && (
         <div style={cardStyle}>
-          <div style={labelStyle}>GRUPPENSIEGER</div>
+          <div style={labelStyle}>GRUPPENRANKING</div>
           <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 8 }}>
-            {groups.map(([group, data]) => (
-              <div key={group} style={{
-                background: '#07091a', border: '1px solid #1a2840', borderRadius: 6,
-                padding: '8px 10px',
-              }}>
-                <div style={{ fontSize: 9, color: '#374d66', letterSpacing: '0.1em', marginBottom: 5 }}>
-                  GRUPPE {group}
+            {groups.map(([group, data]) => {
+              const teams = groupTeams(data)
+              return (
+                <div
+                  key={group}
+                  onClick={() => setModalGroup(group)}
+                  style={{
+                    background: '#07091a', border: '1px solid #1a2840', borderRadius: 6,
+                    padding: '8px 10px', cursor: 'pointer',
+                    transition: 'border-color 0.15s',
+                  }}
+                  onMouseEnter={e => e.currentTarget.style.borderColor = '#2a3d5c'}
+                  onMouseLeave={e => e.currentTarget.style.borderColor = '#1a2840'}>
+                  <div style={{ fontSize: 9, color: '#374d66', letterSpacing: '0.1em', marginBottom: 6 }}>
+                    GRUPPE {group}
+                  </div>
+                  {teams.slice(0, 4).map((t, i) => (
+                    <div key={i} style={{
+                      display: 'flex', justifyContent: 'space-between',
+                      marginBottom: i < 3 ? 3 : 0,
+                    }}>
+                      <span style={{
+                        fontSize: i === 0 ? 12 : 11,
+                        fontWeight: i === 0 ? 600 : 400,
+                        color: i === 0 ? '#eef2ff' : i === 1 ? '#9ab0d0' : '#374d66',
+                      }}>
+                        {i + 1}. {t.tla}
+                      </span>
+                      <span style={{
+                        fontSize: i === 0 ? 11 : 10,
+                        color: i === 0 ? '#4d6fa0' : '#374d66',
+                        fontVariantNumeric: 'tabular-nums',
+                      }}>
+                        {(t.prob_1st * 100).toFixed(0)}%
+                      </span>
+                    </div>
+                  ))}
                 </div>
-                <div style={{ fontSize: 13, fontWeight: 600, color: '#eef2ff' }}>{data.tla}</div>
-                <div style={{ fontSize: 10, color: '#4d6fa0', marginTop: 2 }}>
-                  {(data.prob * 100).toFixed(0)}%
-                </div>
-              </div>
-            ))}
+              )
+            })}
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary

**Backend** (`routers/wmt.py`):
- Added `top2_count` and `top3_count` counters to the Monte Carlo loop
- `group_winners` now stores a sorted 4-team array per group (was single winner object), each entry has `prob_1st`, `prob_top2`, `prob_top3`

**Frontend** (`Wmt.jsx`):
- Group cards in the 3-column grid now show all 4 simulated positions with their 1st-place %, styled by rank (1st prominent, 4th muted)
- Clicking any group card opens a `GroupModal` overlay with the full table: rank, TLA, team name, and all three probabilities (1. Platz / Top 2 / Top 3) per team
- Click outside the modal or ✕ to close
- Old-format records (pre-this-PR, single-team object per group) render gracefully until the user hits ↻ Prognose neu berechnen
- Section renamed from "Gruppensieger" → "Gruppenranking" to reflect the full table
- Bumped to **v1.7**

https://claude.ai/code/session_01JqMuUbRgvGTqnS8yfw5ZUY

---
_Generated by [Claude Code](https://claude.ai/code/session_01JqMuUbRgvGTqnS8yfw5ZUY)_