### PR TITLE
wmt: hide … loading indicator when log tab is active

### DIFF
--- a/frontend/src/pages/Wmt.jsx
+++ b/frontend/src/pages/Wmt.jsx
@@ -488,7 +488,7 @@ export default function Wmt() {
           ))}
         </div>
 
-        {loading && (
+        {loading && view !== 'log' && (
           <div style={{ color: '#374d66', fontSize: 12 }}>…</div>
         )}
 


### PR DESCRIPTION
One-line fix: suppress the global `…` loading spinner when `view === 'log'`, since the log already shows load progress via its own entries.

https://claude.ai/code/session_01JqMuUbRgvGTqnS8yfw5ZUY

---
_Generated by [Claude Code](https://claude.ai/code/session_01JqMuUbRgvGTqnS8yfw5ZUY)_