### PR TITLE
wmt: add diagnostic for openligadb data-received-but-0-inserted case

### DIFF
--- a/backend/routers/wmt.py
+++ b/backend/routers/wmt.py
@@ -326,12 +326,15 @@ def do_refresh(db: Session) -> tuple[int, str]:
         logger.warning("WMT openligadb %s: leere Antwort (Liga noch nicht verfügbar?)", WM2026_LEAGUE)
         return 0, f"openligadb: Keine Spiele in Liga '{WM2026_LEAGUE}' — Liga möglicherweise noch nicht angelegt"
 
+    total_received = len(matches_data)
     updated = 0
+    skipped_no_id = 0
     newly_finished: list[models.WmtMatch] = []
 
     for m in matches_data:
         openligadb_id = m.get("MatchID")
         if not openligadb_id:
+            skipped_no_id += 1
             continue
 
         t1 = m.get("Team1") or {}
@@ -444,6 +447,15 @@ def do_refresh(db: Session) -> tuple[int, str]:
         ))
 
     db.commit()
+    if updated == 0 and total_received > 0:
+        first = matches_data[0]
+        first_id  = first.get("MatchID")
+        first_keys = list(first.keys())[:6]
+        return 0, (
+            f"openligadb: {total_received} Objekte empfangen, 0 eingefügt "
+            f"(erstes MatchID={first_id!r}, Felder: {first_keys}, "
+            f"MatchIDs fehlend: {skipped_no_id}/{total_received})"
+        )
     return updated, ""
 
 

--- a/frontend/src/pages/Wmt.jsx
+++ b/frontend/src/pages/Wmt.jsx
@@ -465,7 +465,7 @@ export default function Wmt() {
             }}>
             {refreshing ? '…' : '↻'}
           </button>
-          <span className="topbar-version">v1.9</span>
+          <span className="topbar-version">v1.10</span>
         </div>
       </div>
 


### PR DESCRIPTION
When openligadb returns data but nothing gets inserted, the log now shows:

```
openligadb: 144 Objekte empfangen, 0 eingefügt (erstes MatchID=None, Felder: ['key1', 'key2', ...], MatchIDs fehlend: 144/144)
```

This will immediately reveal whether `MatchID` is named differently in the wm2026 data (e.g. `matchId`, `id`, `GameID`) vs what we're looking for.

https://claude.ai/code/session_01JqMuUbRgvGTqnS8yfw5ZUY

---
_Generated by [Claude Code](https://claude.ai/code/session_01JqMuUbRgvGTqnS8yfw5ZUY)_