### PR TITLE
wmt: revert resultTypeID-1 fallback (half-time data)

### DIFF
--- a/backend/routers/wmt.py
+++ b/backend/routers/wmt.py
@@ -304,15 +304,9 @@ def _fetch_openligadb(league: str) -> tuple[list[dict], str]:
 
 
 def _openligadb_final_score(match: dict) -> tuple[Optional[int], Optional[int]]:
-    """Endergebnis aus matchResults extrahieren.
-    Sucht zuerst resultTypeID 2 (Endergebnis modern), dann Fallback auf 1 (ältere Datensätze).
-    """
-    results = match.get("matchResults") or []
-    for res in results:
+    """Endergebnis (resultTypeID 2) aus matchResults extrahieren."""
+    for res in (match.get("matchResults") or []):
         if res.get("resultTypeID") == 2:
-            return res.get("pointsTeam1"), res.get("pointsTeam2")
-    for res in results:
-        if res.get("resultTypeID") == 1:
             return res.get("pointsTeam1"), res.get("pointsTeam2")
     return None, None
 


### PR DESCRIPTION
## Summary

Reverts the `resultTypeID == 1` fallback added in PR #209.

The em2016 openligadb data's type-1 entries turn out to be half-time scores (Ø 0.84 goals/match observed vs ~2.1 expected for a major tournament). Using them for ELO calibration causes decisive matches to be silently recorded as 0:0 draws, degrading the calibration quality.

Reverting to type-2 only means em2016 is skipped with the diagnostic message rather than calibrated with wrong data. The warmup base stays at **wm2022 + em2024 = 103 clean matches**.

https://claude.ai/code/session_01JqMuUbRgvGTqnS8yfw5ZUY

---
_Generated by [Claude Code](https://claude.ai/code/session_01JqMuUbRgvGTqnS8yfw5ZUY)_