### PR TITLE
wmt: reduce football-data.org timeout, show refresh errors in red

### DIFF
--- a/backend/routers/wmt.py
+++ b/backend/routers/wmt.py
@@ -63,7 +63,7 @@ def _fetch_fdorg_matches(comp_code: str) -> tuple[list[dict], str]:
     """Alle Spiele eines Wettbewerbs von football-data.org abrufen."""
     url = f"{FOOTBALL_API_BASE}/competitions/{comp_code}/matches"
     try:
-        with httpx.Client(timeout=30.0, follow_redirects=True) as client:
+        with httpx.Client(timeout=10.0, follow_redirects=True) as client:
             r = client.get(url, headers=_api_headers())
         if r.status_code != 200:
             snippet = r.text[:120].replace("\n", " ") if r.text else ""

--- a/frontend/src/pages/Wmt.jsx
+++ b/frontend/src/pages/Wmt.jsx
@@ -443,8 +443,9 @@ export default function Wmt() {
     try {
       const res = await wmt.refresh()
       const elapsed = ((Date.now() - t0) / 1000).toFixed(1)
-      addLog(`${res.message} (${elapsed}s)`, 'done')
-      await loadAll(true)
+      const isErr = !res.updated && !res.message?.startsWith('Aktualisierung')
+      addLog(`${res.message} (${elapsed}s)`, isErr ? 'error' : 'done')
+      if (!isErr) await loadAll(true)
       addLog('Ansicht aktualisiert', 'done')
     } catch (e) {
       addLog('Fehler beim Refresh', 'error')


### PR DESCRIPTION
## Problem

When football-data.org is slow or unresponsive, the backend's 30s httpx timeout causes the total request time to exceed Railway's proxy window (~35–50s). Railway returns a 502/504, `api.js` throws (`!res.ok`), and the frontend shows the generic **"Fehler beim Refresh"** catch message with no detail. The burger menu stays disabled the entire time.

## Fix

- **httpx timeout 30s → 10s** for `_fetch_fdorg_matches`: the backend now responds within ~12s, well inside Railway's proxy window. The proper error message (e.g. `"football-data.org: timed out"`) reaches the UI instead of a gateway error.
- **Refresh error log level**: when the response signals a failure (no updates, message doesn't start with "Aktualisierung"), log in red (`'error'`) rather than green (`'done'`). Also skips the `loadAll` reload on error since there's nothing new to show.

## Side note from the log

`em2016` diagnostic shows `"Kein TLA für: SV Großefehn"` — a German amateur club leaked into openligadb's EM 2016 dataset. Not actionable since em2016 is already skipped (no type-2 score entries).

https://claude.ai/code/session_01JqMuUbRgvGTqnS8yfw5ZUY

---
_Generated by [Claude Code](https://claude.ai/code/session_01JqMuUbRgvGTqnS8yfw5ZUY)_