### PR TITLE
wmt: update stale ↻ references to burger menu wording

### DIFF
--- a/backend/routers/wmt.py
+++ b/backend/routers/wmt.py
@@ -1114,7 +1114,7 @@ def do_historical_warmup(db: Session) -> dict:
 
     db.query(models.WmtPrediction).delete()
     db.commit()
-    log("Alte Prognosen gelöscht — bitte ↻ klicken um neue zu erstellen")
+    log("Alte Prognosen gelöscht — bitte Spielplan aktualisieren (☰) für neue Prognosen")
 
     top_teams = sorted(
         db.query(models.WmtTeam).all(),

--- a/frontend/src/pages/Wmt.jsx
+++ b/frontend/src/pages/Wmt.jsx
@@ -468,7 +468,7 @@ export default function Wmt() {
       setLogs(prev => [...prev, ...serverLogs])
       addLog(`Kalibrierung abgeschlossen (${res.elapsed_seconds?.toFixed(1)}s)`, 'done')
       await loadAll(true)
-      addLog('ELO-Ratings aktualisiert — bitte ↻ für neue Prognosen klicken', 'done')
+      addLog('ELO-Ratings aktualisiert — bitte Spielplan aktualisieren (☰) für neue Prognosen', 'done')
     } catch (e) {
       addLog('Fehler bei der Kalibrierung', 'error')
     } finally {


### PR DESCRIPTION
Replaces two log messages that still referred to the old `↻` topbar button with the current "Spielplan aktualisieren (☰)" wording.

- `backend/routers/wmt.py`: warmup completion log
- `frontend/src/pages/Wmt.jsx`: post-warmup frontend log

https://claude.ai/code/session_01JqMuUbRgvGTqnS8yfw5ZUY

---
_Generated by [Claude Code](https://claude.ai/code/session_01JqMuUbRgvGTqnS8yfw5ZUY)_