### PR TITLE
wmt: fake MD1 results for pre-tournament testing

### DIFF
--- a/backend/routers/wmt.py
+++ b/backend/routers/wmt.py
@@ -1145,6 +1145,77 @@ def do_historical_warmup(db: Session) -> dict:
     }
 
 
+# ── fake MD1 results (dev/test) ───────────────────────────────────────────────
+
+def do_fake_md1(db: Session) -> tuple[int, str]:
+    """Fake-Ergebnisse für alle ausstehenden Gruppenphase-MD1-Spiele setzen.
+
+    Ablauf: ELO-Prognose → normale Ergebnisse für die meisten Spiele,
+    die 3 Spiele mit dem größten ELO-Abstand werden als Upset umgekehrt
+    (Außenseiter gewinnt), um spätere Prognose-Updates sichtbar zu machen.
+    """
+    md1_matches = (
+        db.query(models.WmtMatch)
+        .filter(
+            models.WmtMatch.stage == "GROUP_STAGE",
+            models.WmtMatch.matchday == 1,
+            models.WmtMatch.status != "FINISHED",
+            models.WmtMatch.home_team_id.isnot(None),
+            models.WmtMatch.away_team_id.isnot(None),
+        )
+        .order_by(models.WmtMatch.utc_date)
+        .all()
+    )
+    if not md1_matches:
+        return 0, "Keine ausstehenden MD1-Spiele mit Teambesetzung gefunden."
+
+    def elo_gap(m: models.WmtMatch) -> float:
+        h = db.get(models.WmtTeam, m.home_team_id)
+        a = db.get(models.WmtTeam, m.away_team_id)
+        return abs(h.elo - a.elo) if h and a else 0.0
+
+    upset_ids = {m.id for m in sorted(md1_matches, key=elo_gap, reverse=True)[:3]}
+
+    newly_finished: list[models.WmtMatch] = []
+    for m in md1_matches:
+        home = db.get(models.WmtTeam, m.home_team_id)
+        away = db.get(models.WmtTeam, m.away_team_id)
+        if not home or not away:
+            continue
+
+        home_win, _, away_win = elo_to_win_prob(home.elo, away.elo)
+        home_xg, away_xg = elo_to_expected_goals(home.elo, away.elo)
+        tip_h = max(0, round(home_xg))
+        tip_a = max(0, round(away_xg))
+        if tip_h == tip_a:
+            if home_win > away_win + 0.1:
+                tip_h += 1
+            elif away_win > home_win + 0.1:
+                tip_a += 1
+
+        if m.id in upset_ids:
+            if tip_h != tip_a:
+                # Swap: normally-losing team now wins
+                score_h, score_a = tip_a, tip_h
+            else:
+                # Draw expected → underdog wins 1:0
+                if home.elo <= away.elo:
+                    score_h, score_a = 1, 0
+                else:
+                    score_h, score_a = 0, 1
+        else:
+            score_h, score_a = tip_h, tip_a
+
+        m.score_home = score_h
+        m.score_away = score_a
+        m.status = "FINISHED"
+        newly_finished.append(m)
+
+    db.commit()
+    _apply_elo_and_predictions(db, newly_finished)
+    return len(newly_finished), ""
+
+
 # ── helpers for API response assembly ────────────────────────────────────────
 
 def _team_out(team: Optional[models.WmtTeam]) -> Optional[schemas.WmtTeamOut]:
@@ -1316,3 +1387,15 @@ def clear_data(db: Session = Depends(get_db)):
     db.query(models.WmtTeam).delete()
     db.commit()
     return schemas.WmtRefreshOut(message="Alle WMT-Daten gelöscht.", updated=0)
+
+
+@router.post("/debug/fake-md1", response_model=schemas.WmtRefreshOut)
+def fake_md1_results(db: Session = Depends(get_db)):
+    """Fake-Ergebnisse für alle ausstehenden MD1-Spiele setzen (nur für Tests)."""
+    n, err = do_fake_md1(db)
+    if err:
+        return schemas.WmtRefreshOut(message=err, updated=0)
+    return schemas.WmtRefreshOut(
+        message=f"Fake-Ergebnisse gesetzt: {n} MD1-Spiel{'e' if n != 1 else ''} abgeschlossen.",
+        updated=n,
+    )

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -70,5 +70,6 @@ export const wmt = {
   generateBonus: ()          => post('/wmt/bonus/generate'),
   clearData: ()              => post('/wmt/clear'),
   warmup: ()                 => post('/wmt/warmup'),
+  fakeMd1: ()                => post('/wmt/debug/fake-md1'),
 }
 

--- a/frontend/src/pages/Wmt.jsx
+++ b/frontend/src/pages/Wmt.jsx
@@ -342,6 +342,7 @@ export default function Wmt() {
   const [clearing, setClearing]         = useState(false)
   const [warming, setWarming]           = useState(false)
   const [generatingBonus, setGeneratingBonus] = useState(false)
+  const [fakingMd1, setFakingMd1]       = useState(false)
   const [logs, setLogs]                 = useState([])
   const [menuOpen, setMenuOpen]         = useState(false)
   const logRef                          = useRef(null)
@@ -476,6 +477,23 @@ export default function Wmt() {
     }
   }
 
+  async function handleFakeMd1() {
+    setFakingMd1(true)
+    setView('import')
+    addLog('Fake MD1-Ergebnisse werden gesetzt…')
+    const t0 = Date.now()
+    try {
+      const res = await wmt.fakeMd1()
+      const elapsed = ((Date.now() - t0) / 1000).toFixed(1)
+      addLog(`${res.message} (${elapsed}s)`, res.updated ? 'done' : 'error')
+      if (res.updated) await loadAll(true)
+    } catch (e) {
+      addLog('Fehler beim Setzen der Fake-Ergebnisse', 'error')
+    } finally {
+      setFakingMd1(false)
+    }
+  }
+
   async function handleTogglePred(matchId) {
     if (expandedId === matchId) {
       setExpandedId(null)
@@ -492,7 +510,7 @@ export default function Wmt() {
     }
   }
 
-  const anyBusy = refreshing || clearing || warming || generatingBonus
+  const anyBusy = refreshing || clearing || warming || generatingBonus || fakingMd1
 
   const grouped       = groupMatches(matches)
   const groupKeys     = sortGroupKeys(Object.keys(grouped))
@@ -560,6 +578,12 @@ export default function Wmt() {
               icon="✕" label="Daten löschen"
               danger loading={clearing} disabled={anyBusy && !clearing}
               onClick={() => { setMenuOpen(false); handleClear() }}
+            />
+            <div style={{ borderTop: '1px solid #1a2840', margin: '6px 0' }} />
+            <MenuButton
+              icon="⚗" label="Fake MD1-Ergebnisse"
+              loading={fakingMd1} disabled={anyBusy && !fakingMd1}
+              onClick={() => { setMenuOpen(false); handleFakeMd1() }}
             />
           </div>
         </div>


### PR DESCRIPTION
## Summary

- Adds `POST /api/wmt/debug/fake-md1` — sets FINISHED results on all pending GROUP_STAGE matchday=1 matches
- Most matches get ELO-derived expected scores (rounded xG); the **3 matches with the biggest ELO gap are flipped** so the underdog wins, creating visible prediction divergence for MD2/MD3
- After scores are set, `_apply_elo_and_predictions` runs automatically: team ELOs shift and MD2/MD3 prediction cards show revised forecasts
- Frontend: "⚗ Fake MD1-Ergebnisse" button in the burger menu (below a separator after "Daten löschen")

## How to test

1. Import the full schedule (↻ Spielplan aktualisieren)
2. Open the burger menu → **⚗ Fake MD1-Ergebnisse**
3. Switch to Spieltage → MD 1: all matches show as FINISHED with "Prognose war X:Y ✓/✗"
4. Switch to MD 2 or MD 3: prediction cards now show updated ELO-based forecasts (click "Begründung ▼" to see the revised ELO snapshot — teams that lost upsets will have lower ELO than before)
5. Re-running the action does nothing (filter excludes already-FINISHED matches)

https://claude.ai/code/session_01JqMuUbRgvGTqnS8yfw5ZUY

---
_Generated by [Claude Code](https://claude.ai/code/session_01JqMuUbRgvGTqnS8yfw5ZUY)_