### PR TITLE
wmt: after fake MD1 navigate to Spieltage / MD 1

### DIFF
--- a/frontend/src/pages/Wmt.jsx
+++ b/frontend/src/pages/Wmt.jsx
@@ -486,7 +486,11 @@ export default function Wmt() {
       const res = await wmt.fakeMd1()
       const elapsed = ((Date.now() - t0) / 1000).toFixed(1)
       addLog(`${res.message} (${elapsed}s)`, res.updated ? 'done' : 'error')
-      if (res.updated) await loadAll(true)
+      if (res.updated) {
+        await loadAll(true)
+        setView('spieltage')
+        setSelectedKey('md_1')
+      }
     } catch (e) {
       addLog('Fehler beim Setzen der Fake-Ergebnisse', 'error')
     } finally {


### PR DESCRIPTION
## Summary

After `loadAll(true)` runs following a successful fake MD1 operation, the `activeKey` finder inside `loadAll` selects MD2 (the first group that still has non-finished matches). The `setSelectedKey(prev => prev ?? activeKey)` guard only preserves the previous key if it's non-null — so if `selectedKey` was somehow null or on a different matchday, the user would land on MD2, not MD1.

Additionally the view stayed on 'import' after the fake, requiring a manual tab switch.

**Fix:** explicitly set `view='spieltage'` and `selectedKey='md_1'` after `loadAll(true)` resolves, so the user is taken directly to the completed results.

https://claude.ai/code/session_01JqMuUbRgvGTqnS8yfw5ZUY

---
_Generated by [Claude Code](https://claude.ai/code/session_01JqMuUbRgvGTqnS8yfw5ZUY)_