### PR TITLE
wmt: smart startup with DB status check and ELO calibration detection (v2.1)

### DIFF
--- a/backend/routers/wmt.py
+++ b/backend/routers/wmt.py
@@ -1277,6 +1277,30 @@ def _match_out(match: models.WmtMatch, db: Session) -> schemas.WmtMatchOut:
 
 # ── API endpoints ─────────────────────────────────────────────────────────────
 
+def _is_calibrated(db: Session) -> bool:
+    """True wenn ELO-Werte merklich von INITIAL_ELO abweichen (Warmup wurde durchgeführt)."""
+    teams = db.query(models.WmtTeam).filter(models.WmtTeam.tla.isnot(None)).all()
+    if not teams:
+        return False
+    total_diff, count = 0.0, 0
+    for t in teams:
+        initial = INITIAL_ELO.get(t.tla)
+        if initial is not None:
+            total_diff += abs(t.elo - initial)
+            count += 1
+    return count > 0 and (total_diff / count) > 10.0
+
+
+@router.get("/status", response_model=schemas.WmtStatusOut)
+def get_status(db: Session = Depends(get_db)):
+    return schemas.WmtStatusOut(
+        match_count=db.query(models.WmtMatch).count(),
+        team_count=db.query(models.WmtTeam).count(),
+        prediction_count=db.query(models.WmtPrediction).count(),
+        calibrated=_is_calibrated(db),
+    )
+
+
 @router.get("/matches", response_model=list[schemas.WmtMatchOut])
 def list_matches(db: Session = Depends(get_db)):
     matches = (

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -244,3 +244,10 @@ class WmtWarmupOut(BaseModel):
     teams_updated: int
     elapsed_seconds: float
 
+
+class WmtStatusOut(BaseModel):
+    match_count: int
+    team_count: int
+    prediction_count: int
+    calibrated: bool
+

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -60,6 +60,7 @@ export const str = {
 
 // ── wmt ───────────────────────────────────────────────────────
 export const wmt = {
+  getStatus: ()              => get('/wmt/status'),
   getMatches: ()             => get('/wmt/matches'),
   getMatchPredictions: (id)  => get(`/wmt/matches/${id}/predictions`),
   getTeams: ()               => get('/wmt/teams'),

--- a/frontend/src/pages/Wmt.jsx
+++ b/frontend/src/pages/Wmt.jsx
@@ -356,26 +356,13 @@ export default function Wmt() {
     if (el) el.scrollTop = el.scrollHeight
   }, [logs])
 
-  const loadAll = useCallback(async (silent = false) => {
-    if (!silent) setLoading(true)
+  const loadAll = useCallback(async () => {
     try {
       const ms = await wmt.getMatches()
       setMatches(ms)
-      if (!silent) {
-        for (let i = 0; i < ms.length; i++) {
-          const m    = ms[i]
-          const home = m.home_team?.tla ?? m.home_team?.short_name ?? '?'
-          const away = m.away_team?.tla ?? m.away_team?.short_name ?? '?'
-          const ctx  = m.group_name ? `Gr.${m.group_name}` : stageLabel(m.stage)
-          addLog(`${ctx} · ${home} vs ${away}`)
-          await new Promise(r => setTimeout(r, 20))
-        }
-        addLog(`${ms.length} Spiele geladen`, 'done')
-      }
 
       const ss = await wmt.getSummaries()
       setSummaries(ss)
-      if (!silent) addLog(`${ss.length} Morgenberichte geladen`, 'done')
 
       try {
         const b = await wmt.getBonus()
@@ -391,13 +378,49 @@ export default function Wmt() {
       setSelectedKey(prev => prev ?? activeKey ?? null)
     } catch (e) {
       console.error(e)
-      addLog('Fehler beim Laden', 'error')
-    } finally {
-      if (!silent) setLoading(false)
+      throw e
     }
-  }, [addLog])
+  }, [])
 
-  useEffect(() => { loadAll() }, [loadAll])
+  useEffect(() => {
+    async function startup() {
+      setLoading(true)
+      setView('import')
+      try {
+        const status = await wmt.getStatus()
+
+        if (status.match_count === 0) {
+          addLog('Kein Spielplan in der Datenbank', 'error')
+          addLog('→ Spielplan aktualisieren (☰) um Daten zu laden')
+          return
+        }
+
+        addLog(`${status.match_count} Spiele im Spielplan`, 'done')
+
+        if (status.calibrated) {
+          addLog('ELO: kalibriert — historische Kalibrierung aktiv', 'done')
+        } else {
+          addLog('ELO: Standard-Schätzungen aktiv (keine historische Kalibrierung)')
+          addLog('→ Historische Kalibrierung (☰) für genauere Prognosen empfohlen')
+        }
+
+        if (status.prediction_count > 0) {
+          addLog(`${status.prediction_count} Prognosen vorhanden`, 'done')
+        } else {
+          addLog('Keine Prognosen — Spielplan aktualisieren (☰) um Prognosen zu berechnen')
+        }
+
+        await loadAll()
+        setView('spieltage')
+      } catch (e) {
+        addLog('Fehler beim Starten', 'error')
+        console.error(e)
+      } finally {
+        setLoading(false)
+      }
+    }
+    startup()
+  }, [addLog, loadAll])
 
   async function handleClear() {
     if (!window.confirm('Alle WMT-Daten löschen? (Teams, Spiele, Prognosen, Morgenberichte, Bonus)')) return
@@ -446,7 +469,7 @@ export default function Wmt() {
       const elapsed = ((Date.now() - t0) / 1000).toFixed(1)
       const isErr = !res.updated && !res.message?.startsWith('Aktualisierung')
       addLog(`${res.message} (${elapsed}s)`, isErr ? 'error' : 'done')
-      if (!isErr) await loadAll(true)
+      if (!isErr) await loadAll()
       addLog('Ansicht aktualisiert', 'done')
     } catch (e) {
       addLog('Fehler beim Refresh', 'error')
@@ -468,7 +491,7 @@ export default function Wmt() {
       }))
       setLogs(prev => [...prev, ...serverLogs])
       addLog(`Kalibrierung abgeschlossen (${res.elapsed_seconds?.toFixed(1)}s)`, 'done')
-      await loadAll(true)
+      await loadAll()
       addLog('ELO-Ratings aktualisiert — bitte Spielplan aktualisieren (☰) für neue Prognosen', 'done')
     } catch (e) {
       addLog('Fehler bei der Kalibrierung', 'error')
@@ -487,7 +510,7 @@ export default function Wmt() {
       const elapsed = ((Date.now() - t0) / 1000).toFixed(1)
       addLog(`${res.message} (${elapsed}s)`, res.updated ? 'done' : 'error')
       if (res.updated) {
-        await loadAll(true)
+        await loadAll()
         setView('spieltage')
         setSelectedKey('md_1')
       }
@@ -543,7 +566,7 @@ export default function Wmt() {
             }}>
             {anyBusy ? '…' : '☰'}
           </button>
-          <span className="topbar-version">v2.0</span>
+          <span className="topbar-version">v2.1</span>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

- New `GET /wmt/status` endpoint returns `match_count`, `team_count`, `prediction_count`, and `calibrated`
- `calibrated` is detected by comparing stored team ELOs against `INITIAL_ELO`: if the average absolute deviation exceeds 10 ELO points, historical calibration has been applied
- On page load the app calls `/wmt/status` first and logs each decision in the Import tab before loading data:

**Empty DB:**
```
Kein Spielplan in der Datenbank  ← red
→ Spielplan aktualisieren (☰) um Daten zu laden
```

**Data present, not calibrated:**
```
104 Spiele im Spielplan  ✓
ELO: Standard-Schätzungen aktiv (keine historische Kalibrierung)
→ Historische Kalibrierung (☰) für genauere Prognosen empfohlen
312 Prognosen vorhanden  ✓
```

**Data present, calibrated:**
```
104 Spiele im Spielplan  ✓
ELO: kalibriert — historische Kalibrierung aktiv  ✓
312 Prognosen vorhanden  ✓
```

After loading, the app switches automatically to Spieltage. If the DB is empty it stays on the Import tab with instructions.

The old startup log (104 match entries × 20 ms delay ≈ 2 s) is replaced by this 3–4 line summary. `loadAll` is simplified to a pure silent data refresh with no logging side effects.

https://claude.ai/code/session_01JqMuUbRgvGTqnS8yfw5ZUY

---
_Generated by [Claude Code](https://claude.ai/code/session_01JqMuUbRgvGTqnS8yfw5ZUY)_