### PR TITLE
wmt: fix N+1 query in GET /wmt/matches; add load-time log on startup

### DIFF
--- a/backend/routers/wmt.py
+++ b/backend/routers/wmt.py
@@ -1259,6 +1259,15 @@ def _match_out(match: models.WmtMatch, db: Session) -> schemas.WmtMatchOut:
         .order_by(models.WmtPrediction.created_at.desc())
         .first()
     )
+    return _assemble_match_out(match, home, away, pred)
+
+
+def _assemble_match_out(
+    match: models.WmtMatch,
+    home: Optional[models.WmtTeam],
+    away: Optional[models.WmtTeam],
+    pred: Optional[models.WmtPrediction],
+) -> schemas.WmtMatchOut:
     return schemas.WmtMatchOut(
         id=match.id,
         api_id=match.api_id,
@@ -1308,7 +1317,22 @@ def list_matches(db: Session = Depends(get_db)):
         .order_by(models.WmtMatch.utc_date)
         .all()
     )
-    return [_match_out(m, db) for m in matches]
+    # Bulk-load teams and latest predictions (avoids N+1: 3 queries instead of ~312)
+    teams = {t.id: t for t in db.query(models.WmtTeam).all()}
+    # Latest prediction per match: load all ordered desc, keep first seen per match_id
+    pred_by_match: dict[int, models.WmtPrediction] = {}
+    for p in db.query(models.WmtPrediction).order_by(models.WmtPrediction.created_at.desc()).all():
+        if p.match_id not in pred_by_match:
+            pred_by_match[p.match_id] = p
+    return [
+        _assemble_match_out(
+            m,
+            teams.get(m.home_team_id) if m.home_team_id else None,
+            teams.get(m.away_team_id) if m.away_team_id else None,
+            pred_by_match.get(m.id),
+        )
+        for m in matches
+    ]
 
 
 @router.get("/matches/{mid}/predictions", response_model=list[schemas.WmtPredictionOut])

--- a/frontend/src/pages/Wmt.jsx
+++ b/frontend/src/pages/Wmt.jsx
@@ -410,7 +410,10 @@ export default function Wmt() {
           addLog('Keine Prognosen — Spielplan aktualisieren (☰) um Prognosen zu berechnen')
         }
 
+        addLog('Spieldaten werden geladen…')
+        const t0 = Date.now()
         await loadAll()
+        addLog(`Bereit (${((Date.now() - t0) / 1000).toFixed(1)}s)`, 'done')
         setView('spieltage')
       } catch (e) {
         addLog('Fehler beim Starten', 'error')


### PR DESCRIPTION
## Root cause

`GET /wmt/matches` was calling `_match_out(m, db)` for each of the 104 matches. Each call made 3 separate DB round trips:
- `db.get(WmtTeam, home_team_id)`
- `db.get(WmtTeam, away_team_id)`
- `db.query(WmtPrediction).filter_by(match_id=…).first()`

**Total: ~312 sequential queries per page load.** On Railway's managed Postgres, even 100 ms average latency per query gives ~30 s — matching exactly what was observed.

## Fix

Bulk-load all teams and latest predictions upfront in 2 additional queries, then assemble match objects from in-memory dicts. Total queries drop from ~312 to **3** regardless of match count:

1. `SELECT * FROM wmt_matches ORDER BY utc_date`
2. `SELECT * FROM wmt_teams`
3. `SELECT * FROM wmt_predictions ORDER BY created_at DESC` (deduplicated in Python)

The existing `_match_out` helper is preserved for the few places that still call it with a single match (e.g. after a refresh). A new `_assemble_match_out` handles the bulk path.

## Also

Adds `"Spieldaten werden geladen…"` + `"Bereit (X.Xs)"` log entries in the startup sequence so the previously-silent ~30 s gap has visible progress feedback.

https://claude.ai/code/session_01JqMuUbRgvGTqnS8yfw5ZUY

---
_Generated by [Claude Code](https://claude.ai/code/session_01JqMuUbRgvGTqnS8yfw5ZUY)_