### PR TITLE
wmt: always-visible reasoning/history; shorten Begründung text (v2.2)

### DIFF
--- a/backend/routers/wmt.py
+++ b/backend/routers/wmt.py
@@ -254,8 +254,8 @@ def _stage_de(stage: str) -> str:
 def build_reasoning(
     home_name: str, away_name: str, home_tla: str, away_tla: str,
     home_elo: float, away_elo: float,
-    home_win: float, draw: float, away_win: float,
-    home_xg: float, away_xg: float,
+    home_win: float = 0.0, draw: float = 0.0, away_win: float = 0.0,
+    home_xg: float = 0.0, away_xg: float = 0.0,
 ) -> str:
     diff = home_elo - away_elo
     if abs(diff) < 30:
@@ -267,20 +267,9 @@ def build_reasoning(
         label = "leichter" if abs(diff) < 100 else ("klarer" if abs(diff) < 200 else "deutlicher")
         strength = f"{away_name} ist {label} Favorit ({diff:.0f} ELO)"
 
-    tip_home = max(0, round(home_xg))
-    tip_away = max(0, round(away_xg))
-    if tip_home == tip_away:
-        if home_win > away_win + 0.1:
-            tip_home += 1
-        elif away_win > home_win + 0.1:
-            tip_away += 1
-
     return (
         f"{strength}. "
-        f"ELO: {home_tla} {home_elo:.0f} vs. {away_tla} {away_elo:.0f}. "
-        f"Gewinnchancen: {home_tla} {home_win*100:.0f}% | "
-        f"Remis {draw*100:.0f}% | {away_tla} {away_win*100:.0f}%. "
-        f"Empfohlener Tipp: {tip_home}:{tip_away}."
+        f"ELO: {home_tla} {home_elo:.0f} vs. {away_tla} {away_elo:.0f}."
     )
 
 
@@ -1278,6 +1267,7 @@ def _assemble_match_out(
     home: Optional[models.WmtTeam],
     away: Optional[models.WmtTeam],
     pred: Optional[models.WmtPrediction],
+    all_preds: Optional[list[models.WmtPrediction]] = None,
 ) -> schemas.WmtMatchOut:
     return schemas.WmtMatchOut(
         id=match.id,
@@ -1292,6 +1282,7 @@ def _assemble_match_out(
         home_team=_team_out(home),
         away_team=_team_out(away),
         prediction=_pred_out(pred),
+        predictions=[_pred_out(p) for p in (all_preds or ([pred] if pred else []))],
     )
 
 
@@ -1328,19 +1319,18 @@ def list_matches(db: Session = Depends(get_db)):
         .order_by(models.WmtMatch.utc_date)
         .all()
     )
-    # Bulk-load teams and latest predictions (avoids N+1: 3 queries instead of ~312)
+    # Bulk-load teams and all predictions (avoids N+1: 3 queries total)
     teams = {t.id: t for t in db.query(models.WmtTeam).all()}
-    # Latest prediction per match: load all ordered desc, keep first seen per match_id
-    pred_by_match: dict[int, models.WmtPrediction] = {}
+    all_preds_by_match: dict[int, list[models.WmtPrediction]] = {}
     for p in db.query(models.WmtPrediction).order_by(models.WmtPrediction.created_at.desc()).all():
-        if p.match_id not in pred_by_match:
-            pred_by_match[p.match_id] = p
+        all_preds_by_match.setdefault(p.match_id, []).append(p)
     return [
         _assemble_match_out(
             m,
             teams.get(m.home_team_id) if m.home_team_id else None,
             teams.get(m.away_team_id) if m.away_team_id else None,
-            pred_by_match.get(m.id),
+            all_preds_by_match.get(m.id, [None])[0],
+            all_preds_by_match.get(m.id, []),
         )
         for m in matches
     ]

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -208,6 +208,7 @@ class WmtMatchOut(BaseModel):
     home_team: Optional[WmtTeamOut]
     away_team: Optional[WmtTeamOut]
     prediction: Optional[WmtPredictionOut]
+    predictions: list[WmtPredictionOut] = []
 
 
 class WmtSummaryOut(BaseModel):

--- a/frontend/src/pages/Wmt.jsx
+++ b/frontend/src/pages/Wmt.jsx
@@ -150,7 +150,7 @@ function ProbBar({ home, draw, away, homeTla, awayTla }) {
   )
 }
 
-function MatchCard({ match, predHistory, onTogglePred, isExpanded }) {
+function MatchCard({ match }) {
   const p = match.prediction
   const isFinished = match.status === 'FINISHED'
   const isLive = match.status === 'IN_PLAY' || match.status === 'PAUSED'
@@ -233,19 +233,7 @@ function MatchCard({ match, predHistory, onTogglePred, isExpanded }) {
             homeTla={homeTla} awayTla={awayTla}
           />
 
-          <button
-            onClick={() => onTogglePred(match.id)}
-            style={{
-              marginTop: 10, background: 'none', border: 'none',
-              color: '#4d6fa0', fontSize: 11, cursor: 'pointer',
-              padding: 0, fontFamily: 'inherit',
-            }}>
-            {isExpanded ? 'Begründung ▲' : 'Begründung ▼'}
-            {predHistory && predHistory.length > 1 && ` · ${predHistory.length} Versionen`}
-          </button>
-
-          {isExpanded && (
-            <div style={{ marginTop: 10, borderTop: '1px solid #1a2840', paddingTop: 10 }}>
+          <div style={{ marginTop: 10, borderTop: '1px solid #1a2840', paddingTop: 10 }}>
               <div style={{ fontSize: 12, color: '#9ab0d0', lineHeight: 1.65, marginBottom: p.home_elo ? 10 : 0 }}>
                 {p.reasoning}
               </div>
@@ -256,12 +244,12 @@ function MatchCard({ match, predHistory, onTogglePred, isExpanded }) {
                 </div>
               )}
 
-              {predHistory && predHistory.length > 1 && (
+              {match.predictions?.length > 1 && (
                 <div style={{ marginTop: 12 }}>
                   <div style={{ fontSize: 10, color: '#374d66', letterSpacing: '0.1em', marginBottom: 6 }}>
-                    VERLAUF ({predHistory.length} VERSIONEN)
+                    VERLAUF ({match.predictions.length} VERSIONEN)
                   </div>
-                  {predHistory.map((ph, i) => (
+                  {match.predictions.map((ph, i) => (
                     <div key={ph.id} style={{
                       padding: '6px 0',
                       borderTop: '1px solid #1a2840',
@@ -284,7 +272,6 @@ function MatchCard({ match, predHistory, onTogglePred, isExpanded }) {
                 </div>
               )}
             </div>
-          )}
         </div>
       ) : (
         <div style={{ fontSize: 11, color: '#374d66' }}>Noch keine Prognose verfügbar.</div>
@@ -335,8 +322,6 @@ export default function Wmt() {
   const [bonus, setBonus]               = useState(null)
   const [view, setView]                 = useState('spieltage')
   const [selectedKey, setSelectedKey]   = useState(null)
-  const [expandedId, setExpandedId]     = useState(null)
-  const [predHistory, setPredHistory]   = useState({})
   const [loading, setLoading]           = useState(true)
   const [refreshing, setRefreshing]     = useState(false)
   const [clearing, setClearing]         = useState(false)
@@ -524,22 +509,6 @@ export default function Wmt() {
     }
   }
 
-  async function handleTogglePred(matchId) {
-    if (expandedId === matchId) {
-      setExpandedId(null)
-      return
-    }
-    setExpandedId(matchId)
-    if (!predHistory[matchId]) {
-      try {
-        const hist = await wmt.getMatchPredictions(matchId)
-        setPredHistory(prev => ({ ...prev, [matchId]: hist }))
-      } catch (e) {
-        console.error(e)
-      }
-    }
-  }
-
   const anyBusy = refreshing || clearing || warming || generatingBonus || fakingMd1
 
   const grouped       = groupMatches(matches)
@@ -569,7 +538,7 @@ export default function Wmt() {
             }}>
             {anyBusy ? '…' : '☰'}
           </button>
-          <span className="topbar-version">v2.1</span>
+          <span className="topbar-version">v2.2</span>
         </div>
       </div>
 
@@ -719,26 +688,14 @@ export default function Wmt() {
                         {calDayLabel(isoDay).toUpperCase()}
                       </div>
                       {dayMatches.map(m => (
-                        <MatchCard
-                          key={m.id}
-                          match={m}
-                          predHistory={predHistory[m.id]}
-                          onTogglePred={handleTogglePred}
-                          isExpanded={expandedId === m.id}
-                        />
+                        <MatchCard key={m.id} match={m} />
                       ))}
                     </div>
                   ))
                 ) : (
                   // Knockout rounds: flat list
                   currentMatches.map(m => (
-                    <MatchCard
-                      key={m.id}
-                      match={m}
-                      predHistory={predHistory[m.id]}
-                      onTogglePred={handleTogglePred}
-                      isExpanded={expandedId === m.id}
-                    />
+                    <MatchCard key={m.id} match={m} />
                   ))
                 )}
               </>


### PR DESCRIPTION
- build_reasoning now produces only the two-sentence summary (strength + ELO line); Gewinnchancen and Empfohlener Tipp are removed since both are already shown in the card header
- All prediction versions are now embedded in GET /wmt/matches (no extra per-match API calls needed); list_matches groups all predictions by match_id in one bulk query
- MatchCard no longer has a Begründung toggle: reasoning, ELO snapshot, and VERLAUF are always rendered immediately
- Removed expandedId state, handleTogglePred handler, and predHistory state (and its per-match lazy fetch) from the main component

https://claude.ai/code/session_01JqMuUbRgvGTqnS8yfw5ZUY