### PR TITLE
wmt: fake-all endpoint + N+1 fix in group-stage faker (v2.6)

### DIFF
--- a/backend/routers/wmt.py
+++ b/backend/routers/wmt.py
@@ -388,7 +388,11 @@ def _upsert_openligadb_team(db: Session, team_data: dict) -> Optional[models.Wmt
 
 # ── core business logic ───────────────────────────────────────────────────────
 
-def _apply_elo_and_predictions(db: Session, newly_finished: list[models.WmtMatch]) -> None:
+def _apply_elo_and_predictions(
+    db: Session,
+    newly_finished: list[models.WmtMatch],
+    generate_predictions: bool = True,
+) -> None:
     """ELO für neu abgeschlossene Spiele aktualisieren + Prognosen für ausstehende neu berechnen."""
     newly_finished.sort(key=lambda x: x.utc_date)
     for match in newly_finished:
@@ -401,6 +405,9 @@ def _apply_elo_and_predictions(db: Session, newly_finished: list[models.WmtMatch
             home.matches_played = (home.matches_played or 0) + 1
             away.matches_played = (away.matches_played or 0) + 1
     db.commit()
+
+    if not generate_predictions:
+        return
 
     upcoming = (
         db.query(models.WmtMatch)
@@ -1174,7 +1181,9 @@ def do_historical_warmup(db: Session) -> dict:
 
 # ── fake results (dev/test) ───────────────────────────────────────────────────
 
-def do_fake_group_md(db: Session, matchday: int, n_upsets: int) -> tuple[int, str]:
+def do_fake_group_md(
+    db: Session, matchday: int, n_upsets: int, generate_predictions: bool = True,
+) -> tuple[int, str]:
     """Fake-Ergebnisse für alle ausstehenden Gruppenphase-Spiele eines Spieltags setzen."""
     md_matches = (
         db.query(models.WmtMatch)
@@ -1191,9 +1200,11 @@ def do_fake_group_md(db: Session, matchday: int, n_upsets: int) -> tuple[int, st
     if not md_matches:
         return 0, f"Keine ausstehenden MD{matchday}-Spiele mit Teambesetzung gefunden."
 
+    all_teams = {t.id: t for t in db.query(models.WmtTeam).all()}
+
     def elo_gap(m: models.WmtMatch) -> float:
-        h = db.get(models.WmtTeam, m.home_team_id)
-        a = db.get(models.WmtTeam, m.away_team_id)
+        h = all_teams.get(m.home_team_id)
+        a = all_teams.get(m.away_team_id)
         return abs(h.elo - a.elo) if h and a else 0.0
 
     n = min(n_upsets, len(md_matches))
@@ -1201,8 +1212,8 @@ def do_fake_group_md(db: Session, matchday: int, n_upsets: int) -> tuple[int, st
 
     newly_finished: list[models.WmtMatch] = []
     for m in md_matches:
-        home = db.get(models.WmtTeam, m.home_team_id)
-        away = db.get(models.WmtTeam, m.away_team_id)
+        home = all_teams.get(m.home_team_id)
+        away = all_teams.get(m.away_team_id)
         if not home or not away:
             continue
 
@@ -1233,7 +1244,7 @@ def do_fake_group_md(db: Session, matchday: int, n_upsets: int) -> tuple[int, st
         newly_finished.append(m)
 
     db.commit()
-    _apply_elo_and_predictions(db, newly_finished)
+    _apply_elo_and_predictions(db, newly_finished, generate_predictions)
     return len(newly_finished), ""
 
 
@@ -1303,7 +1314,7 @@ def _compute_group_standings(db: Session) -> dict[str, list[dict]]:
     return standings
 
 
-def do_fake_rd32(db: Session) -> tuple[int, str]:
+def do_fake_rd32(db: Session, generate_predictions: bool = True) -> tuple[int, str]:
     """Fake-Ergebnisse für Rd.32 setzen (benötigt abgeschlossene Gruppenphase)."""
     standings = _compute_group_standings(db)
     if not standings:
@@ -1397,7 +1408,7 @@ def do_fake_rd32(db: Session) -> tuple[int, str]:
         newly_finished.append(m)
 
     db.commit()
-    _apply_elo_and_predictions(db, newly_finished)
+    _apply_elo_and_predictions(db, newly_finished, generate_predictions)
     return len(newly_finished), ""
 
 
@@ -1435,6 +1446,7 @@ def _get_round_losers(db: Session, stage: str) -> list[int]:
 
 def do_fake_knockout_round(
     db: Session, stage: str, n_upsets: int, prev_stage: str = "",
+    generate_predictions: bool = True,
 ) -> tuple[int, str]:
     """
     Fake results for a knockout stage round.
@@ -1536,8 +1548,31 @@ def do_fake_knockout_round(
                 tp.away_team_id = losers[1]
                 db.commit()
 
-    _apply_elo_and_predictions(db, newly_finished)
+    _apply_elo_and_predictions(db, newly_finished, generate_predictions)
     return len(newly_finished), ""
+
+
+def do_fake_all(db: Session) -> tuple[int, str]:
+    """Alle Turnierphasen MD1–Finale in einem Schritt faken.
+    ELO-Updates laufen zwischen den Phasen; Prognosen werden nur einmal am Ende
+    generiert (no-op, da keine SCHEDULED-Spiele mehr übrig bleiben).
+    """
+    total = 0
+    pipeline = [
+        (do_fake_group_md,      (db, 1, 3)),
+        (do_fake_group_md,      (db, 2, 5)),
+        (do_fake_group_md,      (db, 3, 7)),
+        (do_fake_rd32,          (db,)),
+        (do_fake_knockout_round, (db, "LAST_16",        3, "LAST_32")),
+        (do_fake_knockout_round, (db, "QUARTER_FINALS", 2, "LAST_16")),
+        (do_fake_knockout_round, (db, "SEMI_FINALS",    1, "QUARTER_FINALS")),
+        (do_fake_knockout_round, (db, "THIRD_PLACE",    0, "SEMI_FINALS")),
+        (do_fake_knockout_round, (db, "FINAL",          0, "SEMI_FINALS")),
+    ]
+    for fn, args in pipeline:
+        n, _ = fn(*args, generate_predictions=False)
+        total += n
+    return total, f"Alle {total} Spiele gefakt (Gesamtturnier)."
 
 
 # ── helpers for API response assembly ────────────────────────────────────────
@@ -1889,3 +1924,10 @@ def fake_final_results(db: Session = Depends(get_db)):
         message=f"Fake-Ergebnisse gesetzt: Finale abgeschlossen.",
         updated=n,
     )
+
+
+@router.post("/debug/fake-all", response_model=schemas.WmtRefreshOut)
+def fake_all_results(db: Session = Depends(get_db)):
+    """Alle Phasen MD1–Finale in einem Schritt faken (nur für Tests)."""
+    n, msg = do_fake_all(db)
+    return schemas.WmtRefreshOut(message=msg, updated=n)

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -80,5 +80,6 @@ export const wmt = {
   fakeSf: ()                 => post('/wmt/debug/fake-sf'),
   fakeTp: ()                 => post('/wmt/debug/fake-tp'),
   fakeFinal: ()              => post('/wmt/debug/fake-final'),
+  fakeAll: ()                => post('/wmt/debug/fake-all'),
 }
 

--- a/frontend/src/pages/Wmt.jsx
+++ b/frontend/src/pages/Wmt.jsx
@@ -447,6 +447,7 @@ export default function Wmt() {
   const [fakingSf, setFakingSf]           = useState(false)
   const [fakingTp, setFakingTp]           = useState(false)
   const [fakingFinal, setFakingFinal]     = useState(false)
+  const [fakingAll, setFakingAll]         = useState(false)
   const [logs, setLogs]                   = useState([])
   const [menuOpen, setMenuOpen]         = useState(false)
   const logRef                          = useRef(null)
@@ -751,9 +752,21 @@ export default function Wmt() {
     finally { setFakingFinal(false) }
   }
 
+  async function handleFakeAll() {
+    setFakingAll(true); setView('import')
+    addLog('Alle Turnierphasen (MD1–Finale) werden gefakt…')
+    const t0 = Date.now()
+    try {
+      const res = await wmt.fakeAll()
+      addLog(`${res.message} (${((Date.now()-t0)/1000).toFixed(1)}s)`, res.updated ? 'done' : 'error')
+      if (res.updated) { await loadAll(); setView('spieltage'); setSelectedKey('stage_FINAL') }
+    } catch { addLog('Fehler beim Setzen der Fake-Ergebnisse', 'error') }
+    finally { setFakingAll(false) }
+  }
+
   const anyBusy = refreshing || clearing || warming || generatingBonus ||
     fakingMd1 || fakingMd2 || fakingMd3 || fakingRd32 ||
-    fakingLast16 || fakingQf || fakingSf || fakingTp || fakingFinal
+    fakingLast16 || fakingQf || fakingSf || fakingTp || fakingFinal || fakingAll
 
   const md1Done = matches.some(m => m.stage === 'GROUP_STAGE' && m.matchday === 1) &&
     matches.filter(m => m.stage === 'GROUP_STAGE' && m.matchday === 1).every(m => m.status === 'FINISHED')
@@ -843,7 +856,7 @@ export default function Wmt() {
             }}>
             {anyBusy ? '…' : '☰'}
           </button>
-          <span className="topbar-version">v2.5</span>
+          <span className="topbar-version">v2.6</span>
         </div>
       </div>
 
@@ -882,6 +895,12 @@ export default function Wmt() {
               icon="✕" label="Daten löschen"
               danger loading={clearing} disabled={anyBusy && !clearing}
               onClick={() => { setMenuOpen(false); handleClear() }}
+            />
+            <div style={{ borderTop: '1px solid #1a2840', margin: '6px 0' }} />
+            <MenuButton
+              icon="⚗" label="Fake alles (MD1–Finale)"
+              loading={fakingAll} disabled={(anyBusy && !fakingAll) || finalDone}
+              onClick={() => { setMenuOpen(false); handleFakeAll() }}
             />
             <div style={{ borderTop: '1px solid #1a2840', margin: '6px 0' }} />
             <MenuButton


### PR DESCRIPTION
Speed improvements for dev faking:
- Add generate_predictions=False path to _apply_elo_and_predictions, do_fake_group_md,
  do_fake_rd32, and do_fake_knockout_round — ELO updates run between stages but
  ~200 intermediate prediction inserts are skipped
- Fix N+1 in do_fake_group_md: pre-load all teams once instead of db.get() per match
  in both elo_gap() and the main loop (~48 queries → 1 per fake-group-md call)
- Add do_fake_all() that chains all 9 stages in one DB session with generate_predictions=False
- Add POST /wmt/debug/fake-all endpoint
- Add "Fake alles (MD1–Finale)" burger menu button (disabled once finalDone)