### PR TITLE
Add light/dark mode toggle with full site theming

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,6 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import { ThemeProvider } from './context/ThemeContext'
+import ThemeToggle from './components/ThemeToggle'
 import Home from './pages/Home'
 import Productivity from './pages/Productivity'
 import Personal from './pages/Personal'
@@ -14,21 +16,24 @@ import Wmt from './pages/Wmt'
 
 export default function App() {
   return (
-    <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/productivity" element={<Productivity />} />
-        <Route path="/personal" element={<Personal />} />
-        <Route path="/games" element={<Games />} />
-        <Route path="/tts" element={<TimeTracker />} />
-        <Route path="/cal" element={<Calendar />} />
-        <Route path="/idx" element={<IdeaInbox />} />
-        <Route path="/str" element={<StringTracker />} />
-        <Route path="/bpm" element={<BpmCounter />} />
-        <Route path="/spt" element={<SpotifyExplorer />} />
-        <Route path="/block-hero" element={<BlockHero />} />
-        <Route path="/wmt" element={<Wmt />} />
-      </Routes>
-    </BrowserRouter>
+    <ThemeProvider>
+      <ThemeToggle />
+      <BrowserRouter>
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/productivity" element={<Productivity />} />
+          <Route path="/personal" element={<Personal />} />
+          <Route path="/games" element={<Games />} />
+          <Route path="/tts" element={<TimeTracker />} />
+          <Route path="/cal" element={<Calendar />} />
+          <Route path="/idx" element={<IdeaInbox />} />
+          <Route path="/str" element={<StringTracker />} />
+          <Route path="/bpm" element={<BpmCounter />} />
+          <Route path="/spt" element={<SpotifyExplorer />} />
+          <Route path="/block-hero" element={<BlockHero />} />
+          <Route path="/wmt" element={<Wmt />} />
+        </Routes>
+      </BrowserRouter>
+    </ThemeProvider>
   )
 }

--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -1,0 +1,64 @@
+import { useState, useRef, useEffect } from 'react'
+import { useTheme } from '../context/ThemeContext'
+
+function LightbulbIcon() {
+  return (
+    <svg width="13" height="14" viewBox="0 0 13 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M6.5 1a3.2 3.2 0 0 1 2 5.7c-.38.3-.65.74-.65 1.3H5.15c0-.56-.27-1-.65-1.3A3.2 3.2 0 0 1 6.5 1z"
+        stroke="currentColor" strokeWidth="1.1" strokeLinejoin="round"/>
+      <line x1="5.15" y1="8" x2="7.85" y2="8" stroke="currentColor" strokeWidth="1.1" strokeLinecap="round"/>
+      <line x1="5.45" y1="9.4" x2="7.55" y2="9.4" stroke="currentColor" strokeWidth="1.1" strokeLinecap="round"/>
+      <line x1="5.9" y1="10.7" x2="7.1" y2="10.7" stroke="currentColor" strokeWidth="1.1" strokeLinecap="round"/>
+    </svg>
+  )
+}
+
+export default function ThemeToggle() {
+  const { theme, setTheme } = useTheme()
+  const [open, setOpen] = useState(false)
+  const ref = useRef(null)
+
+  useEffect(() => {
+    if (!open) return
+    function handler(e) {
+      if (ref.current && !ref.current.contains(e.target)) setOpen(false)
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [open])
+
+  useEffect(() => {
+    if (!open) return
+    function onKey(e) {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [open])
+
+  return (
+    <div ref={ref} className="theme-toggle-wrap">
+      <button
+        onClick={() => setOpen(o => !o)}
+        title="Toggle theme"
+        className={`theme-toggle-btn${open ? ' open' : ''}`}
+      >
+        <LightbulbIcon />
+      </button>
+      {open && (
+        <div className="theme-flyout">
+          {['dark', 'light'].map(t => (
+            <button
+              key={t}
+              onClick={() => { setTheme(t); setOpen(false) }}
+              className={`theme-option${t === theme ? ' active' : ''}`}
+            >
+              <span className="theme-option-dot" />
+              {t}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/context/ThemeContext.jsx
+++ b/frontend/src/context/ThemeContext.jsx
@@ -1,0 +1,26 @@
+import { createContext, useContext, useState, useEffect } from 'react'
+
+const ThemeContext = createContext(null)
+
+export function ThemeProvider({ children }) {
+  const [theme, setThemeState] = useState(() => {
+    const saved = localStorage.getItem('theme') || 'dark'
+    document.documentElement.setAttribute('data-theme', saved)
+    return saved
+  })
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme)
+    localStorage.setItem('theme', theme)
+  }, [theme])
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme: setThemeState }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}
+
+export function useTheme() {
+  return useContext(ThemeContext)
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,3 +1,72 @@
+/* ── Theme variables ─────────────────────────────────────────── */
+:root {
+  --bg:                 #07091a;
+  --surface:            #0d1221;
+  --surface-alt:        #111828;
+  --surface-dark:       #111;
+  --topbar-bg:          #070914;
+  --border:             #1a2840;
+  --border-hover:       #2a3d5c;
+  --border-dark:        #1e1e1e;
+  --text-primary:       #eef2ff;
+  --text-secondary:     #9ab0d0;
+  --text-muted:         #5d7592;
+  --text-dim:           #374d66;
+  --text-bright:        #e0e0e0;
+  --text-sub:           #bbbbbb;
+  --text-subtle:        #aaaaaa;
+  --text-faint:         #888888;
+  --text-faintest:      #666666;
+  --timer-inactive:     #2a2a2a;
+  --overlay-bg:         rgba(4, 6, 18, 0.9);
+  --error-bg:           #2a0000;
+  --tts-stop-bg:        #1a0e0e;
+  --tts-stop-hover:     #220e0e;
+  --tts-start-hover-bg: #0d1a10;
+  --tts-live-border:    #0d2a18;
+  --tts-live-bg:        #071810;
+  --tts-active-bg:      #0a1020;
+  --tts-today-border:   #2a4a2a;
+  --tts-today-bg:       #071a0e;
+  --swipe-promote-bg:   #110822;
+  --swipe-defer-bg:     #131100;
+  --swipe-kill-bg:      #1a0606;
+}
+
+:root[data-theme="light"] {
+  --bg:                 #f0f4ff;
+  --surface:            #ffffff;
+  --surface-alt:        #eaf0ff;
+  --surface-dark:       #f4f7ff;
+  --topbar-bg:          #e8eef8;
+  --border:             #c8d4e8;
+  --border-hover:       #9ab0d0;
+  --border-dark:        #d8e0f0;
+  --text-primary:       #0d1a35;
+  --text-secondary:     #3d5880;
+  --text-muted:         #4a6080;
+  --text-dim:           #8a9fb8;
+  --text-bright:        #1a2840;
+  --text-sub:           #3d5062;
+  --text-subtle:        #4a6078;
+  --text-faint:         #607080;
+  --text-faintest:      #748898;
+  --timer-inactive:     #c0ccdd;
+  --overlay-bg:         rgba(10, 20, 50, 0.7);
+  --error-bg:           #fff0f0;
+  --tts-stop-bg:        #fff5f5;
+  --tts-stop-hover:     #ffe8e8;
+  --tts-start-hover-bg: #f0fff4;
+  --tts-live-border:    #b8e8d0;
+  --tts-live-bg:        #f0fff8;
+  --tts-active-bg:      #f0f8ff;
+  --tts-today-border:   #90c890;
+  --tts-today-bg:       #f4fff8;
+  --swipe-promote-bg:   #f5f0ff;
+  --swipe-defer-bg:     #fffce8;
+  --swipe-kill-bg:      #fff0f0;
+}
+
 * {
   margin: 0;
   padding: 0;
@@ -5,8 +74,8 @@
 }
 
 body {
-  background: #07091a;
-  color: #eef2ff;
+  background: var(--bg);
+  color: var(--text-primary);
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
   min-height: 100vh;
 }
@@ -33,21 +102,21 @@ input, textarea, select {
   justify-content: space-between;
   align-items: center;
   padding: 8px 14px;
-  background: #070914;
-  border-bottom: 1px solid #1a2840;
+  background: var(--topbar-bg);
+  border-bottom: 1px solid var(--border);
   font-size: 11px;
-  color: #9ab0d0;
+  color: var(--text-secondary);
   z-index: 50;
 }
 .topbar-left { display: flex; align-items: center; gap: 8px; }
-.topbar-right { display: flex; align-items: center; gap: 8px; }
-.topbar-version { font-size: 10px; color: #374d66; letter-spacing: 0.08em; }
-.topbar-title { font-weight: 600; letter-spacing: 0.12em; color: #eef2ff; }
+.topbar-right { display: flex; align-items: center; gap: 8px; padding-right: 22px; }
+.topbar-version { font-size: 10px; color: var(--text-dim); letter-spacing: 0.08em; }
+.topbar-title { font-weight: 600; letter-spacing: 0.12em; color: var(--text-primary); }
 .topbar-back {
-  background: none; border: 1px solid #1a2840; color: #5d7592;
+  background: none; border: 1px solid var(--border); color: var(--text-muted);
   font-size: 11px; padding: 2px 8px;
 }
-.topbar-back:hover { border-color: #2a3d5c; color: #9ab0d0; }
+.topbar-back:hover { border-color: var(--border-hover); color: var(--text-secondary); }
 
 /* ── Page shell ──────────────────────────────────────────────── */
 .page {
@@ -61,12 +130,12 @@ input, textarea, select {
 /* ── Shared controls ─────────────────────────────────────────── */
 .btn {
   background: none;
-  border: 1px solid #1a2840;
-  color: #9ab0d0;
+  border: 1px solid var(--border);
+  color: var(--text-secondary);
   padding: 5px 12px;
   font-size: 12px;
 }
-.btn:hover { border-color: #2a3d5c; color: #eef2ff; }
+.btn:hover { border-color: var(--border-hover); color: var(--text-primary); }
 .btn-primary { border-color: #4d6fa0; color: #7a9fd4; }
 .btn-primary:hover { background: rgba(122,159,212,0.08); }
 .btn-danger { border-color: #f44336; color: #f44336; }
@@ -74,21 +143,21 @@ input, textarea, select {
 .btn-sm { padding: 2px 8px; font-size: 11px; }
 
 .input {
-  background: #0d1221;
-  border: 1px solid #1a2840;
-  color: #eef2ff;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  color: var(--text-primary);
   padding: 8px 10px;
   font-size: 14px;
   width: 100%;
   outline: none;
 }
 .input:focus { border-color: #4d6fa0; }
-.input::placeholder { color: #374d66; }
+.input::placeholder { color: var(--text-dim); }
 
 .textarea {
-  background: #0d1221;
-  border: 1px solid #1a2840;
-  color: #eef2ff;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  color: var(--text-primary);
   padding: 8px 10px;
   font-size: 13px;
   width: 100%;
@@ -100,12 +169,12 @@ input, textarea, select {
 
 /* ── Cards ───────────────────────────────────────────────────── */
 .card {
-  background: #0d1221;
-  border: 1px solid #1a2840;
+  background: var(--surface);
+  border: 1px solid var(--border);
   padding: 14px;
   margin-bottom: 8px;
 }
-.card:hover { border-color: #2a3d5c; }
+.card:hover { border-color: var(--border-hover); }
 
 /* ── Home grid ───────────────────────────────────────────────── */
 .home-grid {
@@ -115,15 +184,15 @@ input, textarea, select {
   margin-top: 24px;
 }
 .home-card {
-  background: #0d1221;
-  border: 1px solid #1a2840;
+  background: var(--surface);
+  border: 1px solid var(--border);
   padding: 20px 16px;
   display: block;
   transition: border-color 0.15s;
 }
-.home-card:hover { border-color: #2a3d5c; }
-.home-card-name { font-size: 13px; color: #eef2ff; letter-spacing: 0.06em; }
-.home-card-desc { font-size: 11px; color: #5d7592; margin-top: 4px; }
+.home-card:hover { border-color: var(--border-hover); }
+.home-card-name { font-size: 13px; color: var(--text-primary); letter-spacing: 0.06em; }
+.home-card-desc { font-size: 11px; color: var(--text-muted); margin-top: 4px; }
 
 /* ── Flex utils ──────────────────────────────────────────────── */
 .row { display: flex; align-items: center; gap: 8px; }
@@ -139,29 +208,29 @@ input, textarea, select {
 
 /* ── Text utils ──────────────────────────────────────────────── */
 .text-sm   { font-size: 11px; }
-.text-muted { color: #5d7592; }
+.text-muted { color: var(--text-muted); }
 .text-accent { color: #8855ff; }
-.label { font-size: 11px; color: #9ab0d0; letter-spacing: 0.04em; margin-bottom: 4px; display: block; }
+.label { font-size: 11px; color: var(--text-secondary); letter-spacing: 0.04em; margin-bottom: 4px; display: block; }
 
 /* ── Section header ──────────────────────────────────────────── */
 .section-header {
   font-size: 11px;
   letter-spacing: 0.15em;
   text-transform: uppercase;
-  color: #5d7592;
+  color: var(--text-muted);
   margin-bottom: 12px;
   padding-bottom: 6px;
-  border-bottom: 1px solid #1a2840;
+  border-bottom: 1px solid var(--border);
 }
 
 /* ── Tabs ────────────────────────────────────────────────────── */
-.tabs { display: flex; border-bottom: 1px solid #1a2840; margin-bottom: 16px; }
+.tabs { display: flex; border-bottom: 1px solid var(--border); margin-bottom: 16px; }
 .tab {
   background: none; border: none; border-bottom: 2px solid transparent;
-  color: #5d7592; padding: 7px 14px; font-size: 13px;
+  color: var(--text-muted); padding: 7px 14px; font-size: 13px;
   letter-spacing: 0.04em; margin-bottom: -1px;
 }
-.tab:hover { color: #9ab0d0; }
+.tab:hover { color: var(--text-secondary); }
 .tab.active { color: #8855ff; border-bottom-color: #8855ff; }
 
 /* ── Color dot ───────────────────────────────────────────────── */
@@ -172,7 +241,7 @@ input, textarea, select {
 
 /* ── Landing / category pages ────────────────────────────────── */
 .landing-page {
-  background: #07091a;
+  background: var(--bg);
   min-height: 100vh;
   display: flex;
   flex-direction: column;
@@ -188,18 +257,18 @@ input, textarea, select {
 .landing-crumb {
   display: block;
   font-size: 0.65rem;
-  color: #374d66;
+  color: var(--text-dim);
   letter-spacing: 0.12em;
   margin-bottom: 8px;
   text-decoration: none;
 }
-.landing-crumb:hover { color: #9ab0d0; }
+.landing-crumb:hover { color: var(--text-secondary); }
 
 .landing-title {
   font-size: 1.25rem;
   font-weight: 600;
   letter-spacing: 0.06em;
-  color: #eef2ff;
+  color: var(--text-primary);
   text-transform: lowercase;
   line-height: 1.2;
 }
@@ -207,7 +276,7 @@ input, textarea, select {
 .landing-sub {
   margin-top: 6px;
   font-size: 0.7rem;
-  color: #374d66;
+  color: var(--text-dim);
   letter-spacing: 0.12em;
 }
 
@@ -222,13 +291,13 @@ input, textarea, select {
   margin-top: 32px;
   font-size: 10px;
   letter-spacing: 0.08em;
-  color: #374d66;
+  color: var(--text-dim);
 }
 .landing-deploy a {
-  color: #374d66;
+  color: var(--text-dim);
   text-decoration: none;
 }
-.landing-deploy a:hover { color: #9ab0d0; }
+.landing-deploy a:hover { color: var(--text-secondary); }
 
 .nav-card {
   display: flex;
@@ -236,22 +305,22 @@ input, textarea, select {
   align-items: center;
   text-decoration: none;
   padding: 13px 16px;
-  border: 1px solid #1a2840;
-  background: #0d1221;
-  color: #eef2ff;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text-primary);
   transition: border-color 0.15s, background 0.15s;
   gap: 14px;
 }
 
 .nav-card:hover {
-  border-color: #2a3d5c;
-  background: #111828;
+  border-color: var(--border-hover);
+  background: var(--surface-alt);
 }
 
 .nav-card-label {
   font-size: 0.6rem;
   letter-spacing: 0.15em;
-  color: #374d66;
+  color: var(--text-dim);
   width: 22px;
   flex-shrink: 0;
 }
@@ -259,13 +328,13 @@ input, textarea, select {
 .nav-card-name {
   font-size: 0.9rem;
   font-weight: 500;
-  color: #eef2ff;
+  color: var(--text-primary);
   flex: 1;
 }
 
 .nav-card-arrow {
   font-size: 0.7rem;
-  color: #374d66;
+  color: var(--text-dim);
 }
 
 
@@ -390,18 +459,18 @@ input, textarea, select {
 
 .tts-toggle {
   padding: 10px 22px;
-  border: 1px solid #1a2840;
-  background: #0d1221;
+  border: 1px solid var(--border);
+  background: var(--surface);
   font-size: 10px;
   letter-spacing: 0.2em;
   text-transform: uppercase;
   white-space: nowrap;
   transition: all 0.15s;
-  color: #ddd;
+  color: var(--text-sub);
 }
-.tts-start:hover { border-color: #7effa0; color: #7effa0; background: #0d1a10; }
-.tts-stop  { border-color: #ff6b6b; color: #ff6b6b; background: #1a0e0e; }
-.tts-stop:hover { background: #220e0e; }
+.tts-start:hover { border-color: #7effa0; color: #7effa0; background: var(--tts-start-hover-bg); }
+.tts-stop  { border-color: #ff6b6b; color: #ff6b6b; background: var(--tts-stop-bg); }
+.tts-stop:hover { background: var(--tts-stop-hover); }
 
 .tts-active-bar {
   display: flex;
@@ -432,8 +501,8 @@ input, textarea, select {
 
 .tts-card {
   position: relative;
-  background: #0d1221;
-  border: 1px solid #1a2840;
+  background: var(--surface);
+  border: 1px solid var(--border);
   padding: 14px 12px 12px;
   text-align: left;
   cursor: pointer;
@@ -443,9 +512,9 @@ input, textarea, select {
   transition: border-color 0.15s, background 0.15s;
   overflow: hidden;
 }
-.tts-card:hover   { border-color: #2a3d5c; background: #111828; }
-.tts-card-on      { background: #0a1020; } /* border-color set via inline style from project color */
-.tts-card-on .tts-card-stripe { display: none; } /* full 4-side border replaces the stripe when active */
+.tts-card:hover   { border-color: var(--border-hover); background: var(--surface-alt); }
+.tts-card-on      { background: var(--tts-active-bg); }
+.tts-card-on .tts-card-stripe { display: none; }
 
 .tts-card-stripe {
   position: absolute;
@@ -467,7 +536,6 @@ input, textarea, select {
 .tts-now-badge {
   font-size: 8px;
   letter-spacing: 0.15em;
-  /* color set via inline style from project color */
 }
 
 .tts-card-rows {
@@ -488,12 +556,12 @@ input, textarea, select {
   font-size: 9px;
   letter-spacing: 0.1em;
   text-transform: uppercase;
-  color: #999;
+  color: var(--text-faint);
 }
 
 .tts-row-val {
   font-size: 11px;
-  color: #bbb;
+  color: var(--text-sub);
   font-variant-numeric: tabular-nums;
 }
 
@@ -504,29 +572,29 @@ input, textarea, select {
   align-items: center;
   gap: 10px;
   padding: 6px 0;
-  border-bottom: 1px solid #111828;
+  border-bottom: 1px solid var(--surface-alt);
 }
 
 .tts-mgmt-name {
   flex: 1;
   background: none;
   border: none;
-  color: #e0e0e0;
+  color: var(--text-bright);
   font-size: 13px;
   text-align: left;
   padding: 0;
   cursor: pointer;
 }
-.tts-mgmt-name:hover { color: #fff; }
+.tts-mgmt-name:hover { color: var(--text-primary); }
 
-.tts-del-btn { color: #444 !important; border-color: #1e1e1e !important; font-size: 14px !important; }
+.tts-del-btn { color: var(--border-dark) !important; border-color: var(--border-dark) !important; font-size: 14px !important; }
 .tts-del-btn:hover { color: #ff6b6b !important; border-color: #882222 !important; }
 
 /* ── Shared modal overlay ────────────────────────────────────── */
 .tts-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(4,6,18,0.9);
+  background: var(--overlay-bg);
   z-index: 100;
   display: flex;
   align-items: center;
@@ -535,8 +603,8 @@ input, textarea, select {
 }
 
 .tts-modal {
-  background: #0d1221;
-  border: 1px solid #1a2840;
+  background: var(--surface);
+  border: 1px solid var(--border);
   width: 100%;
   max-width: 420px;
 }
@@ -546,23 +614,23 @@ input, textarea, select {
   justify-content: space-between;
   align-items: center;
   padding: 12px 16px;
-  border-bottom: 1px solid #1a2840;
+  border-bottom: 1px solid var(--border);
   font-size: 11px;
   letter-spacing: 0.2em;
   text-transform: uppercase;
-  color: #ddd;
+  color: var(--text-sub);
 }
 
 .tts-modal-x {
   background: none;
   border: none;
-  color: #888;
+  color: var(--text-faint);
   font-size: 18px;
   line-height: 1;
   cursor: pointer;
   padding: 0 2px;
 }
-.tts-modal-x:hover { color: #e0e0e0; }
+.tts-modal-x:hover { color: var(--text-bright); }
 
 .tts-modal-body {
   padding: 16px;
@@ -573,13 +641,13 @@ input, textarea, select {
   font-size: 10px;
   letter-spacing: 0.15em;
   text-transform: uppercase;
-  color: #bbb;
+  color: var(--text-sub);
   margin-bottom: 6px;
 }
 
 .tts-modal-hint {
   font-size: 10px;
-  color: #888;
+  color: var(--text-faint);
   margin-top: 8px;
   line-height: 1.5;
 }
@@ -589,24 +657,24 @@ input, textarea, select {
   gap: 8px;
   justify-content: flex-end;
   padding: 12px 16px;
-  border-top: 1px solid #1a2840;
+  border-top: 1px solid var(--border);
 }
 
 /* ── TTS Today's Log ─────────────────────────────────────────── */
 .tts-log { display: flex; flex-direction: column; gap: 1px; }
 .tts-log-entry {
   display: flex; align-items: center; gap: 8px;
-  padding: 7px 10px; background: #0d1221; border: 1px solid #1a2840; font-size: 11px;
+  padding: 7px 10px; background: var(--surface); border: 1px solid var(--border); font-size: 11px;
 }
-.tts-log-live { border-color: #0d2a18; background: #071810; }
+.tts-log-live { border-color: var(--tts-live-border); background: var(--tts-live-bg); }
 .tts-log-dot { width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0; }
 .tts-log-info { flex: 1; display: flex; gap: 8px; align-items: baseline; min-width: 0; }
-.tts-log-project { color: #e0e0e0; letter-spacing: 0.04em; }
-.tts-log-meta { color: #aaa; font-size: 10px; }
-.tts-log-dur { color: #ccc; font-size: 10px; letter-spacing: 0.04em; flex-shrink: 0; }
+.tts-log-project { color: var(--text-bright); letter-spacing: 0.04em; }
+.tts-log-meta { color: var(--text-subtle); font-size: 10px; }
+.tts-log-dur { color: var(--text-sub); font-size: 10px; letter-spacing: 0.04em; flex-shrink: 0; }
 .tts-log-live .tts-log-dur { color: #7effa0; }
 .tts-log-del {
-  background: none; border: none; color: #2a2a2a; font-size: 14px;
+  background: none; border: none; color: var(--border-dark); font-size: 14px;
   padding: 0 4px; cursor: pointer; flex-shrink: 0; line-height: 1;
 }
 .tts-log-del:hover { color: #ff6b6b; }
@@ -616,47 +684,47 @@ input, textarea, select {
   display: flex; align-items: center; gap: 10px; margin-bottom: 8px;
 }
 .tts-week-cw {
-  flex: 1; text-align: center; font-size: 11px; color: #bbb; letter-spacing: 0.1em;
+  flex: 1; text-align: center; font-size: 11px; color: var(--text-sub); letter-spacing: 0.1em;
 }
 .tts-week-wrap { overflow-x: auto; margin-bottom: 4px; }
 .tts-week-table {
   width: 100%; border-collapse: collapse; font-size: 10px;
 }
 .tts-week-table th, .tts-week-table td {
-  padding: 5px 6px; text-align: right; border-bottom: 1px solid #111828;
+  padding: 5px 6px; text-align: right; border-bottom: 1px solid var(--surface-alt);
 }
 .tts-wk-proj-col { width: 90px; }
-.tts-wk-day-col  { color: #bbb; font-weight: normal; letter-spacing: 0.05em; }
+.tts-wk-day-col  { color: var(--text-sub); font-weight: normal; letter-spacing: 0.05em; }
 .tts-wk-today    { color: #7effa0 !important; }
-.tts-wk-date     { display: block; font-size: 9px; color: #888; margin-top: 2px; }
+.tts-wk-date     { display: block; font-size: 9px; color: var(--text-faint); margin-top: 2px; }
 .tts-wk-today .tts-wk-date { color: #3a7a3a; }
-.tts-wk-total-col { color: #999; font-weight: normal; letter-spacing: 0.05em; }
+.tts-wk-total-col { color: var(--text-faint); font-weight: normal; letter-spacing: 0.05em; }
 .tts-wk-label {
-  text-align: left; color: #aaa; font-size: 10px; white-space: nowrap; overflow: hidden;
+  text-align: left; color: var(--text-subtle); font-size: 10px; white-space: nowrap; overflow: hidden;
   text-overflow: ellipsis; max-width: 90px;
 }
-.tts-wk-bounds-label { color: #888; font-size: 9px; }
-.tts-wk-bounds-cell  { font-size: 9px; color: #999; text-align: center; line-height: 1.5; }
+.tts-wk-bounds-label { color: var(--text-faint); font-size: 9px; }
+.tts-wk-bounds-cell  { font-size: 9px; color: var(--text-faint); text-align: center; line-height: 1.5; }
 .tts-wk-dot {
   display: inline-block; width: 6px; height: 6px; border-radius: 50%;
   margin-right: 5px; vertical-align: middle; flex-shrink: 0;
 }
-.tts-wk-cell       { color: #ccc; }
-.tts-wk-empty      { color: #666; }
-.tts-wk-row-total  { color: #e0e0e0; border-left: 1px solid #1a2840; }
+.tts-wk-cell       { color: var(--text-sub); }
+.tts-wk-empty      { color: var(--text-faintest); }
+.tts-wk-row-total  { color: var(--text-bright); border-left: 1px solid var(--border); }
 .tts-wk-total-cell { }
 .tts-wk-total-row td {
-  border-top: 1px solid #1a2840; color: #e0e0e0; font-size: 10px;
+  border-top: 1px solid var(--border); color: var(--text-bright); font-size: 10px;
 }
 
 /* ── IDX swipe cards ─────────────────────────────────────────── */
 .idea-wrap {
   position: relative;
   overflow: hidden;
-  border: 1px solid #1e1e1e;
+  border: 1px solid var(--border-dark);
   transition: opacity 0.15s ease, transform 0.15s ease;
 }
-.idea-wrap:hover { border-color: #2a2a2a; }
+.idea-wrap:hover { border-color: var(--border); }
 .idea-wrap.killing { opacity: 0; transform: translateX(10px); pointer-events: none; }
 
 .swipe-bg {
@@ -665,39 +733,39 @@ input, textarea, select {
   font-size: 11px; letter-spacing: 0.12em;
   pointer-events: none; opacity: 0;
 }
-.swipe-right { left: 0; right: 35%; background: #110822; color: #8855ff; padding-left: 16px; }
-.swipe-left  { left: 35%; right: 0; background: #131100; color: #ccaa00; padding-right: 16px; justify-content: flex-end; }
-.swipe-left.kill-swipe { background: #1a0606; color: #ff5555; }
+.swipe-right { left: 0; right: 35%; background: var(--swipe-promote-bg); color: #8855ff; padding-left: 16px; }
+.swipe-left  { left: 35%; right: 0; background: var(--swipe-defer-bg); color: #ccaa00; padding-right: 16px; justify-content: flex-end; }
+.swipe-left.kill-swipe { background: var(--swipe-kill-bg); color: #ff5555; }
 
 .idea-card {
-  background: #111; padding: 10px 12px;
+  background: var(--surface-dark); padding: 10px 12px;
   display: flex; align-items: flex-start; gap: 10px;
   position: relative; z-index: 1; will-change: transform;
 }
 .idea-body { flex: 1; min-width: 0; }
-.idea-text { color: #e0e0e0; word-break: break-word; line-height: 1.5; font-size: 13px; }
+.idea-text { color: var(--text-bright); word-break: break-word; line-height: 1.5; font-size: 13px; }
 .idea-text.clickable { cursor: pointer; }
-.idea-text.clickable:hover { color: #fff; }
+.idea-text.clickable:hover { color: var(--text-primary); }
 
 .idea-actions { display: flex; gap: 5px; flex-shrink: 0; align-self: stretch; align-items: center; }
 .act {
-  background: none; border: 1px solid #2a2a2a; color: #ccc;
+  background: none; border: 1px solid var(--border-dark); color: var(--text-sub);
   padding: 2px 8px; cursor: pointer; font-size: 10px; letter-spacing: 0.05em;
 }
-.act:hover { border-color: #555; color: #e0e0e0; }
+.act:hover { border-color: var(--border-hover); color: var(--text-bright); }
 .act.kill {
   padding: 0 8px; aspect-ratio: 1; display: flex; align-items: center;
-  justify-content: center; background: #1a0606; border-color: #882222; color: #ff5555;
+  justify-content: center; background: var(--swipe-kill-bg); border-color: #882222; color: #ff5555;
 }
-.act.kill:hover { border-color: #cc3333; color: #ff8888; background: #2a0a0a; }
+.act.kill:hover { border-color: #cc3333; color: #ff8888; background: var(--error-bg); }
 
 .idea-edit {
-  width: 100%; background: #0d0d0d; border: 1px solid #8855ff;
-  color: #e0e0e0; padding: 3px 6px; font-size: 16px; outline: none;
+  width: 100%; background: var(--surface-dark); border: 1px solid #8855ff;
+  color: var(--text-bright); padding: 3px 6px; font-size: 16px; outline: none;
 }
 
 .drag-handle {
-  cursor: grab; color: #2a3a4a; font-size: 14px; line-height: 1;
+  cursor: grab; color: var(--border-hover); font-size: 14px; line-height: 1;
   user-select: none; touch-action: none; flex-shrink: 0; align-self: center;
   padding: 2px 4px 2px 0;
 }
@@ -706,39 +774,39 @@ input, textarea, select {
 
 /* ── IDX stats ───────────────────────────────────────────────── */
 .stat-topline { display: flex; margin-bottom: 28px; }
-.stat-box { flex: 1; text-align: center; padding: 14px 6px; border: 1px solid #1e1e1e; background: #111; }
+.stat-box { flex: 1; text-align: center; padding: 14px 6px; border: 1px solid var(--border-dark); background: var(--surface-dark); }
 .stat-box + .stat-box { border-left: none; }
 .stat-box-val   { font-size: 26px; line-height: 1; margin-bottom: 5px; }
-.stat-box-label { font-size: 9px; color: #aaa; letter-spacing: 0.15em; }
+.stat-box-label { font-size: 9px; color: var(--text-subtle); letter-spacing: 0.15em; }
 
 .stat-section { margin-bottom: 28px; }
-.stat-heading { font-size: 9px; color: #aaa; letter-spacing: 0.15em; margin-bottom: 12px; }
+.stat-heading { font-size: 9px; color: var(--text-subtle); letter-spacing: 0.15em; margin-bottom: 12px; }
 
 .stat-funnel-row   { display: flex; align-items: center; gap: 8px; margin-bottom: 7px; }
-.stat-funnel-label { font-size: 10px; color: #ccc; letter-spacing: 0.08em; width: 44px; flex-shrink: 0; text-align: right; }
-.stat-funnel-wrap  { flex: 1; height: 10px; background: #1a1a1a; }
+.stat-funnel-label { font-size: 10px; color: var(--text-sub); letter-spacing: 0.08em; width: 44px; flex-shrink: 0; text-align: right; }
+.stat-funnel-wrap  { flex: 1; height: 10px; background: var(--border-dark); }
 .stat-funnel-bar   { height: 100%; }
-.stat-funnel-count { font-size: 10px; color: #aaa; width: 68px; flex-shrink: 0; }
-.stat-pct          { color: #888; }
+.stat-funnel-count { font-size: 10px; color: var(--text-subtle); width: 68px; flex-shrink: 0; }
+.stat-pct          { color: var(--text-faint); }
 
 .stat-resolution { display: flex; gap: 28px; margin-bottom: 10px; }
 .stat-res-item   { display: flex; align-items: baseline; gap: 7px; }
 .stat-res-pct    { font-size: 32px; line-height: 1; }
-.stat-res-label  { font-size: 9px; color: #aaa; letter-spacing: 0.12em; }
+.stat-res-label  { font-size: 9px; color: var(--text-subtle); letter-spacing: 0.12em; }
 .stat-res-bar    { width: 100%; height: 4px; display: flex; overflow: hidden; }
 
 .stat-bars     { display: flex; align-items: flex-end; gap: 4px; }
 .stat-bar-col  { display: flex; flex-direction: column; align-items: center; flex: 1; gap: 3px; }
-.stat-bar-val  { font-size: 9px; color: #aaa; min-height: 12px; line-height: 12px; }
-.stat-bar-out  { width: 100%; height: 60px; background: #1a1a1a; display: flex; align-items: flex-end; }
+.stat-bar-val  { font-size: 9px; color: var(--text-subtle); min-height: 12px; line-height: 12px; }
+.stat-bar-out  { width: 100%; height: 60px; background: var(--border-dark); display: flex; align-items: flex-end; }
 .stat-bar-in   { width: 100%; background: #8855ff; min-height: 0; }
-.stat-bar-date { font-size: 8px; color: #999; white-space: nowrap; }
+.stat-bar-date { font-size: 8px; color: var(--text-faint); white-space: nowrap; }
 
 .stat-dow       { display: flex; gap: 4px; }
 .stat-dow-col   { flex: 1; display: flex; flex-direction: column; align-items: center; gap: 5px; }
 .stat-dow-cell  { width: 100%; aspect-ratio: 1; }
-.stat-dow-label { font-size: 8px; color: #aaa; letter-spacing: 0.04em; }
-.stat-dow-count { font-size: 9px; color: #ccc; }
+.stat-dow-label { font-size: 8px; color: var(--text-subtle); letter-spacing: 0.04em; }
+.stat-dow-count { font-size: 9px; color: var(--text-sub); }
 
 /* ── TTS Stats tab ───────────────────────────────────────────── */
 .tts-stat-section { margin-bottom: 28px; }
@@ -747,13 +815,13 @@ input, textarea, select {
   font-size: 9px;
   letter-spacing: 0.2em;
   text-transform: uppercase;
-  color: #888;
+  color: var(--text-faint);
   margin-bottom: 10px;
 }
 
 .tts-stat-empty {
   font-size: 11px;
-  color: #666;
+  color: var(--text-faintest);
   text-align: center;
   padding: 14px 0;
   letter-spacing: 0.08em;
@@ -780,7 +848,7 @@ input, textarea, select {
 
 .tts-stat-vbar-val {
   font-size: 9px;
-  color: #bbb;
+  color: var(--text-sub);
   margin-bottom: 3px;
   white-space: nowrap;
   min-height: 12px;
@@ -790,7 +858,7 @@ input, textarea, select {
 .tts-stat-vbar-track {
   width: 100%;
   height: 80px;
-  background: #111828;
+  background: var(--surface-alt);
   display: flex;
   align-items: flex-end;
 }
@@ -799,7 +867,7 @@ input, textarea, select {
 
 .tts-stat-vbar-name {
   font-size: 8px;
-  color: #888;
+  color: var(--text-faint);
   margin-top: 4px;
   max-width: 100%;
   overflow: hidden;
@@ -821,16 +889,16 @@ input, textarea, select {
   width: 40px;
   flex-shrink: 0;
   font-size: 10px;
-  color: #aaa;
+  color: var(--text-subtle);
   line-height: 1.3;
 }
 
-.tts-stat-stack-date { display: block; font-size: 8px; color: #777; }
+.tts-stat-stack-date { display: block; font-size: 8px; color: var(--text-faint); }
 
 .tts-stat-stack-track {
   flex: 1;
   height: 16px;
-  background: #111828;
+  background: var(--surface-alt);
 }
 
 .tts-stat-stack-bar { height: 100%; display: flex; min-width: 0; }
@@ -839,7 +907,7 @@ input, textarea, select {
   width: 36px;
   flex-shrink: 0;
   font-size: 9px;
-  color: #999;
+  color: var(--text-faint);
   text-align: right;
 }
 
@@ -858,14 +926,14 @@ input, textarea, select {
 
 .tts-stat-heat-dhd {
   font-size: 9px;
-  color: #888;
+  color: var(--text-faint);
   font-weight: normal;
   letter-spacing: 0.05em;
 }
 
 .tts-stat-heat-proj {
   text-align: left;
-  color: #aaa;
+  color: var(--text-subtle);
   font-size: 10px;
   white-space: nowrap;
   overflow: hidden;
@@ -873,7 +941,7 @@ input, textarea, select {
   max-width: 80px;
 }
 
-.tts-stat-heat-cell { font-size: 9px; color: #e0e0e0; }
+.tts-stat-heat-cell { font-size: 9px; color: var(--text-bright); }
 
 /* ── Month view ── */
 .tts-month-dow {
@@ -885,7 +953,7 @@ input, textarea, select {
 .tts-month-dow-cell {
   text-align: center;
   font-size: 9px;
-  color: #374d66;
+  color: var(--text-dim);
   padding: 3px 0;
   letter-spacing: 0.05em;
 }
@@ -896,8 +964,8 @@ input, textarea, select {
   margin-bottom: 2px;
 }
 .tts-month-cell {
-  background: #0d1221;
-  border: 1px solid #1a2840;
+  background: var(--surface);
+  border: 1px solid var(--border);
   padding: 4px 5px;
   min-height: 52px;
   display: flex;
@@ -905,12 +973,12 @@ input, textarea, select {
 }
 .tts-month-out { opacity: 0.28; }
 .tts-month-today {
-  border-color: #2a4a2a;
-  background: #071a0e;
+  border-color: var(--tts-today-border);
+  background: var(--tts-today-bg);
 }
 .tts-month-daynum {
   font-size: 9px;
-  color: #9ab0d0;
+  color: var(--text-secondary);
   margin-bottom: 4px;
   line-height: 1;
 }
@@ -924,7 +992,7 @@ input, textarea, select {
 }
 .tts-month-total {
   font-size: 8px;
-  color: #9ab0d0;
+  color: var(--text-secondary);
   margin-top: 3px;
   line-height: 1;
 }
@@ -934,7 +1002,7 @@ input, textarea, select {
   gap: 10px;
   margin-top: 16px;
   padding-top: 12px;
-  border-top: 1px solid #1a2840;
+  border-top: 1px solid var(--border);
 }
 .tts-month-legend-item { display: flex; align-items: center; gap: 5px; }
 .tts-month-legend-dot {
@@ -943,4 +1011,52 @@ input, textarea, select {
   border-radius: 50%;
   flex-shrink: 0;
 }
-.tts-month-legend-name { font-size: 9px; color: #9ab0d0; }
+.tts-month-legend-name { font-size: 9px; color: var(--text-secondary); }
+
+/* ── Theme toggle ─────────────────────────────────────────────── */
+.theme-toggle-wrap {
+  position: fixed;
+  top: 0; right: 0;
+  width: 28px; height: 32px;
+  display: flex; align-items: center; justify-content: center;
+  z-index: 200;
+}
+
+.theme-toggle-btn {
+  background: none; border: none; cursor: pointer;
+  color: var(--text-dim);
+  display: flex; align-items: center; justify-content: center;
+  width: 100%; height: 100%;
+  padding: 0;
+  transition: color 0.15s;
+}
+.theme-toggle-btn:hover,
+.theme-toggle-btn.open { color: var(--text-secondary); }
+
+.theme-flyout {
+  position: absolute; top: 100%; right: 0;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  min-width: 90px;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.25);
+  z-index: 201;
+}
+
+.theme-option {
+  display: flex; align-items: center; gap: 8px;
+  width: 100%; background: none; border: none; cursor: pointer;
+  padding: 7px 12px; font-size: 12px; font-family: inherit;
+  color: var(--text-secondary); text-align: left;
+  letter-spacing: 0.04em;
+}
+.theme-option:hover { background: var(--surface-alt); color: var(--text-primary); }
+.theme-option.active { color: var(--text-primary); }
+
+.theme-option-dot {
+  width: 5px; height: 5px; border-radius: 50%; flex-shrink: 0;
+  border: 1px solid var(--text-dim);
+}
+.theme-option.active .theme-option-dot {
+  background: var(--text-secondary);
+  border-color: var(--text-secondary);
+}

--- a/frontend/src/pages/BpmCounter.jsx
+++ b/frontend/src/pages/BpmCounter.jsx
@@ -68,18 +68,18 @@ export default function BpmCounter() {
       <div className="page" style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', paddingTop: 60 }}>
 
         <div style={{ fontSize: 96, fontWeight: 600, lineHeight: 1, marginBottom: 6,
-          color: bpm ? '#eef2ff' : '#374d66', fontVariantNumeric: 'tabular-nums' }}>
+          color: bpm ? 'var(--text-primary)' : 'var(--text-dim)', fontVariantNumeric: 'tabular-nums' }}>
           {bpm ?? '--'}
         </div>
-        <div style={{ fontSize: 11, color: '#374d66', letterSpacing: '0.2em', marginBottom: 52 }}>BPM</div>
+        <div style={{ fontSize: 11, color: 'var(--text-dim)', letterSpacing: '0.2em', marginBottom: 52 }}>BPM</div>
 
         <button
           onPointerDown={handleTap}
           style={{
             width: '100%', height: 160, borderRadius: 16,
-            background: flash ? 'rgba(77,111,160,0.2)' : '#0d1221',
-            border: `2px solid ${flash ? '#4d6fa0' : '#1a2840'}`,
-            color: '#9ab0d0', fontSize: 15, fontFamily: 'inherit',
+            background: flash ? 'rgba(77,111,160,0.2)' : 'var(--surface)',
+            border: `2px solid ${flash ? '#4d6fa0' : 'var(--border)'}`,
+            color: 'var(--text-secondary)', fontSize: 15, fontFamily: 'inherit',
             letterSpacing: '0.18em', cursor: 'pointer',
             transition: 'background 0.05s, border-color 0.05s',
             userSelect: 'none', touchAction: 'none',
@@ -96,7 +96,7 @@ export default function BpmCounter() {
           </>}
         </div>
 
-        <div style={{ marginTop: 28, fontSize: 11, color: '#1a2840' }}>space bar also works</div>
+        <div style={{ marginTop: 28, fontSize: 11, color: 'var(--border)' }}>space bar also works</div>
       </div>
     </div>
   )

--- a/frontend/src/pages/Calendar.jsx
+++ b/frontend/src/pages/Calendar.jsx
@@ -450,14 +450,14 @@ export default function Calendar() {
 
           return (
             <div key={`${y}-${m}`} style={{ marginBottom: 28 }}>
-              <div style={{ fontSize: 11, color: '#5d7592', letterSpacing: '0.2em', marginBottom: 8, textTransform: 'uppercase' }}>
+              <div style={{ fontSize: 11, color: 'var(--text-muted)', letterSpacing: '0.2em', marginBottom: 8, textTransform: 'uppercase' }}>
                 {MONTHS[m]} {y}
               </div>
               {/* Day-of-week header — blank CW cell + Mo…Su */}
               <div style={{ display: 'grid', gridTemplateColumns: COLS, gap: 2, marginBottom: 2 }}>
                 <div />
                 {DOW_HDR.map(d => (
-                  <div key={d} style={{ textAlign: 'center', fontSize: 9, color: '#374d66', letterSpacing: '0.05em', padding: '2px 0' }}>
+                  <div key={d} style={{ textAlign: 'center', fontSize: 9, color: 'var(--text-dim)', letterSpacing: '0.05em', padding: '2px 0' }}>
                     {d}
                   </div>
                 ))}
@@ -469,7 +469,7 @@ export default function Calendar() {
                   <div key={wi} style={{ display: 'grid', gridTemplateColumns: COLS, gap: 2, marginBottom: 2 }}>
                     {/* CW label */}
                     <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center',
-                      fontSize: 8, color: '#374d66', letterSpacing: '0.03em' }}>
+                      fontSize: 8, color: 'var(--text-dim)', letterSpacing: '0.03em' }}>
                       {cw}
                     </div>
                     {week.map((d, di) => {
@@ -491,11 +491,11 @@ export default function Calendar() {
                           onClick={e => openTooltip(e, tipLines)}
                           style={{
                             aspectRatio: '1',
-                            background: holBg || '#0d1221',
-                            border: isToday ? '1px solid #8855ff' : '1px solid #1a2840',
+                            background: holBg || 'var(--surface)',
+                            border: isToday ? '1px solid #8855ff' : '1px solid var(--border)',
                             display: 'flex', alignItems: 'center', justifyContent: 'center',
                             fontSize: 10, position: 'relative',
-                            color: isToday ? '#8855ff' : dayHols.length ? '#9ab0d0' : '#374d66',
+                            color: isToday ? '#8855ff' : dayHols.length ? 'var(--text-secondary)' : 'var(--text-dim)',
                           }}>
                           {dayProjs.map(p => (
                             <div key={p.id} style={{
@@ -509,7 +509,7 @@ export default function Calendar() {
                             <span style={{
                               position: 'absolute', bottom: 2, left: '50%', transform: 'translateX(-50%)',
                               width: 3, height: 3, borderRadius: '50%',
-                              background: HOLIDAY_DOT[dayHols[0].country] || '#aaa',
+                              background: HOLIDAY_DOT[dayHols[0].country] || 'var(--text-subtle)',
                               zIndex: 1,
                             }} />
                           )}
@@ -525,10 +525,10 @@ export default function Calendar() {
                 const s = parseDate(p.start_date), en = parseDate(p.end_date)
                 return s <= new Date(y, m + 1, 0) && en >= new Date(y, m, 1)
               }).map(p => (
-                <div key={p.id} style={{ marginTop: 4, display: 'flex', alignItems: 'center', gap: 6, fontSize: 11, color: '#9ab0d0' }}>
+                <div key={p.id} style={{ marginTop: 4, display: 'flex', alignItems: 'center', gap: 6, fontSize: 11, color: 'var(--text-secondary)' }}>
                   <span style={{ width: 6, height: 6, borderRadius: '50%', background: p.color }} />
                   {p.name}
-                  <span style={{ color: '#374d66' }}>{fmtIsoDate(p.start_date)} → {fmtIsoDate(p.end_date)}</span>
+                  <span style={{ color: 'var(--text-dim)' }}>{fmtIsoDate(p.start_date)} → {fmtIsoDate(p.end_date)}</span>
                 </div>
               ))}
             </div>
@@ -540,11 +540,11 @@ export default function Calendar() {
       {showSettings && (
         <div style={{
           position: 'fixed', top: 32, left: 0, right: 0, zIndex: 40,
-          background: '#07091a', borderBottom: '1px solid #1a2840',
+          background: 'var(--bg)', borderBottom: '1px solid var(--border)',
           maxHeight: 'calc(100vh - 32px)', overflowY: 'auto',
         }}>
           <div style={{ maxWidth: 900, margin: '0 auto', padding: '16px 16px' }}>
-            <div style={{ fontSize: 11, color: '#9ab0d0', marginBottom: 8, letterSpacing: '0.08em' }}>RANGE</div>
+            <div style={{ fontSize: 11, color: 'var(--text-secondary)', marginBottom: 8, letterSpacing: '0.08em' }}>RANGE</div>
             <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap', marginBottom: 16 }}>
               <div>
                 <label className="label">from</label>
@@ -577,17 +577,17 @@ export default function Calendar() {
                 </div>
               </div>
             </div>
-            <div style={{ fontSize: 11, color: '#9ab0d0', marginBottom: 8, letterSpacing: '0.08em' }}>HOLIDAYS</div>
+            <div style={{ fontSize: 11, color: 'var(--text-secondary)', marginBottom: 8, letterSpacing: '0.08em' }}>HOLIDAYS</div>
             <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
               {COUNTRIES.map(code => (
                 <button key={code} type="button" className="btn btn-sm"
-                  style={{ borderColor: countries.includes(code) ? '#4d6fa0' : '#1a2840',
-                           color:       countries.includes(code) ? '#eef2ff' : '#5d7592' }}
+                  style={{ borderColor: countries.includes(code) ? '#4d6fa0' : 'var(--border)',
+                           color:       countries.includes(code) ? 'var(--text-primary)' : 'var(--text-muted)' }}
                   onClick={() => toggleCountry(code)}>
                   <span style={{ display: 'inline-block', width: 8, height: 8, borderRadius: '50%',
                     background: HOLIDAY_DOT[code], marginRight: 5 }} />
                   {code}
-                  <span style={{ marginLeft: 4, fontSize: 10, color: '#374d66' }}>{COUNTRY_LABEL[code]}</span>
+                  <span style={{ marginLeft: 4, fontSize: 10, color: 'var(--text-dim)' }}>{COUNTRY_LABEL[code]}</span>
                 </button>
               ))}
             </div>
@@ -598,7 +598,7 @@ export default function Calendar() {
       {/* Fixed controls panel — chips, add button, and forms always in view */}
       <div ref={formPanelRef} style={{
         position: 'fixed', top: 32, left: 0, right: 0, zIndex: 30,
-        background: '#07091a', borderBottom: '1px solid #1a2840',
+        background: 'var(--bg)', borderBottom: '1px solid var(--border)',
       }}>
         <div style={{ maxWidth: 900, margin: '0 auto', padding: '10px 16px' }}>
           {/* Project chips + add button */}
@@ -606,9 +606,9 @@ export default function Calendar() {
             {projects.map(p => (
               <span key={p.id} onClick={() => startEdit(p)}
                 style={{ display: 'flex', alignItems: 'center', gap: 6,
-                  background: editId === p.id ? '#1a2840' : '#0d1221',
-                  border: `1px solid ${editId === p.id ? '#2a3d5c' : '#1a2840'}`,
-                  padding: '4px 10px', fontSize: 12, cursor: 'pointer', color: '#ccc' }}>
+                  background: editId === p.id ? 'var(--border)' : 'var(--surface)',
+                  border: `1px solid ${editId === p.id ? 'var(--border-hover)' : 'var(--border)'}`,
+                  padding: '4px 10px', fontSize: 12, cursor: 'pointer', color: 'var(--text-sub)' }}>
                 <span style={{ width: 8, height: 8, borderRadius: '50%', background: p.color }} />
                 {p.name}
               </span>
@@ -632,7 +632,7 @@ export default function Calendar() {
                       {COLORS.map(c => (
                         <button key={c} type="button" onClick={() => setF('color', c)}
                           style={{ width: 20, height: 20, background: c, borderRadius: 2,
-                                   border: form.color === c ? '2px solid #fff' : '2px solid transparent' }} />
+                                   border: form.color === c ? '2px solid var(--text-primary)' : '2px solid transparent' }} />
                       ))}
                     </div>
                   </div>
@@ -641,7 +641,7 @@ export default function Calendar() {
                   <label className="label">start</label>
                   <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap', alignItems: 'center' }}>
                     {projects.length > 0 && (
-                      <label style={{ display: 'flex', alignItems: 'center', gap: 5, fontSize: 12, color: '#9ab0d0' }}>
+                      <label style={{ display: 'flex', alignItems: 'center', gap: 5, fontSize: 12, color: 'var(--text-secondary)' }}>
                         <input type="radio" checked={form.startMode === 'after'} onChange={() => setF('startMode', 'after')} />
                         after
                         <select className="input" style={{ width: 'auto', padding: '2px 6px', fontSize: 12 }}
@@ -652,7 +652,7 @@ export default function Calendar() {
                         </select>
                       </label>
                     )}
-                    <label style={{ display: 'flex', alignItems: 'center', gap: 5, fontSize: 12, color: '#9ab0d0' }}>
+                    <label style={{ display: 'flex', alignItems: 'center', gap: 5, fontSize: 12, color: 'var(--text-secondary)' }}>
                       <input type="radio" checked={form.startMode === 'offset'} onChange={() => setF('startMode', 'offset')} />
                       in
                       <input type="number" min="0" className="input" style={{ width: 52, padding: '2px 6px', fontSize: 12 }}
@@ -681,7 +681,7 @@ export default function Calendar() {
                     </select>
                   </div>
                 </div>
-                <div style={{ fontSize: 11, color: '#5d7592', marginBottom: 12 }}>
+                <div style={{ fontSize: 11, color: 'var(--text-muted)', marginBottom: 12 }}>
                   {toDateStr(previewStart)} → {toDateStr(previewEnd)}
                 </div>
                 <div style={{ display: 'flex', gap: 8 }}>
@@ -712,7 +712,7 @@ export default function Calendar() {
                     {COLORS.map(c => (
                       <button key={c} type="button" onClick={() => setEF('color', c)}
                         style={{ width: 20, height: 20, background: c, borderRadius: 2,
-                                 border: editForm.color === c ? '2px solid #fff' : '2px solid transparent' }} />
+                                 border: editForm.color === c ? '2px solid var(--text-primary)' : '2px solid transparent' }} />
                     ))}
                   </div>
                 </div>
@@ -734,11 +734,11 @@ export default function Calendar() {
           left: tooltip.x,
           top: tooltip.below ? tooltip.y + 6 : tooltip.y - 6,
           transform: tooltip.below ? 'translateX(-50%)' : 'translate(-50%, -100%)',
-          background: '#0d1221',
-          border: '1px solid #2a3d5c',
+          background: 'var(--surface)',
+          border: '1px solid var(--border-hover)',
           padding: '6px 10px',
           fontSize: 11,
-          color: '#9ab0d0',
+          color: 'var(--text-secondary)',
           zIndex: 200,
           pointerEvents: 'none',
           whiteSpace: 'nowrap',

--- a/frontend/src/pages/IdeaInbox.jsx
+++ b/frontend/src/pages/IdeaInbox.jsx
@@ -222,7 +222,7 @@ function Stats({ ideas }) {
   const killedCount = ideas.filter(i => i.status === 'killed').length
 
   if (total === 0) return (
-    <div style={{ color: '#444', fontSize: 13, padding: '32px 0', textAlign: 'center', letterSpacing: '0.1em' }}>no data yet</div>
+    <div style={{ color: 'var(--text-faintest)', fontSize: 13, padding: '32px 0', textAlign: 'center', letterSpacing: '0.1em' }}>no data yet</div>
   )
 
   const resolved   = doneCount + killedCount
@@ -273,7 +273,7 @@ function Stats({ ideas }) {
   return (
     <div>
       <div className="stat-topline">
-        <div className="stat-box"><div className="stat-box-val" style={{ color: '#aaa' }}>{total}</div><div className="stat-box-label">TOTAL</div></div>
+        <div className="stat-box"><div className="stat-box-val" style={{ color: 'var(--text-subtle)' }}>{total}</div><div className="stat-box-label">TOTAL</div></div>
         <div className="stat-box"><div className="stat-box-val" style={{ color: '#8855ff' }}>{doCount}</div><div className="stat-box-label">DO</div></div>
         <div className="stat-box"><div className="stat-box-val" style={{ color: '#44cc88' }}>{doneCount}</div><div className="stat-box-label">DONE</div></div>
         <div className="stat-box"><div className="stat-box-val" style={{ color: '#ff5555' }}>{killedCount}</div><div className="stat-box-label">KILLED</div></div>
@@ -467,7 +467,7 @@ export default function IdeaInbox() {
           {TABS.map(t => (
             <button key={t.key} className={`tab${tab === t.key ? ' active' : ''}`} onClick={() => setTab(t.key)}>
               {t.label}
-              {t.status && <span style={{ fontSize: 11, color: '#555', marginLeft: 4 }}>{counts[t.key]}</span>}
+              {t.status && <span style={{ fontSize: 11, color: 'var(--text-faintest)', marginLeft: 4 }}>{counts[t.key]}</span>}
             </button>
           ))}
         </div>
@@ -477,7 +477,7 @@ export default function IdeaInbox() {
         ) : (
           <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
             {visible.length === 0 && (
-              <div style={{ color: '#444', fontSize: 13, padding: '20px 0', textAlign: 'center', letterSpacing: '0.05em' }}>empty</div>
+              <div style={{ color: 'var(--text-faintest)', fontSize: 13, padding: '20px 0', textAlign: 'center', letterSpacing: '0.05em' }}>empty</div>
             )}
             {visible.map(idea => (
               tab === 'done' ? (

--- a/frontend/src/pages/SpotifyExplorer.jsx
+++ b/frontend/src/pages/SpotifyExplorer.jsx
@@ -20,7 +20,7 @@ const BAR_SEGMENTS = [
   { key: 'deezer',     color: '#a78bfa', label: 'deezer'     },
   { key: 'getsongbpm', color: '#4ade80', label: 'getsong.co' },
   { key: 'notFound',   color: '#f44336', label: 'not found'  },
-  { key: 'pending',    color: '#1a2840', label: 'pending'    },
+  { key: 'pending',    color: 'var(--border)', label: 'pending'    },
 ]
 
 function BpmBar({ stats }) {
@@ -31,7 +31,7 @@ function BpmBar({ stats }) {
 
   return (
     <div style={{ marginTop: 16 }}>
-      <div style={{ display: 'flex', height: 10, borderRadius: 5, overflow: 'hidden', background: '#1a2840' }}>
+      <div style={{ display: 'flex', height: 10, borderRadius: 5, overflow: 'hidden', background: 'var(--border)' }}>
         {BAR_SEGMENTS.map(seg => {
           const pct = (counts[seg.key] / total) * 100
           if (!pct) return null
@@ -60,21 +60,21 @@ function BpmBar({ stats }) {
               onMouseLeave={() => setHovered(null)}
             >
               <div style={{ width: 8, height: 8, borderRadius: 2, background: seg.color, flexShrink: 0 }} />
-              <span style={{ fontSize: 11, color: isHovered ? '#eef2ff' : '#9ab0d0' }}>
+              <span style={{ fontSize: 11, color: isHovered ? 'var(--text-primary)' : 'var(--text-secondary)' }}>
                 {seg.label}
               </span>
-              <span style={{ fontSize: 11, color: isHovered ? seg.color : '#374d66', minWidth: 18, textAlign: 'right' }}>
+              <span style={{ fontSize: 11, color: isHovered ? seg.color : 'var(--text-dim)', minWidth: 18, textAlign: 'right' }}>
                 {n}
               </span>
               {isHovered && (
-                <span style={{ fontSize: 10, color: '#374d66' }}>({pct}%)</span>
+                <span style={{ fontSize: 10, color: 'var(--text-dim)' }}>({pct}%)</span>
               )}
             </div>
           )
         })}
         <div style={{ display: 'flex', alignItems: 'center', gap: 5, marginLeft: 'auto' }}>
-          <span style={{ fontSize: 11, color: '#374d66' }}>total</span>
-          <span style={{ fontSize: 11, color: '#9ab0d0' }}>{total}</span>
+          <span style={{ fontSize: 11, color: 'var(--text-dim)' }}>total</span>
+          <span style={{ fontSize: 11, color: 'var(--text-secondary)' }}>{total}</span>
         </div>
       </div>
     </div>
@@ -84,21 +84,21 @@ function BpmBar({ stats }) {
 function LogEntry({ e }) {
   const bpmText = e.bpm ? `${e.bpm} bpm` : '—'
   return (
-    <div style={{ padding: '4px 0', borderBottom: '1px solid #0d1221' }}>
-      <div style={{ fontSize: 12, color: '#9ab0d0', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', marginBottom: 2 }}>
-        <span style={{ color: '#eef2ff' }}>{e.artist}</span>
-        <span style={{ color: '#374d66' }}> — </span>
+    <div style={{ padding: '4px 0', borderBottom: '1px solid var(--surface)' }}>
+      <div style={{ fontSize: 12, color: 'var(--text-secondary)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', marginBottom: 2 }}>
+        <span style={{ color: 'var(--text-primary)' }}>{e.artist}</span>
+        <span style={{ color: 'var(--text-dim)' }}> — </span>
         <span>{e.name}</span>
-        <span style={{ color: '#374d66' }}> — </span>
-        <span style={{ color: e.bpm ? '#4ade80' : '#9ab0d0', fontWeight: 500 }}>{bpmText}</span>
+        <span style={{ color: 'var(--text-dim)' }}> — </span>
+        <span style={{ color: e.bpm ? '#4ade80' : 'var(--text-secondary)', fontWeight: 500 }}>{bpmText}</span>
       </div>
       <div style={{ fontSize: 10, fontFamily: 'monospace', display: 'flex', gap: 14 }}>
         {['deezer', 'getsongbpm'].map(key => {
           const val = e[key]
           const label = key === 'getsongbpm' ? 'getsong.co' : key
-          const color = val === 'pass' ? '#4ade80' : val === 'fail' ? '#f44336' : '#374d66'
+          const color = val === 'pass' ? '#4ade80' : val === 'fail' ? '#f44336' : 'var(--text-dim)'
           return (
-            <span key={key} style={{ color: '#374d66' }}>
+            <span key={key} style={{ color: 'var(--text-dim)' }}>
               {label}: <span style={{ color }}>{val ?? '—'}</span>
             </span>
           )
@@ -436,7 +436,7 @@ export default function SpotifyExplorer() {
           /* ── Scan-all view ─────────────────────────────── */
           <>
             {/* Progress — sticky below topbar */}
-            <div style={{ position: 'sticky', top: 32, background: '#07091a', zIndex: 10, paddingBottom: 12, borderBottom: '1px solid #1a2840', marginBottom: 4 }}>
+            <div style={{ position: 'sticky', top: 32, background: 'var(--bg)', zIndex: 10, paddingBottom: 12, borderBottom: '1px solid var(--border)', marginBottom: 4 }}>
               <div style={{ display: 'flex', gap: 32, paddingTop: 12, flexWrap: 'wrap' }}>
                 {[
                   { label: 'playlists done', value: scanProgress.playlistsDone },
@@ -445,22 +445,22 @@ export default function SpotifyExplorer() {
                   { label: 'tracks open',    value: Math.max(0, scanProgress.tracksTotal - scanProgress.tracksDone) },
                 ].map(({ label, value }) => (
                   <div key={label}>
-                    <div style={{ fontSize: 10, color: '#374d66', marginBottom: 2 }}>{label}</div>
-                    <div style={{ fontSize: 24, fontWeight: 600, color: '#eef2ff', lineHeight: 1 }}>{value}</div>
+                    <div style={{ fontSize: 10, color: 'var(--text-dim)', marginBottom: 2 }}>{label}</div>
+                    <div style={{ fontSize: 24, fontWeight: 600, color: 'var(--text-primary)', lineHeight: 1 }}>{value}</div>
                   </div>
                 ))}
                 {scanStartedAt && (
                   <div>
-                    <div style={{ fontSize: 10, color: '#374d66', marginBottom: 2 }}>elapsed</div>
-                    <div style={{ fontSize: 24, fontWeight: 600, color: '#eef2ff', lineHeight: 1 }}>{fmtElapsed(elapsedMs)}</div>
+                    <div style={{ fontSize: 10, color: 'var(--text-dim)', marginBottom: 2 }}>elapsed</div>
+                    <div style={{ fontSize: 24, fontWeight: 600, color: 'var(--text-primary)', lineHeight: 1 }}>{fmtElapsed(elapsedMs)}</div>
                   </div>
                 )}
               </div>
               {scanMode === 'fetching' && (
-                <div style={{ fontSize: 11, color: '#9ab0d0', marginTop: 8 }}>fetching playlists from spotify…</div>
+                <div style={{ fontSize: 11, color: 'var(--text-secondary)', marginTop: 8 }}>fetching playlists from spotify…</div>
               )}
               {scanMode === 'running' && (
-                <div style={{ fontSize: 11, color: '#9ab0d0', marginTop: 8 }}>scanning in background — you can close this page</div>
+                <div style={{ fontSize: 11, color: 'var(--text-secondary)', marginTop: 8 }}>scanning in background — you can close this page</div>
               )}
               {scanMode === 'done' && (
                 <div style={{ fontSize: 11, color: '#4ade80', marginTop: 8 }}>scan complete</div>
@@ -487,13 +487,13 @@ export default function SpotifyExplorer() {
           <>
             <div className="section-header">connect spotify</div>
             <div className="card">
-              <p style={{ fontSize: 12, color: '#9ab0d0', margin: '0 0 12px' }}>
+              <p style={{ fontSize: 12, color: 'var(--text-secondary)', margin: '0 0 12px' }}>
                 Create an app at{' '}
                 <a href="https://developer.spotify.com/dashboard" target="_blank" rel="noopener noreferrer" style={{ color: '#4a9eff' }}>
                   developer.spotify.com/dashboard
                 </a>
                 , add{' '}
-                <code style={{ fontSize: 11, background: '#111827', padding: '1px 4px', borderRadius: 3 }}>
+                <code style={{ fontSize: 11, background: 'var(--surface-alt)', padding: '1px 4px', borderRadius: 3 }}>
                   {window.location.origin}/spt
                 </code>{' '}
                 as a redirect URI, then paste your Client ID below.
@@ -546,8 +546,8 @@ export default function SpotifyExplorer() {
               ))}
             </select>
 
-            {status   && <div style={{ fontSize: 12, color: '#9ab0d0', marginTop: 10 }}>{status}</div>}
-            {bpmStatus && <div style={{ fontSize: 12, color: '#9ab0d0', marginTop: 10 }}>{bpmStatus}</div>}
+            {status   && <div style={{ fontSize: 12, color: 'var(--text-secondary)', marginTop: 10 }}>{status}</div>}
+            {bpmStatus && <div style={{ fontSize: 12, color: 'var(--text-secondary)', marginTop: 10 }}>{bpmStatus}</div>}
 
             {bpmLog.length > 0 && (
               <div
@@ -580,23 +580,23 @@ export default function SpotifyExplorer() {
                             : t.bpmSource === 'getsongbpm' ? '#4ade80'
                             : t.bpmSource === 'deezer'   ? '#a78bfa'
                             : t.bpmSource === 'failed'   ? '#f44336'
-                            : '#eef2ff'
+                            : 'var(--text-primary)'
                           }}>
                             {t.bpm ?? '—'}
                           </span>
                         </div>
-                        <div style={{ fontSize: 10, color: '#374d66' }}>bpm</div>
+                        <div style={{ fontSize: 10, color: 'var(--text-dim)' }}>bpm</div>
                       </div>
-                      <div style={{ width: 1, height: 28, background: '#1a2840', flexShrink: 0 }} />
+                      <div style={{ width: 1, height: 28, background: 'var(--border)', flexShrink: 0 }} />
                       <div style={{ flex: 1, minWidth: 0 }}>
-                        <div style={{ fontSize: 13, color: '#eef2ff', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                        <div style={{ fontSize: 13, color: 'var(--text-primary)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                           {t.name}
                         </div>
-                        <div style={{ fontSize: 11, color: '#9ab0d0', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                        <div style={{ fontSize: 11, color: 'var(--text-secondary)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                           {t.artists.map(a => a.name).join(', ')}
                         </div>
                       </div>
-                      <span style={{ fontSize: 11, color: '#374d66', flexShrink: 0 }}>{fmtDuration(t.duration_ms)}</span>
+                      <span style={{ fontSize: 11, color: 'var(--text-dim)', flexShrink: 0 }}>{fmtDuration(t.duration_ms)}</span>
                     </div>
                   ))}
                 </div>
@@ -605,16 +605,16 @@ export default function SpotifyExplorer() {
                     { color: '#a78bfa', label: 'deezer' },
                     { color: '#4ade80', label: 'getsong.co' },
                     { color: '#f44336', label: 'not found' },
-                    { color: '#eef2ff', label: 'pending' },
+                    { color: 'var(--text-primary)', label: 'pending' },
                   ].map(({ color, label }) => (
                     <div key={label} style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
                       <div style={{ width: 8, height: 8, borderRadius: '50%', background: color, flexShrink: 0 }} />
-                      <span style={{ fontSize: 10, color: '#374d66' }}>{label}</span>
+                      <span style={{ fontSize: 10, color: 'var(--text-dim)' }}>{label}</span>
                     </div>
                   ))}
                   <div style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
                     <div style={{ width: 5, height: 5, borderRadius: '50%', background: '#e879f9', flexShrink: 0 }} />
-                    <span style={{ fontSize: 10, color: '#374d66' }}>db cache</span>
+                    <span style={{ fontSize: 10, color: 'var(--text-dim)' }}>db cache</span>
                   </div>
                 </div>
               </div>
@@ -624,7 +624,7 @@ export default function SpotifyExplorer() {
 
         {/* Bottom bar — always visible when connected */}
         {connected && (
-          <div style={{ marginTop: 24, borderTop: '1px solid #1a2840', paddingTop: 16 }}>
+          <div style={{ marginTop: 24, borderTop: '1px solid var(--border)', paddingTop: 16 }}>
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
               <div style={{ display: 'flex', gap: 8 }}>
                 <button className="btn btn-sm" onClick={disconnect}>disconnect spotify</button>
@@ -637,7 +637,7 @@ export default function SpotifyExplorer() {
                   {scanMode === 'fetching' ? 'fetching… (cancel)' : scanMode === 'running' ? 'scanning…' : scanMode === 'done' ? 'close scan' : 'scan all'}
                 </button>
               </div>
-              <a href="https://getsong.co" target="_blank" rel="noopener noreferrer" style={{ fontSize: 10, color: '#374d66', textDecoration: 'none' }}>
+              <a href="https://getsong.co" target="_blank" rel="noopener noreferrer" style={{ fontSize: 10, color: 'var(--text-dim)', textDecoration: 'none' }}>
                 BPM data: GetSong.co
               </a>
             </div>

--- a/frontend/src/pages/StringTracker.jsx
+++ b/frontend/src/pages/StringTracker.jsx
@@ -154,7 +154,7 @@ export default function StringTracker() {
           const snapping = swipeOffset.id !== g.id
 
           return (
-            <div key={g.id} style={{ position: 'relative', marginBottom: 8, borderRadius: 8, overflow: 'hidden', border: '1px solid #1a2840' }}>
+            <div key={g.id} style={{ position: 'relative', marginBottom: 8, borderRadius: 8, overflow: 'hidden', border: '1px solid var(--border)' }}>
               {/* delete zone revealed by left swipe */}
               <div style={{
                 position: 'absolute', top: 0, right: 0, bottom: 0, width: 80,
@@ -181,17 +181,17 @@ export default function StringTracker() {
                   onClick={() => handleCardClick(g.id)}
                 >
                   <span style={{ width: 8, height: 8, borderRadius: '50%', background: color, flexShrink: 0 }} />
-                  <span style={{ flex: 1, fontSize: 14, color: '#ddd' }}>{g.name}</span>
+                  <span style={{ flex: 1, fontSize: 14, color: 'var(--text-sub)' }}>{g.name}</span>
                   <span style={{ fontSize: 12, color }}>{days !== null ? `${days}d` : '—'}</span>
-                  <span style={{ fontSize: 12, color: '#374d66', margin: '0 2px' }}>|</span>
+                  <span style={{ fontSize: 12, color: 'var(--text-dim)', margin: '0 2px' }}>|</span>
                   <span style={{ fontSize: 12, color }}>{remaining !== null ? `${Math.abs(remaining)}d` : '—'}</span>
-                  <span style={{ fontSize: 12, color: '#374d66', margin: '0 2px' }}>|</span>
-                  <span style={{ fontSize: 12, color: '#374d66' }}>{g.threshold_days}d</span>
+                  <span style={{ fontSize: 12, color: 'var(--text-dim)', margin: '0 2px' }}>|</span>
+                  <span style={{ fontSize: 12, color: 'var(--text-dim)' }}>{g.threshold_days}d</span>
                 </div>
 
                 {expanded && (
-                  <div style={{ marginTop: 12, borderTop: '1px solid #1e1e1e', paddingTop: 12 }}>
-                    <div style={{ fontSize: 11, color: '#666', marginBottom: 8 }}>
+                  <div style={{ marginTop: 12, borderTop: '1px solid var(--border-dark)', paddingTop: 12 }}>
+                    <div style={{ fontSize: 11, color: 'var(--text-faintest)', marginBottom: 8 }}>
                       last changed: {fmtDate(g.last_changed)}
                     </div>
                     {g.history?.length > 0 && (
@@ -199,7 +199,7 @@ export default function StringTracker() {
                         <div className="label">change history</div>
                         <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
                           {[...g.history].reverse().slice(0, 10).map((h, i) => (
-                            <div key={i} style={{ fontSize: 12, color: '#555' }}>{fmtDate(h)}</div>
+                            <div key={i} style={{ fontSize: 12, color: 'var(--text-faintest)' }}>{fmtDate(h)}</div>
                           ))}
                         </div>
                       </div>

--- a/frontend/src/pages/TimeTracker.jsx
+++ b/frontend/src/pages/TimeTracker.jsx
@@ -171,7 +171,7 @@ function ProjectModal({ project, onSave, onClose }) {
               style={{
                 width: 22, height: 22, background: c, border: 'none', borderRadius: '50%',
                 cursor: 'pointer',
-                outline: color === c ? '2px solid #fff' : '2px solid transparent',
+                outline: color === c ? '2px solid var(--text-primary)' : '2px solid transparent',
                 outlineOffset: 2,
               }}
             />
@@ -192,7 +192,7 @@ function TodayLog({ entries, projects, onDelete }) {
   const now = Date.now()
 
   function getProject(pid) {
-    return projects.find(p => p.id === pid) || { name: '?', color: '#666' }
+    return projects.find(p => p.id === pid) || { name: '?', color: 'var(--text-faintest)' }
   }
 
   const todayAll  = entries.filter(e => isToday(e.start_time))
@@ -203,7 +203,7 @@ function TodayLog({ entries, projects, onDelete }) {
 
   if (!active && completed.length === 0) {
     return (
-      <div style={{ color: '#444', fontSize: 12, padding: '20px 0', textAlign: 'center', letterSpacing: '0.08em' }}>
+      <div style={{ color: 'var(--text-faintest)', fontSize: 12, padding: '20px 0', textAlign: 'center', letterSpacing: '0.08em' }}>
         no entries today yet
       </div>
     )
@@ -902,7 +902,7 @@ export default function TimeTracker() {
 
       <div className="page">
         {error && (
-          <div style={{ background: '#2a0000', border: '1px solid #f44336', color: '#f44336', fontSize: 12, padding: '8px 12px', marginBottom: 16 }}>
+          <div style={{ background: 'var(--error-bg)', border: '1px solid #f44336', color: '#f44336', fontSize: 12, padding: '8px 12px', marginBottom: 16 }}>
             {error}
             <button style={{ float: 'right', background: 'none', border: 'none', color: '#f44336', cursor: 'pointer' }} onClick={() => setError(null)}>×</button>
           </div>
@@ -925,7 +925,7 @@ export default function TimeTracker() {
         {tab === 'log' && (
           <>
             <div className="tts-global">
-              <div className="tts-timer" style={{ color: globalStart ? '#f0f0f0' : '#2a2a2a' }}>
+              <div className="tts-timer" style={{ color: globalStart ? 'var(--text-primary)' : 'var(--timer-inactive)' }}>
                 {fmtMs(globalElapsed)}
               </div>
               <button
@@ -958,14 +958,14 @@ export default function TimeTracker() {
                       onClick={() => handleCardClick(p.id)}
                     >
                       <div className="tts-card-stripe" style={{ background: p.color }} />
-                      <div className="tts-card-name" style={{ color: isActive ? p.color : '#f0f0f0' }}>
+                      <div className="tts-card-name" style={{ color: isActive ? p.color : 'var(--text-primary)' }}>
                         {p.name}
                         {isActive && <span className="tts-now-badge" style={{ color: p.color }}>ACTIVE</span>}
                       </div>
                       <div className="tts-card-rows">
                         <div className="tts-card-row">
                           <span className="tts-row-lbl">session</span>
-                          <span className="tts-row-val" style={{ color: isActive ? p.color : '#666' }}>
+                          <span className="tts-row-val" style={{ color: isActive ? p.color : 'var(--text-faintest)' }}>
                             {fmtMsStat(sessionMs)}
                           </span>
                         </div>
@@ -983,7 +983,7 @@ export default function TimeTracker() {
                 })}
               </div>
             ) : (
-              <div style={{ color: '#888', fontSize: 12, padding: '20px 0', textAlign: 'center', letterSpacing: '0.08em' }}>
+              <div style={{ color: 'var(--text-faint)', fontSize: 12, padding: '20px 0', textAlign: 'center', letterSpacing: '0.08em' }}>
                 no projects yet — add one in the org tab
               </div>
             )}
@@ -1024,12 +1024,12 @@ export default function TimeTracker() {
 
             {archivedProjects.length > 0 && (
               <>
-                <div className="section-header mt24" style={{ color: '#2a2a2a' }}>archived</div>
+                <div className="section-header mt24" style={{ color: 'var(--timer-inactive)' }}>archived</div>
                 <div className="tts-mgmt-list">
                   {archivedProjects.map(p => (
                     <div key={p.id} className="tts-mgmt-row" style={{ opacity: 0.4 }}>
                       <span className="color-dot" style={{ background: p.color }} />
-                      <span className="tts-mgmt-name" style={{ color: '#666', cursor: 'default' }}>
+                      <span className="tts-mgmt-name" style={{ color: 'var(--text-faintest)', cursor: 'default' }}>
                         {p.name}
                       </span>
                       <button className="btn btn-sm" onClick={() => reactivate(p.id)} title="reactivate">

--- a/frontend/src/pages/Wmt.jsx
+++ b/frontend/src/pages/Wmt.jsx
@@ -30,9 +30,9 @@ const STATUS_LABELS = {
 
 const STATUS_COLORS = {
   IN_PLAY: '#4d8a4d',
-  PAUSED:  '#9ab0d0',
-  FINISHED:'#374d66',
-  default: '#9ab0d0',
+  PAUSED:  'var(--text-secondary)',
+  FINISHED:'var(--text-dim)',
+  default: 'var(--text-secondary)',
 }
 
 function statusColor(s) { return STATUS_COLORS[s] ?? STATUS_COLORS.default }
@@ -119,7 +119,7 @@ function renderMarkdown(text) {
       j % 2 === 1 ? <strong key={j}>{p}</strong> : p
     )
     if (line.startsWith('## '))
-      return <div key={i} style={{ fontSize: 13, fontWeight: 600, color: '#eef2ff', marginBottom: 6 }}>{line.slice(3)}</div>
+      return <div key={i} style={{ fontSize: 13, fontWeight: 600, color: 'var(--text-primary)', marginBottom: 6 }}>{line.slice(3)}</div>
     if (line.startsWith('- '))
       return <div key={i} style={{ paddingLeft: 12, marginBottom: 3 }}>• {parts.slice(1)}</div>
     if (line === '')
@@ -200,10 +200,10 @@ function ProbBar({ home, draw, away, homeTla, awayTla }) {
     <div>
       <div style={{ display: 'flex', height: 6, borderRadius: 3, overflow: 'hidden', gap: 2 }}>
         <div style={{ width: `${hw}%`, background: '#4d6fa0', transition: 'width 0.4s' }} />
-        <div style={{ width: `${dw}%`, background: '#2a3d5c', transition: 'width 0.4s' }} />
-        <div style={{ width: `${aw}%`, background: '#1a2840', transition: 'width 0.4s' }} />
+        <div style={{ width: `${dw}%`, background: 'var(--border-hover)', transition: 'width 0.4s' }} />
+        <div style={{ width: `${aw}%`, background: 'var(--border)', transition: 'width 0.4s' }} />
       </div>
-      <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 10, color: '#9ab0d0', marginTop: 4 }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 10, color: 'var(--text-secondary)', marginTop: 4 }}>
         <span>{homeTla} {hw}%</span>
         <span>Rem {dw}%</span>
         <span>{aw}% {awayTla}</span>
@@ -215,7 +215,7 @@ function ProbBar({ home, draw, away, homeTla, awayTla }) {
 function teamStatusColor(status) {
   if (status === 'qualified')  return '#4d8a4d'
   if (status === 'eliminated') return '#8a4d4d'
-  return '#eef2ff'
+  return 'var(--text-primary)'
 }
 
 function MatchCard({ match, teamStatuses = {} }) {
@@ -235,12 +235,12 @@ function MatchCard({ match, teamStatuses = {} }) {
     else tipAway += 1
   }
 
-  const tipBgColor = isFinished ? '#0d1221' : 'rgba(77,111,160,0.06)'
+  const tipBgColor = isFinished ? 'var(--surface)' : 'rgba(77,111,160,0.06)'
 
   return (
     <div style={{
-      background: '#0d1221',
-      border: '1px solid #1a2840',
+      background: 'var(--surface)',
+      border: '1px solid var(--border)',
       borderRadius: 10,
       padding: '14px 16px',
       marginBottom: 10,
@@ -248,7 +248,7 @@ function MatchCard({ match, teamStatuses = {} }) {
       {/* header row */}
       <div style={{
         display: 'flex', justifyContent: 'space-between', alignItems: 'center',
-        fontSize: 10, color: '#374d66', marginBottom: 12, letterSpacing: '0.05em',
+        fontSize: 10, color: 'var(--text-dim)', marginBottom: 12, letterSpacing: '0.05em',
       }}>
         <span>
           {match.group_name ? `GR. ${match.group_name}` : stageLabel(match.stage)}
@@ -263,22 +263,22 @@ function MatchCard({ match, teamStatuses = {} }) {
       <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 14 }}>
         <div style={{ flex: 1, textAlign: 'right' }}>
           <div style={{ fontSize: 15, fontWeight: 600, color: teamStatusColor(homeStatus) }}>{homeName}</div>
-          <div style={{ fontSize: 10, color: '#9ab0d0', marginTop: 2 }}>{homeTla}</div>
+          <div style={{ fontSize: 10, color: 'var(--text-secondary)', marginTop: 2 }}>{homeTla}</div>
         </div>
 
         <div style={{ minWidth: 56, textAlign: 'center' }}>
           {isFinished || isLive ? (
-            <div style={{ fontSize: 22, fontWeight: 600, color: '#eef2ff', fontVariantNumeric: 'tabular-nums' }}>
+            <div style={{ fontSize: 22, fontWeight: 600, color: 'var(--text-primary)', fontVariantNumeric: 'tabular-nums' }}>
               {match.score_home ?? 0}&nbsp;:&nbsp;{match.score_away ?? 0}
             </div>
           ) : (
-            <div style={{ fontSize: 13, color: '#374d66' }}>vs</div>
+            <div style={{ fontSize: 13, color: 'var(--text-dim)' }}>vs</div>
           )}
         </div>
 
         <div style={{ flex: 1, textAlign: 'left' }}>
           <div style={{ fontSize: 15, fontWeight: 600, color: teamStatusColor(awayStatus) }}>{awayName}</div>
-          <div style={{ fontSize: 10, color: '#9ab0d0', marginTop: 2 }}>{awayTla}</div>
+          <div style={{ fontSize: 10, color: 'var(--text-secondary)', marginTop: 2 }}>{awayTla}</div>
         </div>
       </div>
 
@@ -286,14 +286,14 @@ function MatchCard({ match, teamStatuses = {} }) {
       {p ? (
         <div style={{
           background: tipBgColor,
-          border: '1px solid #1a2840',
+          border: '1px solid var(--border)',
           borderRadius: 6,
           padding: '10px 12px',
         }}>
-          <div style={{ fontSize: 11, color: '#9ab0d0', marginBottom: 8 }}>
+          <div style={{ fontSize: 11, color: 'var(--text-secondary)', marginBottom: 8 }}>
             {isFinished ? 'Prognose war' : 'Tipp-Empfehlung'}:{' '}
-            <span style={{ fontWeight: 600, color: '#eef2ff' }}>{tipHome}:{tipAway}</span>
-            <span style={{ color: '#374d66', marginLeft: 6 }}>
+            <span style={{ fontWeight: 600, color: 'var(--text-primary)' }}>{tipHome}:{tipAway}</span>
+            <span style={{ color: 'var(--text-dim)', marginLeft: 6 }}>
               (xG {p.pred_home_goals.toFixed(1)} : {p.pred_away_goals.toFixed(1)})
             </span>
             {isFinished && match.score_home !== null && (
@@ -307,12 +307,12 @@ function MatchCard({ match, teamStatuses = {} }) {
             homeTla={homeTla} awayTla={awayTla}
           />
 
-          <div style={{ marginTop: 10, borderTop: '1px solid #1a2840', paddingTop: 10 }}>
-              <div style={{ fontSize: 12, color: '#9ab0d0', lineHeight: 1.65, marginBottom: p.home_elo ? 10 : 0, whiteSpace: 'pre-line' }}>
+          <div style={{ marginTop: 10, borderTop: '1px solid var(--border)', paddingTop: 10 }}>
+              <div style={{ fontSize: 12, color: 'var(--text-secondary)', lineHeight: 1.65, marginBottom: p.home_elo ? 10 : 0, whiteSpace: 'pre-line' }}>
                 {p.reasoning}
               </div>
               {p.home_elo && (
-                <div style={{ fontSize: 11, color: '#374d66', marginTop: 6 }}>
+                <div style={{ fontSize: 11, color: 'var(--text-dim)', marginTop: 6 }}>
                   ELO: {homeTla} {p.home_elo.toFixed(0)} · {awayTla} {p.away_elo?.toFixed(0)}
                   {match.home_team && ` · Spiele: ${match.home_team.matches_played}`}
                 </div>
@@ -320,7 +320,7 @@ function MatchCard({ match, teamStatuses = {} }) {
 
               {match.predictions?.length >= 1 && (
                 <div style={{ marginTop: 12 }}>
-                  <div style={{ fontSize: 10, color: '#374d66', letterSpacing: '0.1em', marginBottom: 6 }}>
+                  <div style={{ fontSize: 10, color: 'var(--text-dim)', letterSpacing: '0.1em', marginBottom: 6 }}>
                     VERLAUF ({match.predictions.length} {match.predictions.length === 1 ? 'VERSION' : 'VERSIONEN'})
                   </div>
                   {match.predictions.map((ph, i) => {
@@ -360,14 +360,14 @@ function MatchCard({ match, teamStatuses = {} }) {
                     return (
                       <div key={ph.id} style={{
                         padding: '6px 0',
-                        borderTop: '1px solid #1a2840',
+                        borderTop: '1px solid var(--border)',
                         fontSize: 11,
-                        color: i === 0 ? '#9ab0d0' : '#374d66',
+                        color: i === 0 ? 'var(--text-secondary)' : 'var(--text-dim)',
                       }}>
                         <span style={{ marginRight: 8 }}>{formatDateLong(ph.created_at)}</span>
                         <span style={{ fontVariantNumeric: 'tabular-nums' }}>
                           {tipH}:{tipA}
-                          {' '}<span style={{ color: '#374d66' }}>
+                          {' '}<span style={{ color: 'var(--text-dim)' }}>
                             (xG {ph.pred_home_goals.toFixed(1)}:{ph.pred_away_goals.toFixed(1)})
                           </span>
                           {' '}({(ph.home_win_prob * 100).toFixed(0)}%/
@@ -381,7 +381,7 @@ function MatchCard({ match, teamStatuses = {} }) {
                           </div>
                         )}
                         {!changeNote && i > 0 && ph.reasoning && (
-                          <div style={{ color: '#374d66', marginTop: 2, fontSize: 10, lineHeight: 1.5, whiteSpace: 'pre-line' }}>
+                          <div style={{ color: 'var(--text-dim)', marginTop: 2, fontSize: 10, lineHeight: 1.5, whiteSpace: 'pre-line' }}>
                             {ph.reasoning}
                           </div>
                         )}
@@ -393,7 +393,7 @@ function MatchCard({ match, teamStatuses = {} }) {
             </div>
         </div>
       ) : (
-        <div style={{ fontSize: 11, color: '#374d66' }}>Noch keine Prognose verfügbar.</div>
+        <div style={{ fontSize: 11, color: 'var(--text-dim)' }}>Noch keine Prognose verfügbar.</div>
       )}
     </div>
   )
@@ -419,7 +419,7 @@ function MenuButton({ icon, label, loading, danger, disabled, onClick }) {
       style={{
         display: 'flex', alignItems: 'center', gap: 10,
         width: '100%', background: 'none', border: 'none',
-        color: busy ? '#374d66' : danger ? '#8a4d4d' : '#9ab0d0',
+        color: busy ? 'var(--text-dim)' : danger ? '#8a4d4d' : 'var(--text-secondary)',
         padding: '10px 16px', fontSize: 12,
         cursor: busy ? 'not-allowed' : 'pointer',
         fontFamily: 'inherit', textAlign: 'left',
@@ -876,9 +876,9 @@ export default function Wmt() {
           <button
             onClick={() => setMenuOpen(o => !o)}
             style={{
-              background: menuOpen ? '#1a2840' : 'none',
-              border: menuOpen ? '1px solid #2a3d5c' : '1px solid transparent',
-              color: anyBusy ? '#4d6fa0' : '#9ab0d0',
+              background: menuOpen ? 'var(--border)' : 'none',
+              border: menuOpen ? '1px solid var(--border-hover)' : '1px solid transparent',
+              color: anyBusy ? '#4d6fa0' : 'var(--text-secondary)',
               fontSize: 14, cursor: 'pointer', marginRight: 10,
               fontFamily: 'inherit', borderRadius: 4,
               padding: '2px 6px', lineHeight: 1,
@@ -898,8 +898,8 @@ export default function Wmt() {
             onClick={e => e.stopPropagation()}
             style={{
               position: 'fixed', top: 32, right: 0,
-              width: 220, background: '#0d1221',
-              border: '1px solid #1a2840',
+              width: 220, background: 'var(--surface)',
+              border: '1px solid var(--border)',
               borderRight: 'none', borderTop: 'none',
               borderRadius: '0 0 0 10px',
               paddingTop: 4, paddingBottom: 8,
@@ -924,19 +924,19 @@ export default function Wmt() {
               loading={!!generatingSummaryFor} disabled={anyBusy && !generatingSummaryFor}
               onClick={() => { setMenuOpen(false); setSummaryCalOpen(true) }}
             />
-            <div style={{ borderTop: '1px solid #1a2840', margin: '6px 0' }} />
+            <div style={{ borderTop: '1px solid var(--border)', margin: '6px 0' }} />
             <MenuButton
               icon="✕" label="Daten löschen"
               danger loading={clearing} disabled={anyBusy && !clearing}
               onClick={() => { setMenuOpen(false); handleClear() }}
             />
-            <div style={{ borderTop: '1px solid #1a2840', margin: '6px 0' }} />
+            <div style={{ borderTop: '1px solid var(--border)', margin: '6px 0' }} />
             <MenuButton
               icon="⚗" label="Fake alles (MD1–Finale)"
               loading={fakingAll} disabled={(anyBusy && !fakingAll) || finalDone}
               onClick={() => { setMenuOpen(false); handleFakeAll() }}
             />
-            <div style={{ borderTop: '1px solid #1a2840', margin: '6px 0' }} />
+            <div style={{ borderTop: '1px solid var(--border)', margin: '6px 0' }} />
             <MenuButton
               icon="⚗" label="Fake MD1-Ergebnisse"
               loading={fakingMd1} disabled={(anyBusy && !fakingMd1) || md1Done}
@@ -1010,19 +1010,19 @@ export default function Wmt() {
               key={key}
               onClick={() => setView(key)}
               style={{
-                background: view === key ? '#1a2840' : 'none',
-                border: `1px solid ${view === key ? '#2a3d5c' : '#1a2840'}`,
-                color: view === key ? '#eef2ff' : '#374d66',
+                background: view === key ? 'var(--border)' : 'none',
+                border: `1px solid ${view === key ? 'var(--border-hover)' : 'var(--border)'}`,
+                color: view === key ? 'var(--text-primary)' : 'var(--text-dim)',
                 borderRadius: 6, padding: '5px 12px', fontSize: 12,
                 cursor: 'pointer', fontFamily: 'inherit',
               }}>
-              {label}{key === 'import' && logs.length > 0 && <span style={{ color: '#374d66', marginLeft: 4 }}>{logs.length}</span>}
+              {label}{key === 'import' && logs.length > 0 && <span style={{ color: 'var(--text-dim)', marginLeft: 4 }}>{logs.length}</span>}
             </button>
           ))}
         </div>
 
         {loading && view !== 'import' && (
-          <div style={{ color: '#374d66', fontSize: 12 }}>…</div>
+          <div style={{ color: 'var(--text-dim)', fontSize: 12 }}>…</div>
         )}
 
         {/* ── Import view ────────────────────────────────────────────────── */}
@@ -1032,17 +1032,17 @@ export default function Wmt() {
             style={{ overflowY: 'auto', maxHeight: 'calc(100vh - 160px)', display: 'flex', flexDirection: 'column' }}
           >
             {logs.length === 0 ? (
-              <div style={{ color: '#374d66', fontSize: 12 }}>Noch keine Einträge.</div>
+              <div style={{ color: 'var(--text-dim)', fontSize: 12 }}>Noch keine Einträge.</div>
             ) : (
               logs.map((e, i) => (
                 <div key={i} style={{
                   display: 'flex', gap: 10, padding: '2px 0',
                   fontSize: 11, fontVariantNumeric: 'tabular-nums',
                 }}>
-                  <span style={{ color: '#1a2840', flexShrink: 0 }}>
+                  <span style={{ color: 'var(--border)', flexShrink: 0 }}>
                     {new Date(e.ts).toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit', second: '2-digit' })}
                   </span>
-                  <span style={{ color: e.level === 'done' ? '#4d8a4d' : e.level === 'error' ? '#8a4d4d' : '#374d66' }}>
+                  <span style={{ color: e.level === 'done' ? '#4d8a4d' : e.level === 'error' ? '#8a4d4d' : 'var(--text-dim)' }}>
                     {e.text}
                   </span>
                 </div>
@@ -1070,9 +1070,9 @@ export default function Wmt() {
                         key={k}
                         onClick={() => setSelectedKey(k)}
                         style={{
-                          background: isSelected ? '#1a2840' : 'none',
-                          border: `1px solid ${hasLive ? '#4d8a4d' : isSelected ? '#2a3d5c' : '#1a2840'}`,
-                          color: isSelected ? '#eef2ff' : allDone ? '#374d66' : '#9ab0d0',
+                          background: isSelected ? 'var(--border)' : 'none',
+                          border: `1px solid ${hasLive ? '#4d8a4d' : isSelected ? 'var(--border-hover)' : 'var(--border)'}`,
+                          color: isSelected ? 'var(--text-primary)' : allDone ? 'var(--text-dim)' : 'var(--text-secondary)',
                           borderRadius: 6, padding: '4px 10px', fontSize: 11,
                           cursor: 'pointer', fontFamily: 'inherit',
                         }}>
@@ -1084,15 +1084,15 @@ export default function Wmt() {
 
                 {/* match cards */}
                 {currentMatches.length === 0 ? (
-                  <div style={{ color: '#374d66', fontSize: 13 }}>Keine Spiele.</div>
+                  <div style={{ color: 'var(--text-dim)', fontSize: 13 }}>Keine Spiele.</div>
                 ) : selectedKey?.startsWith('md_') ? (
                   // Group stage matchdays: sub-group by calendar day
                   groupByCalDay(currentMatches).map(([isoDay, dayMatches]) => (
                     <div key={isoDay}>
                       <div style={{
-                        fontSize: 10, color: '#374d66', letterSpacing: '0.1em',
+                        fontSize: 10, color: 'var(--text-dim)', letterSpacing: '0.1em',
                         marginBottom: 10, marginTop: 16,
-                        paddingBottom: 6, borderBottom: '1px solid #1a2840',
+                        paddingBottom: 6, borderBottom: '1px solid var(--border)',
                       }}>
                         {calDayLabel(isoDay).toUpperCase()}
                       </div>
@@ -1126,20 +1126,20 @@ export default function Wmt() {
         {!loading && view === 'zusammenfassung' && (
           <>
             {summaries.length === 0 ? (
-              <div style={{ color: '#9ab0d0', fontSize: 13 }}>
+              <div style={{ color: 'var(--text-secondary)', fontSize: 13 }}>
                 Noch keine Zusammenfassungen vorhanden. Die erste erscheint am Morgen nach dem ersten Spieltag.
               </div>
             ) : (
               summaries.map(s => (
                 <div key={s.id} style={{
-                  background: '#0d1221', border: '1px solid #1a2840',
+                  background: 'var(--surface)', border: '1px solid var(--border)',
                   borderRadius: 10, padding: '16px', marginBottom: 12,
                 }}>
-                  <div style={{ fontSize: 10, color: '#374d66', letterSpacing: '0.1em', marginBottom: 10 }}>
+                  <div style={{ fontSize: 10, color: 'var(--text-dim)', letterSpacing: '0.1em', marginBottom: 10 }}>
                     {new Date(s.date).toLocaleDateString('de-DE', { weekday: 'long', day: '2-digit', month: '2-digit', year: 'numeric' }).toUpperCase()}
                     {' · '}{s.matches_count} SPIEL{s.matches_count !== 1 ? 'E' : ''}
                   </div>
-                  <div style={{ fontSize: 12, color: '#9ab0d0', lineHeight: 1.7 }}>
+                  <div style={{ fontSize: 12, color: 'var(--text-secondary)', lineHeight: 1.7 }}>
                     {renderMarkdown(s.content)}
                   </div>
                 </div>
@@ -1164,34 +1164,34 @@ function GroupModal({ group, teams, onClose }) {
       <div
         onClick={e => e.stopPropagation()}
         style={{
-          background: '#0d1221', border: '1px solid #2a3d5c',
+          background: 'var(--surface)', border: '1px solid var(--border-hover)',
           borderRadius: 12, padding: '20px 24px', width: 320,
         }}>
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 14 }}>
-          <span style={{ fontSize: 11, color: '#374d66', letterSpacing: '0.1em' }}>GRUPPE {group}</span>
+          <span style={{ fontSize: 11, color: 'var(--text-dim)', letterSpacing: '0.1em' }}>GRUPPE {group}</span>
           <button
             onClick={onClose}
-            style={{ background: 'none', border: 'none', color: '#9ab0d0', cursor: 'pointer', fontSize: 16, lineHeight: 1, padding: 0 }}>
+            style={{ background: 'none', border: 'none', color: 'var(--text-secondary)', cursor: 'pointer', fontSize: 16, lineHeight: 1, padding: 0 }}>
             ✕
           </button>
         </div>
         {teams.map((t, i) => (
           <div key={i} style={{
             display: 'flex', alignItems: 'center', gap: 10,
-            padding: '9px 0', borderTop: i > 0 ? '1px solid #1a2840' : 'none',
+            padding: '9px 0', borderTop: i > 0 ? '1px solid var(--border)' : 'none',
           }}>
-            <span style={{ fontSize: 11, color: '#9ab0d0', width: 16, flexShrink: 0 }}>{i + 1}.</span>
+            <span style={{ fontSize: 11, color: 'var(--text-secondary)', width: 16, flexShrink: 0 }}>{i + 1}.</span>
             <div style={{ flex: 1 }}>
-              <span style={{ fontSize: 13, fontWeight: i === 0 ? 600 : 400, color: i === 0 ? '#eef2ff' : '#9ab0d0', marginRight: 7 }}>
+              <span style={{ fontSize: 13, fontWeight: i === 0 ? 600 : 400, color: i === 0 ? 'var(--text-primary)' : 'var(--text-secondary)', marginRight: 7 }}>
                 {t.tla}
               </span>
-              <span style={{ fontSize: 11, color: '#9ab0d0' }}>{t.team}</span>
+              <span style={{ fontSize: 11, color: 'var(--text-secondary)' }}>{t.team}</span>
             </div>
             <div style={{ textAlign: 'right', flexShrink: 0 }}>
               <div style={{ fontSize: 12, color: '#4d6fa0', fontVariantNumeric: 'tabular-nums' }}>
                 {(t.prob_1st * 100).toFixed(0)}% 1.
               </div>
-              <div style={{ fontSize: 10, color: '#9ab0d0', marginTop: 2, fontVariantNumeric: 'tabular-nums' }}>
+              <div style={{ fontSize: 10, color: 'var(--text-secondary)', marginTop: 2, fontVariantNumeric: 'tabular-nums' }}>
                 {(t.prob_top2 * 100).toFixed(0)}% Top 2 · {(t.prob_top3 * 100).toFixed(0)}% Top 3
               </div>
             </div>
@@ -1206,18 +1206,18 @@ function BonusView({ bonus, generating, actualResults }) {
   const [modalGroup, setModalGroup] = useState(null)
 
   const cardStyle = {
-    background: '#0d1221', border: '1px solid #1a2840',
+    background: 'var(--surface)', border: '1px solid var(--border)',
     borderRadius: 10, padding: '16px', marginBottom: 12,
   }
-  const labelStyle = { fontSize: 10, color: '#374d66', letterSpacing: '0.1em', marginBottom: 8 }
+  const labelStyle = { fontSize: 10, color: 'var(--text-dim)', letterSpacing: '0.1em', marginBottom: 8 }
   const teamChip = (item, rank) => (
     <div key={rank} style={{
       display: 'flex', justifyContent: 'space-between', alignItems: 'center',
-      padding: '7px 0', borderTop: rank > 0 ? '1px solid #1a2840' : 'none',
+      padding: '7px 0', borderTop: rank > 0 ? '1px solid var(--border)' : 'none',
     }}>
       <div>
-        <span style={{ fontSize: 13, fontWeight: 600, color: '#eef2ff', marginRight: 8 }}>{item.tla}</span>
-        <span style={{ fontSize: 12, color: '#9ab0d0' }}>{item.team}</span>
+        <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--text-primary)', marginRight: 8 }}>{item.tla}</span>
+        <span style={{ fontSize: 12, color: 'var(--text-secondary)' }}>{item.team}</span>
       </div>
       <span style={{ fontSize: 12, color: '#4d6fa0', fontVariantNumeric: 'tabular-nums' }}>
         {(item.prob * 100).toFixed(0)}%
@@ -1227,7 +1227,7 @@ function BonusView({ bonus, generating, actualResults }) {
 
   if (generating) {
     return (
-      <div style={{ color: '#9ab0d0', fontSize: 12 }}>
+      <div style={{ color: 'var(--text-secondary)', fontSize: 12 }}>
         … Monte-Carlo-Simulation läuft
       </div>
     )
@@ -1236,10 +1236,10 @@ function BonusView({ bonus, generating, actualResults }) {
   if (!bonus) {
     return (
       <div style={{ ...cardStyle, textAlign: 'center' }}>
-        <div style={{ fontSize: 13, color: '#9ab0d0', marginBottom: 8 }}>
+        <div style={{ fontSize: 13, color: 'var(--text-secondary)', marginBottom: 8 }}>
           Noch keine Bonus-Prognose vorhanden.
         </div>
-        <div style={{ fontSize: 12, color: '#374d66', lineHeight: 1.6 }}>
+        <div style={{ fontSize: 12, color: 'var(--text-dim)', lineHeight: 1.6 }}>
           Über das Menü (☰) Prognose berechnen.
         </div>
       </div>
@@ -1265,8 +1265,8 @@ function BonusView({ bonus, generating, actualResults }) {
 
       {/* Prognose vs. Realität – appears once the Final is finished */}
       {actualResults && (
-        <div style={{ ...cardStyle, borderColor: '#2a3d5c', marginBottom: 20 }}>
-          <div style={{ fontSize: 10, color: '#374d66', letterSpacing: '0.1em', marginBottom: 16 }}>
+        <div style={{ ...cardStyle, borderColor: 'var(--border-hover)', marginBottom: 20 }}>
+          <div style={{ fontSize: 10, color: 'var(--text-dim)', letterSpacing: '0.1em', marginBottom: 16 }}>
             PROGNOSE vs. REALITÄT
           </div>
 
@@ -1274,10 +1274,10 @@ function BonusView({ bonus, generating, actualResults }) {
           {bonus.winner && actualResults.winner && (() => {
             const hit = bonus.winner.tla === actualResults.winner.tla
             return (
-              <div style={{ marginBottom: 14, paddingBottom: 14, borderBottom: '1px solid #1a2840' }}>
-                <div style={{ fontSize: 10, color: '#374d66', letterSpacing: '0.08em', marginBottom: 8 }}>TURNIERSIEGER</div>
+              <div style={{ marginBottom: 14, paddingBottom: 14, borderBottom: '1px solid var(--border)' }}>
+                <div style={{ fontSize: 10, color: 'var(--text-dim)', letterSpacing: '0.08em', marginBottom: 8 }}>TURNIERSIEGER</div>
                 <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-                  <span style={{ fontSize: 14, fontWeight: 600, color: '#eef2ff' }}>{bonus.winner.tla}</span>
+                  <span style={{ fontSize: 14, fontWeight: 600, color: 'var(--text-primary)' }}>{bonus.winner.tla}</span>
                   <span style={{ fontSize: 11, color: '#4d6fa0' }}>{(bonus.winner.prob * 100).toFixed(0)}%</span>
                   <span style={{ fontSize: 13, color: hit ? '#4d8a4d' : '#8a4d4d' }}>
                     {hit ? '✓' : `✗ → ${actualResults.winner.tla}`}
@@ -1292,8 +1292,8 @@ function BonusView({ bonus, generating, actualResults }) {
             const actualTlas = new Set(actualResults.finalists.map(t => t?.tla))
             const hits = bonus.finalists.filter(f => actualTlas.has(f.tla)).length
             return (
-              <div style={{ marginBottom: 14, paddingBottom: 14, borderBottom: '1px solid #1a2840' }}>
-                <div style={{ fontSize: 10, color: '#374d66', letterSpacing: '0.08em', marginBottom: 8 }}>
+              <div style={{ marginBottom: 14, paddingBottom: 14, borderBottom: '1px solid var(--border)' }}>
+                <div style={{ fontSize: 10, color: 'var(--text-dim)', letterSpacing: '0.08em', marginBottom: 8 }}>
                   FINALISTEN — {hits} von {bonus.finalists.length}
                 </div>
                 <div style={{ display: 'flex', gap: 16, flexWrap: 'wrap' }}>
@@ -1315,8 +1315,8 @@ function BonusView({ bonus, generating, actualResults }) {
             const actualTlas = new Set(actualResults.semifinalists.map(t => t?.tla))
             const hits = bonus.semifinalists.filter(f => actualTlas.has(f.tla)).length
             return (
-              <div style={{ marginBottom: 14, paddingBottom: 14, borderBottom: '1px solid #1a2840' }}>
-                <div style={{ fontSize: 10, color: '#374d66', letterSpacing: '0.08em', marginBottom: 8 }}>
+              <div style={{ marginBottom: 14, paddingBottom: 14, borderBottom: '1px solid var(--border)' }}>
+                <div style={{ fontSize: 10, color: 'var(--text-dim)', letterSpacing: '0.08em', marginBottom: 8 }}>
                   HALBFINALISTEN — {hits} von {bonus.semifinalists.length}
                 </div>
                 <div style={{ display: 'flex', gap: 16, flexWrap: 'wrap' }}>
@@ -1343,7 +1343,7 @@ function BonusView({ bonus, generating, actualResults }) {
             }).length
             return (
               <div>
-                <div style={{ fontSize: 10, color: '#374d66', letterSpacing: '0.08em', marginBottom: 8 }}>
+                <div style={{ fontSize: 10, color: 'var(--text-dim)', letterSpacing: '0.08em', marginBottom: 8 }}>
                   GRUPPENSIEGER — {hits} von {compGroups.length}
                 </div>
                 <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 6 }}>
@@ -1353,16 +1353,16 @@ function BonusView({ bonus, generating, actualResults }) {
                     const hit = predicted && actual && predicted.tla === actual.tla
                     return (
                       <div key={g} style={{
-                        background: '#07091a',
+                        background: 'var(--bg)',
                         border: `1px solid ${hit ? '#1a3d1a' : '#3d1a1a'}`,
                         borderRadius: 6, padding: '6px 8px',
                       }}>
-                        <div style={{ fontSize: 9, color: '#374d66', marginBottom: 4 }}>GR. {g}</div>
+                        <div style={{ fontSize: 9, color: 'var(--text-dim)', marginBottom: 4 }}>GR. {g}</div>
                         <div style={{ fontSize: 11, fontWeight: 600, color: hit ? '#4d8a4d' : '#8a4d4d' }}>
                           {predicted?.tla ?? '?'} {hit ? '✓' : '✗'}
                         </div>
                         {!hit && actual && (
-                          <div style={{ fontSize: 10, color: '#9ab0d0', marginTop: 2 }}>→ {actual.tla}</div>
+                          <div style={{ fontSize: 10, color: 'var(--text-secondary)', marginTop: 2 }}>→ {actual.tla}</div>
                         )}
                       </div>
                     )
@@ -1376,14 +1376,14 @@ function BonusView({ bonus, generating, actualResults }) {
 
       {/* Turniersieger */}
       {bonus.winner && (
-        <div style={{ ...cardStyle, borderColor: '#2a3d5c' }}>
+        <div style={{ ...cardStyle, borderColor: 'var(--border-hover)' }}>
           <div style={labelStyle}>TURNIERSIEGER</div>
           <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
             <div>
-              <span style={{ fontSize: 18, fontWeight: 700, color: '#eef2ff', marginRight: 10 }}>
+              <span style={{ fontSize: 18, fontWeight: 700, color: 'var(--text-primary)', marginRight: 10 }}>
                 {bonus.winner.tla}
               </span>
-              <span style={{ fontSize: 14, color: '#9ab0d0' }}>{bonus.winner.team}</span>
+              <span style={{ fontSize: 14, color: 'var(--text-secondary)' }}>{bonus.winner.team}</span>
             </div>
             <span style={{ fontSize: 16, fontWeight: 600, color: '#4d6fa0' }}>
               {(bonus.winner.prob * 100).toFixed(0)}%
@@ -1414,10 +1414,10 @@ function BonusView({ bonus, generating, actualResults }) {
           <div style={labelStyle}>TORSCHÜTZENKÖNIG</div>
           <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
             <div>
-              <div style={{ fontSize: 14, fontWeight: 600, color: '#eef2ff', marginBottom: 3 }}>
+              <div style={{ fontSize: 14, fontWeight: 600, color: 'var(--text-primary)', marginBottom: 3 }}>
                 {bonus.top_scorer.player}
               </div>
-              <div style={{ fontSize: 12, color: '#9ab0d0' }}>
+              <div style={{ fontSize: 12, color: 'var(--text-secondary)' }}>
                 {bonus.top_scorer.tla} · {bonus.top_scorer.team}
               </div>
             </div>
@@ -1425,7 +1425,7 @@ function BonusView({ bonus, generating, actualResults }) {
               <div style={{ fontSize: 14, fontWeight: 600, color: '#4d6fa0' }}>
                 ~{bonus.top_scorer.goals} Tore
               </div>
-              <div style={{ fontSize: 10, color: '#374d66', marginTop: 3 }}>
+              <div style={{ fontSize: 10, color: 'var(--text-dim)', marginTop: 3 }}>
                 {bonus.top_scorer.source}
               </div>
             </div>
@@ -1445,13 +1445,13 @@ function BonusView({ bonus, generating, actualResults }) {
                   key={group}
                   onClick={() => setModalGroup(group)}
                   style={{
-                    background: '#07091a', border: '1px solid #1a2840', borderRadius: 6,
+                    background: 'var(--bg)', border: '1px solid var(--border)', borderRadius: 6,
                     padding: '8px 10px', cursor: 'pointer',
                     transition: 'border-color 0.15s',
                   }}
-                  onMouseEnter={e => e.currentTarget.style.borderColor = '#2a3d5c'}
-                  onMouseLeave={e => e.currentTarget.style.borderColor = '#1a2840'}>
-                  <div style={{ fontSize: 9, color: '#374d66', letterSpacing: '0.1em', marginBottom: 6 }}>
+                  onMouseEnter={e => e.currentTarget.style.borderColor = 'var(--border-hover)'}
+                  onMouseLeave={e => e.currentTarget.style.borderColor = 'var(--border)'}>
+                  <div style={{ fontSize: 9, color: 'var(--text-dim)', letterSpacing: '0.1em', marginBottom: 6 }}>
                     GRUPPE {group}
                   </div>
                   {teams.slice(0, 4).map((t, i) => (
@@ -1462,13 +1462,13 @@ function BonusView({ bonus, generating, actualResults }) {
                       <span style={{
                         fontSize: i === 0 ? 12 : 11,
                         fontWeight: i === 0 ? 600 : 400,
-                        color: i === 0 ? '#eef2ff' : '#9ab0d0',
+                        color: i === 0 ? 'var(--text-primary)' : 'var(--text-secondary)',
                       }}>
                         {i + 1}. {t.tla}
                       </span>
                       <span style={{
                         fontSize: i === 0 ? 11 : 10,
-                        color: i === 0 ? '#4d6fa0' : '#9ab0d0',
+                        color: i === 0 ? '#4d6fa0' : 'var(--text-secondary)',
                         fontVariantNumeric: 'tabular-nums',
                       }}>
                         {(t.prob_1st * 100).toFixed(0)}%
@@ -1482,33 +1482,33 @@ function BonusView({ bonus, generating, actualResults }) {
         </div>
       )}
 
-      <div style={{ fontSize: 10, color: '#374d66', textAlign: 'right', marginTop: 4, marginBottom: 24 }}>
+      <div style={{ fontSize: 10, color: 'var(--text-dim)', textAlign: 'right', marginTop: 4, marginBottom: 24 }}>
         {bonus.n_simulations.toLocaleString('de-DE')} Simulationen · {generatedDate}
       </div>
 
       {/* Simulation explanation */}
-      <div style={{ borderTop: '1px solid #1a2840', paddingTop: 20 }}>
-        <div style={{ fontSize: 10, color: '#374d66', letterSpacing: '0.1em', marginBottom: 14 }}>
+      <div style={{ borderTop: '1px solid var(--border)', paddingTop: 20 }}>
+        <div style={{ fontSize: 10, color: 'var(--text-dim)', letterSpacing: '0.1em', marginBottom: 14 }}>
           WIE FUNKTIONIERT DIE SIMULATION?
         </div>
 
-        <div style={{ fontSize: 12, color: '#9ab0d0', lineHeight: 1.8 }}>
+        <div style={{ fontSize: 12, color: 'var(--text-secondary)', lineHeight: 1.8 }}>
           <p style={{ marginBottom: 12 }}>
             Die Prognose basiert auf einer{' '}
-            <span style={{ color: '#eef2ff' }}>Monte-Carlo-Simulation</span>{' '}
+            <span style={{ color: 'var(--text-primary)' }}>Monte-Carlo-Simulation</span>{' '}
             mit {bonus.n_simulations.toLocaleString('de-DE')} Turnierdurchläufen.
             Jeder Durchlauf simuliert das gesamte WM-Turnier von der Gruppenphase bis zum Finale.
             Die angezeigten Prozentwerte geben an, wie häufig ein Ergebnis in diesen Durchläufen eingetreten ist.
           </p>
 
           <div style={{ marginBottom: 10 }}>
-            <span style={{ color: '#eef2ff' }}>ELO-Rating</span>
+            <span style={{ color: 'var(--text-primary)' }}>ELO-Rating</span>
             {' '}— Jedes Team erhält ein ELO-Rating, das auf Ergebnissen der letzten WM und anderen internationalen Spielen basiert.
             Stärkere Teams haben höhere Ratings; ein Unterschied von 400 Punkten entspricht grob einer Gewinnwahrscheinlichkeit von ca. 85:15.
           </div>
 
           <div style={{ marginBottom: 10 }}>
-            <span style={{ color: '#eef2ff' }}>Gruppenphase</span>
+            <span style={{ color: 'var(--text-primary)' }}>Gruppenphase</span>
             {' '}— In jedem Durchlauf wird jedes Gruppenspiel einzeln simuliert.
             Aus den ELO-Ratings wird eine erwartete Toranzahl (xG) pro Team abgeleitet;
             die tatsächlichen Tore werden per Poisson-Verteilung zufällig gezogen.
@@ -1516,20 +1516,20 @@ function BonusView({ bonus, generating, actualResults }) {
           </div>
 
           <div style={{ marginBottom: 10 }}>
-            <span style={{ color: '#eef2ff' }}>K.O.-Runde</span>
+            <span style={{ color: 'var(--text-primary)' }}>K.O.-Runde</span>
             {' '}— Die besten zwei jeder Gruppe sowie die acht besten Gruppendritter (nach Punkten, Tordifferenz, Toren) qualifizieren sich für die Runde der 32.
             Der K.O.-Baum wird in jedem Durchlauf zufällig neu gelost, damit keine bestimmte Hälfte bevorzugt wird.
             Bei Unentschieden nach 90 Minuten entscheidet ein ELO-gewichteter Münzwurf (analog Elfmeterschießen).
           </div>
 
           <div style={{ marginBottom: 10 }}>
-            <span style={{ color: '#eef2ff' }}>Torschützenkönig</span>
+            <span style={{ color: 'var(--text-primary)' }}>Torschützenkönig</span>
             {' '}— Die Prognose basiert auf einer kuratierten Liste bekannter Torjäger mit historischer Torrate.
             Aus der Torrate pro Spiel und der erwarteten Turnierlänge (abhängig vom ELO-Rating des Teams) wird eine prognostizierte Gesamttoranzahl berechnet.
           </div>
 
           <div>
-            <span style={{ color: '#eef2ff' }}>Hinweis</span>
+            <span style={{ color: 'var(--text-primary)' }}>Hinweis</span>
             {' '}— Die Simulation spiegelt den Wissensstand zum Zeitpunkt der letzten Datenaktualisierung wider.
             Nach jedem Spieltag ELO-Ratings neu berechnen (↻) und anschließend die Bonus-Prognose neu generieren, um aktuelle Ergebnisse einzubeziehen.
           </div>
@@ -1572,12 +1572,12 @@ function SummaryCalModal({ matches, summaries, generating, onClose, onGenerate }
 
     return (
       <div key={`${year}-${month}`}>
-        <div style={{ fontSize: 11, color: '#9ab0d0', textAlign: 'center', marginBottom: 8, fontWeight: 600 }}>
+        <div style={{ fontSize: 11, color: 'var(--text-secondary)', textAlign: 'center', marginBottom: 8, fontWeight: 600 }}>
           {MONTH_NAMES[month]} {year}
         </div>
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', gap: 3, marginBottom: 4 }}>
           {DAY_NAMES.map(d => (
-            <div key={d} style={{ fontSize: 9, color: '#374d66', textAlign: 'center' }}>{d}</div>
+            <div key={d} style={{ fontSize: 9, color: 'var(--text-dim)', textAlign: 'center' }}>{d}</div>
           ))}
         </div>
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', gap: 3 }}>
@@ -1594,11 +1594,11 @@ function SummaryCalModal({ matches, summaries, generating, onClose, onGenerate }
                 disabled={!hasMatch || !!generating}
                 style={{
                   position: 'relative',
-                  background: hasMatch ? '#1a2840' : 'none',
-                  border: `1px solid ${hasMatch ? '#2a3d5c' : 'transparent'}`,
+                  background: hasMatch ? 'var(--border)' : 'none',
+                  border: `1px solid ${hasMatch ? 'var(--border-hover)' : 'transparent'}`,
                   borderRadius: 4, padding: '6px 2px 8px',
                   fontSize: 11, textAlign: 'center',
-                  color: hasMatch ? '#eef2ff' : '#1a2840',
+                  color: hasMatch ? 'var(--text-primary)' : 'var(--border)',
                   cursor: hasMatch && !generating ? 'pointer' : 'default',
                   fontFamily: 'inherit',
                   opacity: !!generating && !busy ? 0.5 : 1,
@@ -1625,15 +1625,15 @@ function SummaryCalModal({ matches, summaries, generating, onClose, onGenerate }
       <div
         onClick={e => e.stopPropagation()}
         style={{
-          background: '#0d1221', border: '1px solid #2a3d5c',
+          background: 'var(--surface)', border: '1px solid var(--border-hover)',
           borderRadius: 12, padding: '20px 24px',
           width: 320, maxHeight: '80vh', overflowY: 'auto',
         }}>
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
-          <span style={{ fontSize: 11, color: '#374d66', letterSpacing: '0.1em' }}>MORGENBERICHT ERSTELLEN</span>
-          <button onClick={onClose} style={{ background: 'none', border: 'none', color: '#9ab0d0', cursor: 'pointer', fontSize: 16, lineHeight: 1, padding: 0 }}>✕</button>
+          <span style={{ fontSize: 11, color: 'var(--text-dim)', letterSpacing: '0.1em' }}>MORGENBERICHT ERSTELLEN</span>
+          <button onClick={onClose} style={{ background: 'none', border: 'none', color: 'var(--text-secondary)', cursor: 'pointer', fontSize: 16, lineHeight: 1, padding: 0 }}>✕</button>
         </div>
-        <div style={{ fontSize: 11, color: '#374d66', marginBottom: 16, lineHeight: 1.5 }}>
+        <div style={{ fontSize: 11, color: 'var(--text-dim)', marginBottom: 16, lineHeight: 1.5 }}>
           Spieltag auswählen · blauer Punkt = Bericht vorhanden
         </div>
         <div style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
@@ -1691,8 +1691,8 @@ function GruppenTabellen({ matches }) {
 
   if (sortedGroups.length === 0) {
     return (
-      <div style={{ background: '#0d1221', border: '1px solid #1a2840', borderRadius: 10, padding: 24, textAlign: 'center' }}>
-        <div style={{ fontSize: 13, color: '#9ab0d0' }}>Noch keine Gruppenspiele vorhanden.</div>
+      <div style={{ background: 'var(--surface)', border: '1px solid var(--border)', borderRadius: 10, padding: 24, textAlign: 'center' }}>
+        <div style={{ fontSize: 13, color: 'var(--text-secondary)' }}>Noch keine Gruppenspiele vorhanden.</div>
       </div>
     )
   }
@@ -1715,7 +1715,7 @@ function GruppenTabellen({ matches }) {
     })
   }
 
-  const th = { fontSize: 10, color: '#374d66', fontWeight: 400, letterSpacing: '0.06em', textAlign: 'right', paddingBottom: 6 }
+  const th = { fontSize: 10, color: 'var(--text-dim)', fontWeight: 400, letterSpacing: '0.06em', textAlign: 'right', paddingBottom: 6 }
 
   return (
     <div>
@@ -1724,18 +1724,18 @@ function GruppenTabellen({ matches }) {
           onClick={e => e.stopPropagation()}
           style={{
             position: 'fixed', left: tooltip.x, top: tooltip.y, zIndex: 300,
-            background: '#0d1221', border: '1px solid #2a3d5c',
+            background: 'var(--surface)', border: '1px solid var(--border-hover)',
             borderRadius: 6, padding: '8px 12px',
-            fontSize: 11, color: '#9ab0d0', lineHeight: 1.7,
+            fontSize: 11, color: 'var(--text-secondary)', lineHeight: 1.7,
             minWidth: 160, maxWidth: 220,
             boxShadow: '0 4px 16px rgba(0,0,0,0.5)',
           }}>
-          <div style={{ color: '#eef2ff', fontWeight: 600, marginBottom: 5 }}>{tooltip.name}</div>
+          <div style={{ color: 'var(--text-primary)', fontWeight: 600, marginBottom: 5 }}>{tooltip.name}</div>
           {tooltip.results.length > 0
             ? tooltip.results.map((r, i) => (
                 <div key={i} style={{ fontVariantNumeric: 'tabular-nums' }}>{r}</div>
               ))
-            : <div style={{ color: '#374d66' }}>Noch keine Spiele</div>
+            : <div style={{ color: 'var(--text-dim)' }}>Noch keine Spiele</div>
           }
         </div>
       )}
@@ -1747,10 +1747,10 @@ function GruppenTabellen({ matches }) {
             .sort((a, b) => b.pts - a.pts || b.gd - a.gd || b.gf - a.gf || (b.team.elo ?? 0) - (a.team.elo ?? 0))
 
           return (
-            <div key={group} style={{ background: '#0d1221', border: '1px solid #1a2840', borderRadius: 10, padding: '12px 14px' }}>
-              <div style={{ fontSize: 10, color: '#374d66', letterSpacing: '0.1em', marginBottom: 8 }}>GRUPPE {group}</div>
+            <div key={group} style={{ background: 'var(--surface)', border: '1px solid var(--border)', borderRadius: 10, padding: '12px 14px' }}>
+              <div style={{ fontSize: 10, color: 'var(--text-dim)', letterSpacing: '0.1em', marginBottom: 8 }}>GRUPPE {group}</div>
 
-              <div style={{ display: 'flex', gap: 4, paddingBottom: 5, borderBottom: '1px solid #1a2840' }}>
+              <div style={{ display: 'flex', gap: 4, paddingBottom: 5, borderBottom: '1px solid var(--border)' }}>
                 <div style={{ width: 14, ...th }}>#</div>
                 <div style={{ flex: 1, textAlign: 'left', ...th }}>TEAM</div>
                 <div style={{ width: 20, ...th }}>Sp</div>
@@ -1759,31 +1759,31 @@ function GruppenTabellen({ matches }) {
                 <div style={{ width: 16, ...th }}>N</div>
                 <div style={{ width: 38, ...th }}>Tore</div>
                 <div style={{ width: 26, ...th }}>TD</div>
-                <div style={{ width: 22, ...th, color: '#9ab0d0' }}>Pkt</div>
+                <div style={{ width: 22, ...th, color: 'var(--text-secondary)' }}>Pkt</div>
               </div>
 
               {rows.map((r, i) => (
                 <div key={r.team.id} style={{
                   display: 'flex', gap: 4, alignItems: 'center',
-                  padding: '5px 0', borderTop: i > 0 ? '1px solid #1a2840' : 'none',
+                  padding: '5px 0', borderTop: i > 0 ? '1px solid var(--border)' : 'none',
                 }}>
-                  <div style={{ width: 14, fontSize: 10, color: '#374d66', textAlign: 'right', flexShrink: 0 }}>{i + 1}</div>
+                  <div style={{ width: 14, fontSize: 10, color: 'var(--text-dim)', textAlign: 'right', flexShrink: 0 }}>{i + 1}</div>
                   <div style={{ flex: 1, overflow: 'hidden' }}>
                     <span
                       onClick={e => handleTlaClick(e, r.team)}
-                      style={{ fontSize: 12, fontWeight: 600, color: '#eef2ff', cursor: 'pointer', userSelect: 'none' }}>
+                      style={{ fontSize: 12, fontWeight: 600, color: 'var(--text-primary)', cursor: 'pointer', userSelect: 'none' }}>
                       {r.team.tla ?? r.team.short_name}
                     </span>
                   </div>
-                  <div style={{ width: 20, fontSize: 11, color: '#9ab0d0', textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>{r.gp}</div>
-                  <div style={{ width: 16, fontSize: 11, color: '#9ab0d0', textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>{r.w}</div>
-                  <div style={{ width: 16, fontSize: 11, color: '#9ab0d0', textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>{r.d}</div>
-                  <div style={{ width: 16, fontSize: 11, color: '#9ab0d0', textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>{r.l}</div>
-                  <div style={{ width: 38, fontSize: 11, color: '#9ab0d0', textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>{r.gf}:{r.ga}</div>
-                  <div style={{ width: 26, fontSize: 11, textAlign: 'right', fontVariantNumeric: 'tabular-nums', color: r.gd > 0 ? '#4d8a4d' : r.gd < 0 ? '#8a4d4d' : '#9ab0d0' }}>
+                  <div style={{ width: 20, fontSize: 11, color: 'var(--text-secondary)', textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>{r.gp}</div>
+                  <div style={{ width: 16, fontSize: 11, color: 'var(--text-secondary)', textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>{r.w}</div>
+                  <div style={{ width: 16, fontSize: 11, color: 'var(--text-secondary)', textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>{r.d}</div>
+                  <div style={{ width: 16, fontSize: 11, color: 'var(--text-secondary)', textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>{r.l}</div>
+                  <div style={{ width: 38, fontSize: 11, color: 'var(--text-secondary)', textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>{r.gf}:{r.ga}</div>
+                  <div style={{ width: 26, fontSize: 11, textAlign: 'right', fontVariantNumeric: 'tabular-nums', color: r.gd > 0 ? '#4d8a4d' : r.gd < 0 ? '#8a4d4d' : 'var(--text-secondary)' }}>
                     {r.gd > 0 ? '+' : ''}{r.gd}
                   </div>
-                  <div style={{ width: 22, fontSize: 13, fontWeight: 600, color: '#eef2ff', textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>{r.pts}</div>
+                  <div style={{ width: 22, fontSize: 13, fontWeight: 600, color: 'var(--text-primary)', textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>{r.pts}</div>
                 </div>
               ))}
             </div>
@@ -1797,13 +1797,13 @@ function GruppenTabellen({ matches }) {
 function NoDataPlaceholder() {
   return (
     <div style={{
-      background: '#0d1221', border: '1px solid #1a2840', borderRadius: 10,
+      background: 'var(--surface)', border: '1px solid var(--border)', borderRadius: 10,
       padding: '24px', textAlign: 'center',
     }}>
-      <div style={{ fontSize: 13, color: '#9ab0d0', marginBottom: 12 }}>
+      <div style={{ fontSize: 13, color: 'var(--text-secondary)', marginBottom: 12 }}>
         Noch keine Spieldaten vorhanden.
       </div>
-      <div style={{ fontSize: 12, color: '#9ab0d0', lineHeight: 1.6 }}>
+      <div style={{ fontSize: 12, color: 'var(--text-secondary)', lineHeight: 1.6 }}>
         Über das Menü (☰) Spielplandaten laden.
       </div>
     </div>


### PR DESCRIPTION
- ThemeContext: persists preference in localStorage, applies data-theme
  attribute to <html> on first render (no flash)
- ThemeToggle: fixed lightbulb icon at top-right (z-index 200, always
  in the same position across every page), opens a small flyout to
  select dark or light mode
- index.css: converted all 30+ hardcoded hex colours to CSS variables;
  added :root (dark default) and :root[data-theme="light"] blocks
- All 7 tool + navigation pages: inline-style structural colours
  replaced with CSS variables; data-viz/accent colours (project colours,
  status greens/reds, Spotify green) intentionally kept hardcoded
- BlockHero excluded as requested; legacy static games excluded by design
- topbar-right gets padding-right: 22px to avoid overlap with toggle

https://claude.ai/code/session_01PXtwUQJ4su3v2Jhy8aZCJR