### PR TITLE
feat(wmt): add opponent tip tracking infrastructure (Konkurrenz)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,7 +197,7 @@ Each tool page owns its own version string, displayed in the topbar's right side
 | str  | v4.0 |
 | bpm  | v4.0 |
 | spt  | v4.9 |
-| wmt  | v2.9 |
+| wmt  | v3.0 |
 | block-hero | v1.0 |
 
 There is no global version footer. `vite.config.js` still injects `__GIT_HASH__` and `__GIT_HASH_FULL__` (Railway fallback: `RAILWAY_GIT_COMMIT_SHA`) but these are not currently displayed.
@@ -242,6 +242,7 @@ Match data is fetched via one of two sources, tried in order:
 | `WmtPrediction` | `wmt_predictions` | ELO-based prediction snapshot per match (history kept) |
 | `WmtSummary` | `wmt_summaries` | Daily morning report (markdown) |
 | `WmtBonusPrediction` | `wmt_bonus_predictions` | Monte-Carlo tournament simulation result |
+| `WmtOpponentTip` | `wmt_opponent_tips` | Imported tip of a fellow Tipprunde player for a given match |
 
 ### ELO prediction engine
 
@@ -277,15 +278,24 @@ Monte-Carlo simulation (10 000 runs) of the full tournament. Outputs: tournament
 
 Generates a markdown report for all matches played on a given date: results, prediction accuracy (tendency), upsets. Stored in `WmtSummary`. Auto-generated daily at 08:00 by the APScheduler. Can also be manually triggered per-date via the calendar picker in the burger menu.
 
-### Frontend views (`Wmt.jsx` — v2.9)
+### Gossip in morning reports
 
-The page has five tabs:
+`do_generate_summary` optionally appends a "## Gossip" section: real news snippets about the day's teams are fetched from NewsAPI (`NEWS_API_KEY`, `/v2/everything`, query built from team short names, date range = target..target+2 days), then turned into 3-5 short, lighthearted German tabloid-style headlines by the Claude API (`ANTHROPIC_API_KEY`, model `claude-haiku-4-5-20251001`). The prompt explicitly requires a respectful, non-stereotyping tone — humor comes from sporting drama, not mockery of nations/cultures. Both calls fail silently (logged as warnings) if a key is missing or the request errors, so the rest of the report always renders.
+
+### Opponent tip tracking (`WmtOpponentTip`)
+
+Kicktipp.de has no public API for reading fellow players' tips, so they're imported manually: once tip deadlines pass and Kicktipp reveals the "Tippübersicht" table, the user screenshots it and Claude (vision) parses player names + predicted scores, then calls `POST /api/wmt/opponents/import` with `{tips: [{player_name, home_tla, away_tla, pred_home_goals, pred_away_goals}, ...]}`. The endpoint resolves each tip to a `WmtMatch` via the team TLAs (most recent match between that pairing) and upserts a `WmtOpponentTip` row per `(match_id, player_name)`. Unresolvable tips (unknown TLA / no matching match) are skipped and counted separately in the response. This is purely additive groundwork — it does not touch the ELO prediction engine — laid in place ahead of the tournament so the daily screenshot→import workflow is ready to go from day one.
+
+### Frontend views (`Wmt.jsx` — v3.0)
+
+The page has six tabs:
 
 | Tab | Content |
 |-----|---------|
 | **Import** | Log output for all async operations (refresh, fake, warmup, etc.) |
 | **Spieltage** | Match cards grouped by matchday/stage; sub-grouped by calendar day for group stage. Shows ELO-based tipp-Empfehlung, win/draw/loss prob bar, VERLAUF (prediction history with change notes) |
 | **Gruppen-Tabellen** | Live group standings for all 12 groups (A–L) in a 2-column grid. Columns: Sp / W / U / N / Tore / TD (coloured) / Pkt. Derived from match data, updates on every refresh/fake |
+| **Konkurrenz** | Imported opponent tips (`WmtOpponentTip`) grouped by match: ELO-Tipp + win/draw/loss probabilities, tip-distribution tally (Heimsieg/Unentschieden/Auswärtssieg), and a per-player score table. Empty-state hint until tips are imported |
 | **Bonus-Tipps** | Monte-Carlo simulation results. Shows PROGNOSE vs. REALITÄT comparison at top once the Final is finished |
 | **Morgenberichte** | Daily match summaries in reverse-chronological order |
 
@@ -327,6 +337,8 @@ All under `POST /api/wmt/debug/…`:
 GET  /api/wmt/status            → match_count, prediction_count, calibrated, md*_done, rd32_done
 GET  /api/wmt/matches           → all matches with nested team + latest prediction + prediction history
 GET  /api/wmt/teams             → all teams with ELO
+GET  /api/wmt/opponents         → imported opponent tips (optional ?match_id= filter)
+POST /api/wmt/opponents/import  → import/update opponent tips (resolved via team TLAs)
 GET  /api/wmt/summaries         → all morning reports
 GET  /api/wmt/bonus             → latest bonus prediction
 POST /api/wmt/refresh           → fetch + ELO update + predictions

--- a/backend/models.py
+++ b/backend/models.py
@@ -144,3 +144,14 @@ class WmtBonusPrediction(Base):
     winner        = Column(JSONB)   # {"team": "...", "tla": "...", "prob": 0.15}
     top_scorer    = Column(JSONB)   # {"player": "...", "team": "...", "tla": "...", "goals": 4.2, "source": "..."}
     n_simulations = Column(Integer, default=10000)
+
+
+class WmtOpponentTip(Base):
+    __tablename__ = "wmt_opponent_tips"
+    id              = Column(Integer, primary_key=True, autoincrement=True)
+    match_id        = Column(Integer, ForeignKey("wmt_matches.id"), nullable=False)
+    player_name     = Column(String, nullable=False)
+    pred_home_goals = Column(Integer, nullable=False)
+    pred_away_goals = Column(Integer, nullable=False)
+    captured_at     = Column(DateTime, default=datetime.utcnow)
+

--- a/backend/routers/wmt.py
+++ b/backend/routers/wmt.py
@@ -1929,6 +1929,58 @@ def list_teams(db: Session = Depends(get_db)):
     )
 
 
+@router.post("/opponents/import", response_model=schemas.WmtRefreshOut)
+def import_opponent_tips(payload: schemas.WmtOpponentTipImportIn, db: Session = Depends(get_db)):
+    """Tipps von Mitspielern (z. B. aus Kicktipp-Screenshots geparst) importieren/aktualisieren."""
+    imported = 0
+    skipped = 0
+    for tip in payload.tips:
+        home = db.query(models.WmtTeam).filter_by(tla=tip.home_tla.upper()).first()
+        away = db.query(models.WmtTeam).filter_by(tla=tip.away_tla.upper()).first()
+        if not home or not away:
+            skipped += 1
+            continue
+        match = (
+            db.query(models.WmtMatch)
+            .filter_by(home_team_id=home.id, away_team_id=away.id)
+            .order_by(models.WmtMatch.utc_date.desc())
+            .first()
+        )
+        if not match:
+            skipped += 1
+            continue
+        existing = (
+            db.query(models.WmtOpponentTip)
+            .filter_by(match_id=match.id, player_name=tip.player_name)
+            .first()
+        )
+        if existing:
+            existing.pred_home_goals = tip.pred_home_goals
+            existing.pred_away_goals = tip.pred_away_goals
+            existing.captured_at = datetime.utcnow()
+        else:
+            db.add(models.WmtOpponentTip(
+                match_id=match.id,
+                player_name=tip.player_name,
+                pred_home_goals=tip.pred_home_goals,
+                pred_away_goals=tip.pred_away_goals,
+            ))
+        imported += 1
+    db.commit()
+    return schemas.WmtRefreshOut(message=f"{imported} Tipps importiert, {skipped} übersprungen.", updated=imported)
+
+
+@router.get("/opponents", response_model=list[schemas.WmtOpponentTipOut])
+def list_opponent_tips(match_id: Optional[int] = None, db: Session = Depends(get_db)):
+    q = db.query(models.WmtOpponentTip)
+    if match_id is not None:
+        q = q.filter_by(match_id=match_id)
+    return (
+        q.order_by(models.WmtOpponentTip.match_id, models.WmtOpponentTip.player_name)
+        .all()
+    )
+
+
 @router.get("/summaries", response_model=list[schemas.WmtSummaryOut])
 def list_summaries(db: Session = Depends(get_db)):
     rows = (

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -246,6 +246,28 @@ class WmtWarmupOut(BaseModel):
     elapsed_seconds: float
 
 
+class WmtOpponentTipIn(BaseModel):
+    player_name: str
+    home_tla: str
+    away_tla: str
+    pred_home_goals: int
+    pred_away_goals: int
+
+
+class WmtOpponentTipImportIn(BaseModel):
+    tips: list[WmtOpponentTipIn]
+
+
+class WmtOpponentTipOut(BaseModel):
+    id: int
+    match_id: int
+    player_name: str
+    pred_home_goals: int
+    pred_away_goals: int
+    captured_at: UtcDt
+    model_config = {"from_attributes": True}
+
+
 class WmtStatusOut(BaseModel):
     match_count: int
     team_count: int

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -64,6 +64,8 @@ export const wmt = {
   getMatches: ()             => get('/wmt/matches'),
   getMatchPredictions: (id)  => get(`/wmt/matches/${id}/predictions`),
   getTeams: ()               => get('/wmt/teams'),
+  getOpponentTips: (matchId) => get('/wmt/opponents' + (matchId ? `?match_id=${matchId}` : '')),
+  importOpponentTips: (tips) => post('/wmt/opponents/import', { tips }),
   getSummaries: ()           => get('/wmt/summaries'),
   refresh: ()                => post('/wmt/refresh'),
   generateSummary: ()        => post('/wmt/summary/generate'),

--- a/frontend/src/pages/Wmt.jsx
+++ b/frontend/src/pages/Wmt.jsx
@@ -437,6 +437,7 @@ function MenuButton({ icon, label, loading, danger, disabled, onClick }) {
 
 export default function Wmt() {
   const [matches, setMatches]           = useState([])
+  const [opponentTips, setOpponentTips] = useState([])
   const [summaries, setSummaries]       = useState([])
   const [bonus, setBonus]               = useState(null)
   const [view, setView]                 = useState('spieltage')
@@ -475,6 +476,11 @@ export default function Wmt() {
     try {
       const ms = await wmt.getMatches()
       setMatches(ms)
+
+      try {
+        const ot = await wmt.getOpponentTips()
+        setOpponentTips(ot)
+      } catch { /* ignore */ }
 
       const ss = await wmt.getSummaries()
       setSummaries(ss)
@@ -885,7 +891,7 @@ export default function Wmt() {
             }}>
             {anyBusy ? '…' : '☰'}
           </button>
-          <span className="topbar-version">v2.9</span>
+          <span className="topbar-version">v3.0</span>
         </div>
       </div>
 
@@ -1003,6 +1009,7 @@ export default function Wmt() {
             ['import', 'Import'],
             ['spieltage', 'Spieltage'],
             ['gruppen', 'Gruppen-Tabellen'],
+            ['konkurrenz', 'Konkurrenz'],
             ['bonus', 'Bonus-Tipps'],
             ['zusammenfassung', 'Morgenberichte'],
           ].map(([key, label]) => (
@@ -1115,6 +1122,11 @@ export default function Wmt() {
         {/* ── Gruppen-Tabellen view ─────────────────────────────────────── */}
         {!loading && view === 'gruppen' && (
           <GruppenTabellen matches={matches} />
+        )}
+
+        {/* ── Konkurrenz view ───────────────────────────────────────────── */}
+        {!loading && view === 'konkurrenz' && (
+          <KonkurrenzView matches={matches} opponentTips={opponentTips} />
         )}
 
         {/* ── Bonus-Tipps view ──────────────────────────────────────────── */}
@@ -1640,6 +1652,88 @@ function SummaryCalModal({ matches, summaries, generating, onClose, onGenerate }
           {months.map(m => renderMonth(m))}
         </div>
       </div>
+    </div>
+  )
+}
+
+function KonkurrenzView({ matches, opponentTips }) {
+  const matchById = {}
+  for (const m of matches) matchById[m.id] = m
+
+  const tipsByMatch = {}
+  for (const t of opponentTips) {
+    if (!tipsByMatch[t.match_id]) tipsByMatch[t.match_id] = []
+    tipsByMatch[t.match_id].push(t)
+  }
+
+  const matchIds = Object.keys(tipsByMatch)
+    .map(Number)
+    .filter(id => matchById[id])
+    .sort((a, b) => new Date(matchById[a].utc_date) - new Date(matchById[b].utc_date))
+
+  if (matchIds.length === 0) {
+    return (
+      <div style={{ background: '#0d1221', border: '1px solid #1a2840', borderRadius: 10, padding: 24, textAlign: 'center' }}>
+        <div style={{ fontSize: 13, color: '#9ab0d0' }}>Noch keine Tipps der Mitspieler importiert.</div>
+        <div style={{ fontSize: 11, color: '#374d66', marginTop: 6 }}>
+          Sobald die Tipps in der Tipprunde sichtbar sind, können Screenshots zum Import übergeben werden.
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+      {matchIds.map(mid => {
+        const m = matchById[mid]
+        const tips = tipsByMatch[mid]
+        const home = m.home_team?.short_name ?? m.home_team?.tla ?? '?'
+        const away = m.away_team?.short_name ?? m.away_team?.tla ?? '?'
+        const p = m.prediction
+
+        const tally = { home: 0, draw: 0, away: 0 }
+        for (const t of tips) {
+          if (t.pred_home_goals > t.pred_away_goals) tally.home++
+          else if (t.pred_home_goals < t.pred_away_goals) tally.away++
+          else tally.draw++
+        }
+
+        return (
+          <div key={mid} style={{ background: '#0d1221', border: '1px solid #1a2840', borderRadius: 10, padding: '14px 16px' }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 8 }}>
+              <div style={{ fontSize: 13, color: '#eef2ff', fontWeight: 500 }}>
+                {home} – {away}
+                {m.score_home != null && m.score_away != null && (
+                  <span style={{ color: '#9ab0d0', fontWeight: 400 }}> ({m.score_home}:{m.score_away})</span>
+                )}
+              </div>
+              <div style={{ fontSize: 10, color: '#374d66' }}>
+                {new Date(m.utc_date).toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit' })} · {stageLabel(m.stage)}
+              </div>
+            </div>
+
+            {p && (
+              <div style={{ fontSize: 11, color: '#9ab0d0', marginBottom: 10 }}>
+                ELO-Tipp: {Math.round(p.pred_home_goals)}:{Math.round(p.pred_away_goals)}
+                {' '}({Math.round(p.home_win_prob * 100)}% / {Math.round(p.draw_prob * 100)}% / {Math.round(p.away_win_prob * 100)}%)
+              </div>
+            )}
+
+            <div style={{ fontSize: 11, color: '#374d66', marginBottom: 8 }}>
+              Tipp-Verteilung: {tally.home}× Heimsieg · {tally.draw}× Unentschieden · {tally.away}× Auswärtssieg
+            </div>
+
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+              {tips.map(t => (
+                <div key={t.id} style={{ display: 'flex', justifyContent: 'space-between', fontSize: 12 }}>
+                  <span style={{ color: '#9ab0d0' }}>{t.player_name}</span>
+                  <span style={{ color: '#eef2ff', fontVariantNumeric: 'tabular-nums' }}>{t.pred_home_goals}:{t.pred_away_goals}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )
+      })}
     </div>
   )
 }


### PR DESCRIPTION
Lays the groundwork for analysing fellow Tipprunde players' picks before
the tournament starts, since Kicktipp.de has no public API for reading
tips. Workflow: once tips are revealed, the user screenshots the
Tippübersicht and Claude (vision) parses player names + predicted scores,
then imports them via the new endpoint.

- New WmtOpponentTip model/table, resolved to matches via team TLAs
- POST /api/wmt/opponents/import (upserts per match+player, skips unresolvable)
- GET /api/wmt/opponents (optional ?match_id= filter)
- New "Konkurrenz" tab: per-match ELO-Tipp, tip-distribution tally, player score table
- Purely additive — does not touch the ELO prediction engine

https://claude.ai/code/session_01JqMuUbRgvGTqnS8yfw5ZUY