### PR TITLE
Show wmt-only experience on matthiasweigel.com

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,7 +238,7 @@ Each tool page owns its own version string, displayed in the topbar's right side
 | str  | v4.0 |
 | bpm  | v4.0 |
 | spt  | v4.9 |
-| wmt  | v3.0 |
+| wmt  | v3.1 |
 | block-hero | v1.0 |
 
 There is no global version footer. `vite.config.js` still injects `__GIT_HASH__` and `__GIT_HASH_FULL__` (Railway fallback: `RAILWAY_GIT_COMMIT_SHA`) but these are not currently displayed.

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import { ThemeProvider } from './context/ThemeContext'
 import ThemeToggle from './components/ThemeToggle'
+import { isWmtOnlyDomain } from './domain'
 import Home from './pages/Home'
 import Productivity from './pages/Productivity'
 import Personal from './pages/Personal'
@@ -15,23 +16,31 @@ import BlockHero from './pages/BlockHero'
 import Wmt from './pages/Wmt'
 
 export default function App() {
+  const wmtOnly = isWmtOnlyDomain()
+
   return (
     <ThemeProvider>
       <ThemeToggle />
       <BrowserRouter>
         <Routes>
-          <Route path="/" element={<Home />} />
-          <Route path="/productivity" element={<Productivity />} />
-          <Route path="/personal" element={<Personal />} />
-          <Route path="/games" element={<Games />} />
-          <Route path="/tts" element={<TimeTracker />} />
-          <Route path="/cal" element={<Calendar />} />
-          <Route path="/idx" element={<IdeaInbox />} />
-          <Route path="/str" element={<StringTracker />} />
-          <Route path="/bpm" element={<BpmCounter />} />
-          <Route path="/spt" element={<SpotifyExplorer />} />
-          <Route path="/block-hero" element={<BlockHero />} />
-          <Route path="/wmt" element={<Wmt />} />
+          {wmtOnly ? (
+            <Route path="*" element={<Wmt />} />
+          ) : (
+            <>
+              <Route path="/" element={<Home />} />
+              <Route path="/productivity" element={<Productivity />} />
+              <Route path="/personal" element={<Personal />} />
+              <Route path="/games" element={<Games />} />
+              <Route path="/tts" element={<TimeTracker />} />
+              <Route path="/cal" element={<Calendar />} />
+              <Route path="/idx" element={<IdeaInbox />} />
+              <Route path="/str" element={<StringTracker />} />
+              <Route path="/bpm" element={<BpmCounter />} />
+              <Route path="/spt" element={<SpotifyExplorer />} />
+              <Route path="/block-hero" element={<BlockHero />} />
+              <Route path="/wmt" element={<Wmt />} />
+            </>
+          )}
         </Routes>
       </BrowserRouter>
     </ThemeProvider>

--- a/frontend/src/domain.js
+++ b/frontend/src/domain.js
@@ -1,0 +1,7 @@
+// matthiasweigel.com is a wmt-only mirror shown to Tipprunde opponents —
+// it must never expose the rest of the site (navigation, other tools).
+const WMT_ONLY_HOSTS = ['matthiasweigel.com', 'www.matthiasweigel.com']
+
+export function isWmtOnlyDomain() {
+  return WMT_ONLY_HOSTS.includes(window.location.hostname)
+}

--- a/frontend/src/pages/Wmt.jsx
+++ b/frontend/src/pages/Wmt.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
 import { Link } from 'react-router-dom'
 import { wmt } from '../api'
+import { isWmtOnlyDomain } from '../domain'
 
 // ── constants & helpers ───────────────────────────────────────────────────────
 
@@ -875,7 +876,9 @@ export default function Wmt() {
       {/* topbar */}
       <div className="topbar">
         <div className="topbar-left">
-          <Link to="/personal"><button className="topbar-back btn btn-sm">←</button></Link>
+          {!isWmtOnlyDomain() && (
+            <Link to="/personal"><button className="topbar-back btn btn-sm">←</button></Link>
+          )}
           <span className="topbar-title">wmt</span>
         </div>
         <div className="topbar-right">
@@ -891,7 +894,7 @@ export default function Wmt() {
             }}>
             {anyBusy ? '…' : '☰'}
           </button>
-          <span className="topbar-version">v3.0</span>
+          <span className="topbar-version">v3.1</span>
         </div>
       </div>
 


### PR DESCRIPTION
matmaxx.org and matthiasweigel.com point at the same Railway service and
share the same database. matthiasweigel.com is shown to Tipprunde
opponents, so it must expose only the wmt tool with no path back into the
rest of the site: any route on that host now renders Wmt directly and the
topbar's backlink to /personal is hidden. matmaxx.org keeps the full site
and normal wmt navigation.

https://claude.ai/code/session_01SH5DouCiHnEd5NeJLrgQEk