### PR TITLE
feat(wmt): add daily ranking-snapshot import + rank evolution chart

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,7 +238,7 @@ Each tool page owns its own version string, displayed in the topbar's right side
 | str  | v4.0 |
 | bpm  | v4.0 |
 | spt  | v4.9 |
-| wmt  | v3.3 |
+| wmt  | v3.4 |
 | block-hero | v1.0 |
 
 There is no global version footer. `vite.config.js` still injects `__GIT_HASH__` and `__GIT_HASH_FULL__` (Railway fallback: `RAILWAY_GIT_COMMIT_SHA`) but these are not currently displayed.
@@ -284,6 +284,7 @@ Match data is fetched via one of two sources, tried in order:
 | `WmtSummary` | `wmt_summaries` | Daily morning report (markdown) |
 | `WmtBonusPrediction` | `wmt_bonus_predictions` | Monte-Carlo tournament simulation result |
 | `WmtOpponentTip` | `wmt_opponent_tips` | Imported tip of a fellow Tipprunde player for a given match |
+| `WmtRankingSnapshot` | `wmt_ranking_snapshots` | Imported daily leaderboard snapshot (date, player, rank, points) from Kicktipp's Tippübersicht |
 
 ### ELO prediction engine
 
@@ -337,6 +338,11 @@ Kicktipp.de has no public API for reading fellow players' tips, so they're impor
 3. Claude maps the team names/short codes shown in the table header to TLAs (e.g. "MEX" / "SAFR" / "KAN" / "BIH") and POSTs the parsed data to `/api/wmt/opponents/import`.
 4. The response reports how many tips were imported vs. skipped (unresolved TLA or no matching match) — relay that to the user.
 5. Imported tips immediately appear in the **Konkurrenz** tab, grouped by match with ELO-Tipp comparison and tip-distribution tally.
+6. The same Tippübersicht screenshot also shows each player's current **Pos** (rank) and **P** (points) in the leaderboard header/footer — Claude extracts those too and POSTs them to `/api/wmt/rankings/import` as `{snapshots: [{date, player_name, rank, points}, ...]}`, where `date` is the calendar day the screenshot represents (not the import date — historical catch-up imports are fine as long as the represented date is correct). The endpoint upserts a `WmtRankingSnapshot` row per `(date, player_name)`.
+
+### Rank evolution chart (`WmtRankingSnapshot`)
+
+Kicktipp has no public export and its exact point formula (exact-score / goal-difference bonuses) isn't published, so the app doesn't try to recompute the leaderboard — instead it captures the **official** Pos/P values straight from the daily Tippübersicht screenshot (see step 6 above) and stores them as `WmtRankingSnapshot` rows. Because historical ranks can't be reconstructed retroactively, the chart is only as complete as the daily screenshot habit — there is no backfill. The **Konkurrenz** tab renders a `RankingChart` (custom inline SVG, no charting library — `polyline` per player, axis gridlines/labels, a cycling colour palette) plotting day on the x-axis and rank on the y-axis (inverted, rank 1 at top), one line per player — a Mario-Party-style "ranking over time" view of the whole Tipprunde.
 
 ### Frontend views (`Wmt.jsx` — v3.0)
 
@@ -347,7 +353,7 @@ The page has six tabs:
 | **Import** | Log output for all async operations (refresh, fake, warmup, etc.) |
 | **Spieltage** | Match cards grouped by matchday/stage; sub-grouped by calendar day for group stage. Shows ELO-based tipp-Empfehlung, win/draw/loss prob bar, VERLAUF (prediction history with change notes) |
 | **Gruppen-Tabellen** | Live group standings for all 12 groups (A–L) in a 2-column grid. Columns: Sp / W / U / N / Tore / TD (coloured) / Pkt. Derived from match data, updates on every refresh/fake |
-| **Konkurrenz** | Imported opponent tips (`WmtOpponentTip`) grouped by match: ELO-Tipp + win/draw/loss probabilities, tip-distribution tally (Heimsieg/Unentschieden/Auswärtssieg), and a per-player score table. Empty-state hint until tips are imported |
+| **Konkurrenz** | Rank evolution chart (`RankingChart`, one line per player across imported `WmtRankingSnapshot` days) at the top, then imported opponent tips (`WmtOpponentTip`) grouped by match: ELO-Tipp + win/draw/loss probabilities, tip-distribution tally (Heimsieg/Unentschieden/Auswärtssieg), and a per-player score table. Empty-state hints until tips/snapshots are imported |
 | **Bonus-Tipps** | Monte-Carlo simulation results. Shows PROGNOSE vs. REALITÄT comparison at top once the Final is finished |
 | **Morgenberichte** | Daily match summaries in reverse-chronological order |
 
@@ -391,6 +397,8 @@ GET  /api/wmt/matches           → all matches with nested team + latest predic
 GET  /api/wmt/teams             → all teams with ELO
 GET  /api/wmt/opponents         → imported opponent tips (optional ?match_id= filter)
 POST /api/wmt/opponents/import  → import/update opponent tips (resolved via team TLAs)
+GET  /api/wmt/rankings          → imported daily ranking snapshots (date, player, rank, points)
+POST /api/wmt/rankings/import   → import/update ranking snapshots (upsert by date + player_name)
 GET  /api/wmt/summaries         → all morning reports
 GET  /api/wmt/bonus             → latest bonus prediction
 POST /api/wmt/refresh           → fetch + ELO update + predictions

--- a/backend/models.py
+++ b/backend/models.py
@@ -155,3 +155,14 @@ class WmtOpponentTip(Base):
     pred_away_goals = Column(Integer, nullable=False)
     captured_at     = Column(DateTime, default=datetime.utcnow)
 
+
+class WmtRankingSnapshot(Base):
+    __tablename__ = "wmt_ranking_snapshots"
+    id          = Column(Integer, primary_key=True, autoincrement=True)
+    date        = Column(Date, nullable=False)
+    player_name = Column(String, nullable=False)
+    rank        = Column(Integer, nullable=False)
+    points      = Column(Integer, nullable=False)
+    captured_at = Column(DateTime, default=datetime.utcnow)
+
+

--- a/backend/routers/wmt.py
+++ b/backend/routers/wmt.py
@@ -2104,6 +2104,57 @@ def list_opponent_tips(match_id: Optional[int] = None, db: Session = Depends(get
     )
 
 
+@router.post("/rankings/import", response_model=schemas.WmtRefreshOut)
+def import_ranking_snapshots(payload: schemas.WmtRankingSnapshotImportIn, db: Session = Depends(get_db)):
+    """Tagesschnappschüsse der Kicktipp-Rangliste (Pos/P aus der Tippübersicht) importieren/aktualisieren."""
+    imported = 0
+    skipped = 0
+    for snap in payload.snapshots:
+        try:
+            parsed = date.fromisoformat(snap.date)
+        except ValueError:
+            skipped += 1
+            continue
+        existing = (
+            db.query(models.WmtRankingSnapshot)
+            .filter_by(date=parsed, player_name=snap.player_name)
+            .first()
+        )
+        if existing:
+            existing.rank = snap.rank
+            existing.points = snap.points
+            existing.captured_at = datetime.utcnow()
+        else:
+            db.add(models.WmtRankingSnapshot(
+                date=parsed,
+                player_name=snap.player_name,
+                rank=snap.rank,
+                points=snap.points,
+            ))
+        imported += 1
+    db.commit()
+    return schemas.WmtRefreshOut(message=f"{imported} Rangliste-Schnappschüsse importiert, {skipped} übersprungen.", updated=imported)
+
+
+@router.get("/rankings", response_model=list[schemas.WmtRankingSnapshotOut])
+def list_ranking_snapshots(db: Session = Depends(get_db)):
+    rows = (
+        db.query(models.WmtRankingSnapshot)
+        .order_by(models.WmtRankingSnapshot.date, models.WmtRankingSnapshot.rank)
+        .all()
+    )
+    return [
+        schemas.WmtRankingSnapshotOut(
+            id=r.id,
+            date=r.date.isoformat(),
+            player_name=r.player_name,
+            rank=r.rank,
+            points=r.points,
+        )
+        for r in rows
+    ]
+
+
 @router.get("/summaries", response_model=list[schemas.WmtSummaryOut])
 def list_summaries(db: Session = Depends(get_db)):
     rows = (

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -268,6 +268,26 @@ class WmtOpponentTipOut(BaseModel):
     model_config = {"from_attributes": True}
 
 
+class WmtRankingSnapshotIn(BaseModel):
+    date: str
+    player_name: str
+    rank: int
+    points: int
+
+
+class WmtRankingSnapshotImportIn(BaseModel):
+    snapshots: list[WmtRankingSnapshotIn]
+
+
+class WmtRankingSnapshotOut(BaseModel):
+    id: int
+    date: str
+    player_name: str
+    rank: int
+    points: int
+    model_config = {"from_attributes": True}
+
+
 class WmtStatusOut(BaseModel):
     match_count: int
     team_count: int

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -66,6 +66,8 @@ export const wmt = {
   getTeams: ()               => get('/wmt/teams'),
   getOpponentTips: (matchId) => get('/wmt/opponents' + (matchId ? `?match_id=${matchId}` : '')),
   importOpponentTips: (tips) => post('/wmt/opponents/import', { tips }),
+  getRankingSnapshots: ()    => get('/wmt/rankings'),
+  importRankingSnapshots: (snapshots) => post('/wmt/rankings/import', { snapshots }),
   getSummaries: ()           => get('/wmt/summaries'),
   refresh: ()                => post('/wmt/refresh'),
   generateSummary: ()        => post('/wmt/summary/generate'),

--- a/frontend/src/pages/Wmt.jsx
+++ b/frontend/src/pages/Wmt.jsx
@@ -439,6 +439,7 @@ function MenuButton({ icon, label, loading, danger, disabled, onClick }) {
 export default function Wmt() {
   const [matches, setMatches]           = useState([])
   const [opponentTips, setOpponentTips] = useState([])
+  const [rankingSnapshots, setRankingSnapshots] = useState([])
   const [summaries, setSummaries]       = useState([])
   const [bonus, setBonus]               = useState(null)
   const [view, setView]                 = useState('spieltage')
@@ -481,6 +482,11 @@ export default function Wmt() {
       try {
         const ot = await wmt.getOpponentTips()
         setOpponentTips(ot)
+      } catch { /* ignore */ }
+
+      try {
+        const rs = await wmt.getRankingSnapshots()
+        setRankingSnapshots(rs)
       } catch { /* ignore */ }
 
       const ss = await wmt.getSummaries()
@@ -895,7 +901,7 @@ export default function Wmt() {
             }}>
             {anyBusy ? '…' : '☰'}
           </button>
-          <span className="topbar-version">v3.3</span>
+          <span className="topbar-version">v3.4</span>
         </div>
       </div>
 
@@ -1134,7 +1140,7 @@ export default function Wmt() {
 
         {/* ── Konkurrenz view ───────────────────────────────────────────── */}
         {!loading && view === 'konkurrenz' && (
-          <KonkurrenzView matches={matches} opponentTips={opponentTips} />
+          <KonkurrenzView matches={matches} opponentTips={opponentTips} rankingSnapshots={rankingSnapshots} />
         )}
 
         {/* ── Bonus-Tipps view ──────────────────────────────────────────── */}
@@ -1664,7 +1670,77 @@ function SummaryCalModal({ matches, summaries, generating, onClose, onGenerate }
   )
 }
 
-function KonkurrenzView({ matches, opponentTips }) {
+const RANK_CHART_COLORS = [
+  '#7effa0','#ff6b6b','#6bb5ff','#ffd56b','#d06bff',
+  '#ff9f6b','#6bfff0','#ff6bd6','#b5ff6b','#6b7fff',
+  '#c8c8c8','#4a9eff','#e74c3c','#2ecc71','#f1c40f',
+  '#9b59b6','#e67e22','#1abc9c','#e91e63',
+]
+
+function RankingChart({ snapshots }) {
+  const dates   = [...new Set(snapshots.map(s => s.date))].sort()
+  const players = [...new Set(snapshots.map(s => s.player_name))].sort()
+
+  if (dates.length < 2 || players.length === 0) return null
+
+  const maxRank = Math.max(...snapshots.map(s => s.rank))
+  const W = 680, H = 320
+  const padL = 28, padR = 12, padT = 12, padB = 28
+  const plotW = W - padL - padR
+  const plotH = H - padT - padB
+
+  const xPos = i => padL + (dates.length === 1 ? plotW / 2 : (i / (dates.length - 1)) * plotW)
+  const yPos = rank => padT + ((rank - 1) / Math.max(1, maxRank - 1)) * plotH
+
+  const byPlayer = {}
+  for (const p of players) byPlayer[p] = []
+  for (const s of snapshots) {
+    byPlayer[s.player_name][dates.indexOf(s.date)] = s.rank
+  }
+
+  const labelStep = Math.max(1, Math.ceil(dates.length / 8))
+
+  return (
+    <div style={{ background: 'var(--surface)', border: '1px solid var(--border)', borderRadius: 10, padding: 16, overflowX: 'auto' }}>
+      <div style={{ fontSize: 13, color: 'var(--text-primary)', fontWeight: 500, marginBottom: 10 }}>
+        Rangverlauf
+      </div>
+      <svg width={W} height={H} style={{ display: 'block' }}>
+        {Array.from({ length: maxRank }, (_, i) => i + 1).map(r => (
+          <g key={r}>
+            <line x1={padL} y1={yPos(r)} x2={W - padR} y2={yPos(r)} stroke="var(--border)" strokeWidth={0.5} />
+            <text x={padL - 6} y={yPos(r) + 3} textAnchor="end" fontSize={9} fill="var(--text-muted)">{r}</text>
+          </g>
+        ))}
+        {dates.map((d, i) => (
+          (i === 0 || i === dates.length - 1 || i % labelStep === 0) && (
+            <text key={d} x={xPos(i)} y={H - padB + 14} textAnchor="middle" fontSize={9} fill="var(--text-muted)">
+              {new Date(d).toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit' })}
+            </text>
+          )
+        ))}
+        {players.map((p, pi) => {
+          const color = RANK_CHART_COLORS[pi % RANK_CHART_COLORS.length]
+          const pts = byPlayer[p]
+            .map((r, i) => (r != null ? `${xPos(i)},${yPos(r)}` : null))
+            .filter(Boolean)
+            .join(' ')
+          return <polyline key={p} points={pts} fill="none" stroke={color} strokeWidth={1.5} opacity={0.85} />
+        })}
+      </svg>
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px 14px', marginTop: 12 }}>
+        {players.map((p, pi) => (
+          <div key={p} style={{ display: 'flex', alignItems: 'center', gap: 5, fontSize: 11, color: 'var(--text-secondary)' }}>
+            <span style={{ width: 10, height: 10, borderRadius: 2, background: RANK_CHART_COLORS[pi % RANK_CHART_COLORS.length], display: 'inline-block' }} />
+            {p}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function KonkurrenzView({ matches, opponentTips, rankingSnapshots }) {
   const matchById = {}
   for (const m of matches) matchById[m.id] = m
 
@@ -1679,20 +1755,18 @@ function KonkurrenzView({ matches, opponentTips }) {
     .filter(id => matchById[id])
     .sort((a, b) => new Date(matchById[a].utc_date) - new Date(matchById[b].utc_date))
 
-  if (matchIds.length === 0) {
-    return (
-      <div style={{ background: 'var(--surface)', border: '1px solid var(--border)', borderRadius: 10, padding: 24, textAlign: 'center' }}>
-        <div style={{ fontSize: 13, color: 'var(--text-secondary)' }}>Noch keine Tipps der Mitspieler importiert.</div>
-        <div style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 6 }}>
-          Sobald die Tipps in der Tipprunde sichtbar sind, können Screenshots zum Import übergeben werden.
-        </div>
-      </div>
-    )
-  }
-
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
-      {matchIds.map(mid => {
+      <RankingChart snapshots={rankingSnapshots} />
+
+      {matchIds.length === 0 ? (
+        <div style={{ background: 'var(--surface)', border: '1px solid var(--border)', borderRadius: 10, padding: 24, textAlign: 'center' }}>
+          <div style={{ fontSize: 13, color: 'var(--text-secondary)' }}>Noch keine Tipps der Mitspieler importiert.</div>
+          <div style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 6 }}>
+            Sobald die Tipps in der Tipprunde sichtbar sind, können Screenshots zum Import übergeben werden.
+          </div>
+        </div>
+      ) : matchIds.map(mid => {
         const m = matchById[mid]
         const tips = tipsByMatch[mid]
         const home = m.home_team?.short_name ?? m.home_team?.tla ?? '?'


### PR DESCRIPTION
Adds WmtRankingSnapshot (date, player, rank, points) plus import/list
endpoints, fed by the same daily Tippübersicht screenshot workflow
already used for opponent tips. The Konkurrenz tab now renders a
custom SVG line chart (RankingChart) showing each player's rank over
the course of the tournament — a Mario-Party-style "stars over time"
view, per the user's request. Documents the new model, endpoints, and
chart in CLAUDE.md and extends the daily import workflow to also cover
the Pos/P columns.