### PR TITLE
fix(cal): force date inputs to respect container width on iOS

### DIFF
--- a/frontend/src/pages/Calendar.jsx
+++ b/frontend/src/pages/Calendar.jsx
@@ -423,7 +423,7 @@ export default function Calendar() {
           <span className="topbar-title">cal</span>
         </div>
         <div className="topbar-right">
-          <span className="topbar-version">v4.5</span>
+          <span className="topbar-version">v4.6</span>
           <button className="btn btn-sm" onClick={() => setShowSettings(s => !s)}>
             {showSettings ? 'close' : 'settings'}
           </button>
@@ -696,14 +696,14 @@ export default function Calendar() {
                   <label className="label">name</label>
                   <input className="input" value={editForm.name} onChange={e => setEF('name', e.target.value)} />
                 </div>
-                <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8, marginBottom: 10 }}>
-                  <div style={{ minWidth: 0 }}>
+                <div style={{ display: 'flex', gap: 8, marginBottom: 10 }}>
+                  <div style={{ flex: 1, minWidth: 0 }}>
                     <label className="label">start</label>
-                    <input className="input" type="date" value={editForm.start_date} onChange={e => setEF('start_date', e.target.value)} />
+                    <input className="input" type="date" style={{ minWidth: 0 }} value={editForm.start_date} onChange={e => setEF('start_date', e.target.value)} />
                   </div>
-                  <div style={{ minWidth: 0 }}>
+                  <div style={{ flex: 1, minWidth: 0 }}>
                     <label className="label">end</label>
-                    <input className="input" type="date" value={editForm.end_date} onChange={e => setEF('end_date', e.target.value)} />
+                    <input className="input" type="date" style={{ minWidth: 0 }} value={editForm.end_date} onChange={e => setEF('end_date', e.target.value)} />
                   </div>
                 </div>
                 <div style={{ marginBottom: 12 }}>


### PR DESCRIPTION
## Summary
- The previous fix (v4.5, merged in #239) added `minWidth: 0` to the grid wrapper divs around the start/end date inputs, but `input[type="date"]` on iOS Safari has its own intrinsic minimum width that ignores a parent's `minWidth: 0`.
- This switches the start/end row from CSS grid to flexbox and adds `minWidth: 0` directly on each `<input type="date">`, which forces both date boxes to fit within the edit card and align with the name input above. Bumps cal to v4.6.

https://claude.ai/code/session_01TMCYQxXKoB19iZehhQmQZN

---
_Generated by [Claude Code](https://claude.ai/code/session_01TMCYQxXKoB19iZehhQmQZN)_