### PR TITLE
fix(cal): stack start/end date fields vertically in edit form

### DIFF
--- a/frontend/src/pages/Calendar.jsx
+++ b/frontend/src/pages/Calendar.jsx
@@ -423,7 +423,7 @@ export default function Calendar() {
           <span className="topbar-title">cal</span>
         </div>
         <div className="topbar-right">
-          <span className="topbar-version">v4.6</span>
+          <span className="topbar-version">v4.7</span>
           <button className="btn btn-sm" onClick={() => setShowSettings(s => !s)}>
             {showSettings ? 'close' : 'settings'}
           </button>
@@ -696,15 +696,13 @@ export default function Calendar() {
                   <label className="label">name</label>
                   <input className="input" value={editForm.name} onChange={e => setEF('name', e.target.value)} />
                 </div>
-                <div style={{ display: 'flex', gap: 8, marginBottom: 10 }}>
-                  <div style={{ flex: 1, minWidth: 0 }}>
-                    <label className="label">start</label>
-                    <input className="input" type="date" style={{ minWidth: 0 }} value={editForm.start_date} onChange={e => setEF('start_date', e.target.value)} />
-                  </div>
-                  <div style={{ flex: 1, minWidth: 0 }}>
-                    <label className="label">end</label>
-                    <input className="input" type="date" style={{ minWidth: 0 }} value={editForm.end_date} onChange={e => setEF('end_date', e.target.value)} />
-                  </div>
+                <div style={{ marginBottom: 10 }}>
+                  <label className="label">start</label>
+                  <input className="input" type="date" value={editForm.start_date} onChange={e => setEF('start_date', e.target.value)} />
+                </div>
+                <div style={{ marginBottom: 10 }}>
+                  <label className="label">end</label>
+                  <input className="input" type="date" value={editForm.end_date} onChange={e => setEF('end_date', e.target.value)} />
                 </div>
                 <div style={{ marginBottom: 12 }}>
                   <label className="label">color</label>


### PR DESCRIPTION
## Summary
- Two prior attempts (#239 v4.5, #248 v4.6) tried side-by-side start/end date inputs with `minWidth: 0` on the wrapper and on the input itself, but `input[type="date"]` on iOS still visually overflows its box and spills past the edit card's right edge.
- This stacks start and end as full-width fields, each on its own row, exactly like the `name` field above. This guarantees both inputs fit within the card and align with the name input — no more overlap.
- Bumps cal to v4.7.

https://claude.ai/code/session_01TMCYQxXKoB19iZehhQmQZN

---
_Generated by [Claude Code](https://claude.ai/code/session_01TMCYQxXKoB19iZehhQmQZN)_