### PR TITLE
feat(wmt): show top-3 tournament-winner candidates in Bonus-Tipps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,7 +240,7 @@ Each tool page owns its own version string, displayed in the topbar's right side
 | str  | v4.0 |
 | bpm  | v4.0 |
 | spt  | v4.9 |
-| wmt  | v3.4 |
+| wmt  | v3.5 |
 | block-hero | v1.0 |
 
 There is no global version footer. `vite.config.js` still injects `__GIT_HASH__` and `__GIT_HASH_FULL__` (Railway fallback: `RAILWAY_GIT_COMMIT_SHA`) but these are not currently displayed.
@@ -316,7 +316,7 @@ SEMI_FINALS → FINAL (winners) + THIRD_PLACE (losers)
 
 ### Bonus prediction (`do_generate_bonus`)
 
-Monte-Carlo simulation (10 000 runs) of the full tournament. Outputs: tournament winner, finalists, semi-finalists, group winner probabilities, top-scorer estimate. Frozen (UI-locked) one day before the tournament starts. After the Final is finished, the Bonus view automatically shows a "PROGNOSE vs. REALITÄT" comparison section.
+Monte-Carlo simulation (10 000 runs) of the full tournament. Outputs: tournament winner (plus the top-3 winner candidates by simulated win probability, `winner_candidates`), finalists, semi-finalists, group winner probabilities, top-scorer estimate. Frozen (UI-locked) one day before the tournament starts. After the Final is finished, the Bonus view automatically shows a "PROGNOSE vs. REALITÄT" comparison section (which still compares against the single top `winner` pick).
 
 ### Morning summaries (`do_generate_summary`)
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -142,6 +142,7 @@ class WmtBonusPrediction(Base):
     semifinalists = Column(JSONB)   # [{"team": "...", "tla": "...", "prob": 0.32}, ...]
     finalists     = Column(JSONB)   # [{"team": "...", "tla": "...", "prob": 0.20}, ...]
     winner        = Column(JSONB)   # {"team": "...", "tla": "...", "prob": 0.15}
+    winner_candidates = Column(JSONB)  # [{"team": "...", "tla": "...", "prob": 0.15}, ...] (top 3)
     top_scorer    = Column(JSONB)   # {"player": "...", "team": "...", "tla": "...", "goals": 4.2, "source": "..."}
     n_simulations = Column(Integer, default=10000)
 

--- a/backend/routers/wmt.py
+++ b/backend/routers/wmt.py
@@ -1169,8 +1169,16 @@ def do_generate_bonus(db: Session, n_sims: int = 10000) -> Optional[models.WmtBo
             "tla":  w.tla or "?",
             "prob": round(win_count.get(winner_id, 0) / n_sims, 3),
         }
+        winner_candidates = sorted(
+            [{"team": all_teams[t].short_name or all_teams[t].name,
+              "tla":  all_teams[t].tla or "?",
+              "prob": round(win_count[t] / n_sims, 3)}
+             for t in all_ids if win_count.get(t, 0) > 0],
+            key=lambda x: -x["prob"],
+        )[:3]
     else:
         winner = {"team": "?", "tla": "?", "prob": 0.0}
+        winner_candidates = []
 
     top_scorer = _compute_top_scorer(db)
 
@@ -1179,6 +1187,7 @@ def do_generate_bonus(db: Session, n_sims: int = 10000) -> Optional[models.WmtBo
         semifinalists=semifinalists,
         finalists=finalists,
         winner=winner,
+        winner_candidates=winner_candidates,
         top_scorer=top_scorer,
         n_simulations=n_sims,
     )

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -232,6 +232,7 @@ class WmtBonusPredictionOut(BaseModel):
     semifinalists: Any
     finalists: Any
     winner: Any
+    winner_candidates: Any = None
     top_scorer: Any
     n_simulations: int
     model_config = {"from_attributes": True}

--- a/frontend/src/pages/Wmt.jsx
+++ b/frontend/src/pages/Wmt.jsx
@@ -901,7 +901,7 @@ export default function Wmt() {
             }}>
             {anyBusy ? '…' : '☰'}
           </button>
-          <span className="topbar-version">v3.4</span>
+          <span className="topbar-version">v3.5</span>
         </div>
       </div>
 
@@ -1401,22 +1401,33 @@ function BonusView({ bonus, generating, actualResults }) {
       )}
 
       {/* Turniersieger */}
-      {bonus.winner && (
-        <div style={{ ...cardStyle, borderColor: 'var(--border-hover)' }}>
-          <div style={labelStyle}>TURNIERSIEGER</div>
-          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-            <div>
-              <span style={{ fontSize: 18, fontWeight: 700, color: 'var(--text-primary)', marginRight: 10 }}>
-                {bonus.winner.tla}
-              </span>
-              <span style={{ fontSize: 14, color: 'var(--text-secondary)' }}>{bonus.winner.team}</span>
-            </div>
-            <span style={{ fontSize: 16, fontWeight: 600, color: '#4d6fa0' }}>
-              {(bonus.winner.prob * 100).toFixed(0)}%
-            </span>
+      {bonus.winner && (() => {
+        const candidates = bonus.winner_candidates?.length > 0 ? bonus.winner_candidates : [bonus.winner]
+        return (
+          <div style={{ ...cardStyle, borderColor: 'var(--border-hover)' }}>
+            <div style={labelStyle}>{candidates.length > 1 ? 'TURNIERSIEGER — TOP 3' : 'TURNIERSIEGER'}</div>
+            {candidates.map((item, i) => (
+              <div key={i} style={{
+                display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+                padding: i === 0 ? '0 0 7px' : '7px 0 0', borderTop: i > 0 ? '1px solid var(--border)' : 'none',
+              }}>
+                <div>
+                  <span style={{
+                    fontSize: i === 0 ? 18 : 13, fontWeight: i === 0 ? 700 : 600,
+                    color: 'var(--text-primary)', marginRight: 10,
+                  }}>
+                    {item.tla}
+                  </span>
+                  <span style={{ fontSize: i === 0 ? 14 : 12, color: 'var(--text-secondary)' }}>{item.team}</span>
+                </div>
+                <span style={{ fontSize: i === 0 ? 16 : 12, fontWeight: 600, color: '#4d6fa0' }}>
+                  {(item.prob * 100).toFixed(0)}%
+                </span>
+              </div>
+            ))}
           </div>
-        </div>
-      )}
+        )
+      })()}
 
       {/* Finalisten */}
       {bonus.finalists?.length > 0 && (


### PR DESCRIPTION
The Monte-Carlo simulation already tracks per-team win counts; surface
the three highest-probability candidates (winner_candidates) instead
of just the single favorite. The PROGNOSE vs. REALITÄT comparison still
uses the single top pick (winner) unchanged.