### PR TITLE
fix(cal): strip native appearance from date inputs to stop overflow

### DIFF
--- a/frontend/src/pages/Calendar.jsx
+++ b/frontend/src/pages/Calendar.jsx
@@ -423,7 +423,7 @@ export default function Calendar() {
           <span className="topbar-title">cal</span>
         </div>
         <div className="topbar-right">
-          <span className="topbar-version">v4.7</span>
+          <span className="topbar-version">v4.8</span>
           <button className="btn btn-sm" onClick={() => setShowSettings(s => !s)}>
             {showSettings ? 'close' : 'settings'}
           </button>
@@ -698,11 +698,11 @@ export default function Calendar() {
                 </div>
                 <div style={{ marginBottom: 10 }}>
                   <label className="label">start</label>
-                  <input className="input" type="date" value={editForm.start_date} onChange={e => setEF('start_date', e.target.value)} />
+                  <input className="input" type="date" style={{ WebkitAppearance: 'none', appearance: 'none', maxWidth: '100%' }} value={editForm.start_date} onChange={e => setEF('start_date', e.target.value)} />
                 </div>
                 <div style={{ marginBottom: 10 }}>
                   <label className="label">end</label>
-                  <input className="input" type="date" value={editForm.end_date} onChange={e => setEF('end_date', e.target.value)} />
+                  <input className="input" type="date" style={{ WebkitAppearance: 'none', appearance: 'none', maxWidth: '100%' }} value={editForm.end_date} onChange={e => setEF('end_date', e.target.value)} />
                 </div>
                 <div style={{ marginBottom: 12 }}>
                   <label className="label">color</label>


### PR DESCRIPTION
## Summary
- The v4.7 fix (stacked, full-width start/end fields) still showed `input[type="date"]` overflowing on iOS — the box itself was correctly sized, but the browser's native date control retains its own minimum render width and paints past the box regardless of CSS layout (grid, flex, or block).
- This adds `WebkitAppearance: 'none'` / `appearance: 'none'` plus `maxWidth: '100%'` to the start/end date inputs, removing the native chrome that ignores `width: 100%` so the input renders within its actual box.
- Bumps cal to v4.8.

https://claude.ai/code/session_01TMCYQxXKoB19iZehhQmQZN

---
_Generated by [Claude Code](https://claude.ai/code/session_01TMCYQxXKoB19iZehhQmQZN)_