### PR TITLE
chore(wmt): temporarily unlock Bonus-Prognose generation

### DIFF
--- a/frontend/src/pages/Wmt.jsx
+++ b/frontend/src/pages/Wmt.jsx
@@ -830,6 +830,8 @@ export default function Wmt() {
   const teamStatuses = useMemo(() => computeTeamStatuses(matches), [matches])
 
   const isBonusFrozen = useMemo(() => {
+    return false // TEMPORARY: bonus generation unlocked for re-run after winner_candidates change — re-enable after use
+    // eslint-disable-next-line no-unreachable
     if (!matches.length) return false
     const firstMs = Math.min(...matches.map(m => new Date(m.utc_date).getTime()))
     const freeze = new Date(firstMs)


### PR DESCRIPTION
Bonus generation auto-froze today (one day before kickoff). Disabling
the freeze temporarily so the bonus can be regenerated with the new
winner_candidates field before lock-in. Revert after use.