### PR TITLE
chore(wmt): re-enable Bonus-Prognose freeze

### DIFF
--- a/frontend/src/pages/Wmt.jsx
+++ b/frontend/src/pages/Wmt.jsx
@@ -830,8 +830,6 @@ export default function Wmt() {
   const teamStatuses = useMemo(() => computeTeamStatuses(matches), [matches])
 
   const isBonusFrozen = useMemo(() => {
-    return false // TEMPORARY: bonus generation unlocked for re-run after winner_candidates change — re-enable after use
-    // eslint-disable-next-line no-unreachable
     if (!matches.length) return false
     const firstMs = Math.min(...matches.map(m => new Date(m.utc_date).getTime()))
     const freeze = new Date(firstMs)


### PR DESCRIPTION
Reverts the temporary unlock now that the bonus prediction has been
regenerated with winner_candidates. The one-day-before-kickoff freeze
is restored.