### PR TITLE
fix(wmt): surface refresh errors + serialize concurrent refreshes

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -33,8 +33,10 @@ def _wmt_refresh() -> None:
     """Refresh WM 2026 data every 30 minutes."""
     db = SessionLocal()
     try:
-        n = _wmt_do_refresh(db)
-        if n:
+        n, err = _wmt_do_refresh(db)
+        if err:
+            logger.warning("WMT refresh: %s", err)
+        elif n:
             logger.info("WMT refresh: %d matches updated", n)
         else:
             logger.debug("WMT refresh: no changes")

--- a/backend/routers/wmt.py
+++ b/backend/routers/wmt.py
@@ -10,6 +10,7 @@ import logging
 import math
 import os
 import random
+import threading
 import time
 from collections import defaultdict
 from datetime import date, datetime, timedelta
@@ -722,15 +723,26 @@ def _do_refresh_openligadb(db: Session) -> tuple[int, str]:
     return updated, ""
 
 
+# Refresh läuft alle 30 min per Scheduler UND manuell per Button. Seit echte
+# Ergebnisse eintreffen, schreiben Refreshes (ELO-Updates, Prognosen) — zwei
+# gleichzeitige Läufe würden dieselben Ergebnisse doppelt in die ELOs einrechnen.
+_refresh_lock = threading.Lock()
+
+
 def do_refresh(db: Session) -> tuple[int, str]:
     """
     WM 2026-Spielplan laden: football-data.org (alle 104 Spiele) wenn API-Key gesetzt,
     sonst openligadb (Fallback, nur erster Spieltag).
     Returns (updated_count, error_message).
     """
-    if FOOTBALL_API_KEY:
-        return _do_refresh_fdorg(db)
-    return _do_refresh_openligadb(db)
+    if not _refresh_lock.acquire(blocking=False):
+        return 0, "Eine Aktualisierung läuft bereits — bitte gleich erneut versuchen."
+    try:
+        if FOOTBALL_API_KEY:
+            return _do_refresh_fdorg(db)
+        return _do_refresh_openligadb(db)
+    finally:
+        _refresh_lock.release()
 
 
 def _fetch_newsapi_snippets(team_names: list[str], target: date) -> list[str]:
@@ -2553,7 +2565,17 @@ def list_summaries(db: Session = Depends(get_db)):
 
 @router.post("/refresh", response_model=schemas.WmtRefreshOut)
 def manual_refresh(db: Session = Depends(get_db)):
-    n, err_msg = do_refresh(db)
+    try:
+        n, err_msg = do_refresh(db)
+    except Exception as exc:
+        # Ein unbehandelter Fehler würde als nacktes 500 enden und im Frontend
+        # nur "Fehler beim Refresh" anzeigen — Ursache stattdessen sichtbar machen.
+        logger.exception("WMT refresh failed")
+        db.rollback()
+        return schemas.WmtRefreshOut(
+            message=f"Refresh fehlgeschlagen: {type(exc).__name__}: {str(exc)[:300]}",
+            updated=0,
+        )
     if err_msg:
         return schemas.WmtRefreshOut(message=err_msg, updated=0)
     return schemas.WmtRefreshOut(

--- a/frontend/src/pages/Wmt.jsx
+++ b/frontend/src/pages/Wmt.jsx
@@ -660,7 +660,7 @@ export default function Wmt() {
       if (!isErr) await loadAll()
       addLog('Ansicht aktualisiert', 'done')
     } catch (e) {
-      addLog('Fehler beim Refresh', 'error')
+      addLog(`Fehler beim Refresh${e?.message ? ` — ${e.message}` : ''}`, 'error')
     } finally {
       setRefreshing(false)
     }
@@ -977,7 +977,7 @@ export default function Wmt() {
             }}>
             {anyBusy ? '…' : '☰'}
           </button>
-          <span className="topbar-version">v3.6</span>
+          <span className="topbar-version">v3.7</span>
         </div>
       </div>
 


### PR DESCRIPTION
Since real match data started arriving, manual refreshes frequently fail with a bare "Fehler beim Refresh" and nothing updates. Two fixes plus a logging repair:

**1. Refresh errors are now visible instead of an opaque 500.**
Any unhandled exception in `do_refresh` previously surfaced as a bare HTTP 500, which the frontend can only render as the generic catch-all message. `POST /api/wmt/refresh` now catches the exception, rolls the session back, logs the full traceback (visible in Railway logs), and returns `Refresh fehlgeschlagen: <ExceptionType>: <text>` in the response so the Import log shows the actual cause. The frontend catch handler also appends the HTTP status (`POST /wmt/refresh → 502` etc.), so a network/proxy-level failure is distinguishable from a backend exception.

**2. Concurrent refreshes are serialized.**
`do_refresh` runs both from the 30-minute scheduler job in `main.py` and from the manual burger-menu button. Before the tournament every refresh was a no-op, so overlap was harmless; since real results arrive, every refresh writes scores, ELO updates and regenerated predictions. Two overlapping runs each see the same matches as "newly finished" and apply them to the ELOs twice — reproduced in a concurrency stress test (3 parallel refreshes → `matches_played` and ELO deltas applied 3×). A non-blocking module-level lock now serializes refreshes; a concurrent caller gets a graceful "Aktualisierung läuft bereits" message instead of racing.

**3. Scheduler logging bug.**
`_wmt_refresh` in `main.py` treated the `(count, error)` tuple returned by `do_refresh` as a plain count — always truthy, and scheduler-side refresh errors were silently dropped. Now unpacked and the error logged as a warning.

wmt v3.6 → v3.7. `npm run build` passes.

Note: if ELO values were corrupted by the concurrency race since June 11, a one-time "Historische Kalibrierung" (burger menu) after deployment recomputes them cleanly.

https://claude.ai/code/session_01Nb1JYTrBt7rUVBZtKavuEq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nb1JYTrBt7rUVBZtKavuEq)_