### PR TITLE
wmt: grey overlay for completely wrong opponent tips

### DIFF
--- a/frontend/src/pages/Wmt.jsx
+++ b/frontend/src/pages/Wmt.jsx
@@ -977,7 +977,7 @@ export default function Wmt() {
             }}>
             {anyBusy ? '…' : '☰'}
           </button>
-          <span className="topbar-version">v3.9</span>
+          <span className="topbar-version">v3.10</span>
         </div>
       </div>
 
@@ -1838,7 +1838,7 @@ const TIP_OVERLAYS = {
   exact:    'rgba(255, 64, 255, 0.24)',  // Magenta — exaktes Ergebnis
   diff:     'rgba(0, 200, 255, 0.24)',   // Cyan — richtige Tordifferenz
   tendency: 'rgba(241, 196, 15, 0.24)',  // Gelb — nur Tendenz (Sieger) richtig
-  wrong:    'rgba(231, 76, 60, 0.22)',   // Rot — komplett daneben
+  wrong:    'rgba(128, 128, 128, 0.25)', // Grau — komplett daneben
 }
 
 function tipOverlay(m, t) {


### PR DESCRIPTION
Completely wrong tips in the Konkurrenz cards now get a neutral grey overlay (`rgba(128,128,128,0.25)`) instead of red, so only actual hits (magenta / cyan / yellow) carry color. Works as a tint in both themes.

wmt v3.9 → v3.10. `npm run build` passes.

https://claude.ai/code/session_01Nb1JYTrBt7rUVBZtKavuEq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nb1JYTrBt7rUVBZtKavuEq)_