### PR TITLE
wmt: full-row tip overlays + newest match first in Konkurrenz

### DIFF
--- a/frontend/src/pages/Wmt.jsx
+++ b/frontend/src/pages/Wmt.jsx
@@ -977,7 +977,7 @@ export default function Wmt() {
             }}>
             {anyBusy ? '…' : '☰'}
           </button>
-          <span className="topbar-version">v3.10</span>
+          <span className="topbar-version">v3.11</span>
         </div>
       </div>
 
@@ -1918,13 +1918,13 @@ function KonkurrenzView({ matches, opponentTips, rankingSnapshots }) {
 
             <div style={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
               {tips.map(t => (
-                <div key={t.id} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', fontSize: 12 }}>
+                <div key={t.id} style={{
+                  display: 'flex', justifyContent: 'space-between', alignItems: 'center', fontSize: 12,
+                  background: tipOverlay(m, t) ?? 'transparent',
+                  borderRadius: 4, padding: '1px 6px', margin: '0 -6px',
+                }}>
                   <span style={{ color: 'var(--text-secondary)' }}>{t.player_name}</span>
-                  <span style={{
-                    color: 'var(--text-primary)', fontVariantNumeric: 'tabular-nums',
-                    background: tipOverlay(m, t) ?? 'transparent',
-                    borderRadius: 4, padding: '0 6px',
-                  }}>{t.pred_home_goals}:{t.pred_away_goals}</span>
+                  <span style={{ color: 'var(--text-primary)', fontVariantNumeric: 'tabular-nums' }}>{t.pred_home_goals}:{t.pred_away_goals}</span>
                 </div>
               ))}
             </div>

--- a/frontend/src/pages/Wmt.jsx
+++ b/frontend/src/pages/Wmt.jsx
@@ -1861,10 +1861,11 @@ function KonkurrenzView({ matches, opponentTips, rankingSnapshots }) {
     tipsByMatch[t.match_id].push(t)
   }
 
+  // Neueste Spiele zuerst — das jüngste steht direkt unter dem Ranking-Chart
   const matchIds = Object.keys(tipsByMatch)
     .map(Number)
     .filter(id => matchById[id])
-    .sort((a, b) => new Date(matchById[a].utc_date) - new Date(matchById[b].utc_date))
+    .sort((a, b) => new Date(matchById[b].utc_date) - new Date(matchById[a].utc_date))
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>


### PR DESCRIPTION
Two Konkurrenz-tab tweaks:

**1. Full-row tip overlays.** The hit-quality overlay now stretches across the whole row — player name and tip — instead of being a small chip behind the score only. Negative side margins compensate the row padding so the text columns stay aligned with the rest of the card content.

**2. Newest match first.** The match cards are now sorted newest-first, so the latest game sits directly below the ranking chart.

wmt v3.10 → v3.11. `npm run build` passes.

https://claude.ai/code/session_01Nb1JYTrBt7rUVBZtKavuEq