### PR TITLE
fix(wmt): resolve teams by api_id when football-data.org changes a TLA

### DIFF
--- a/backend/routers/wmt.py
+++ b/backend/routers/wmt.py
@@ -92,10 +92,15 @@ def _upsert_fdorg_team(db: Session, team_data: dict) -> Optional[models.WmtTeam]
     tla = (team_data.get("tla") or "").strip().upper() or None
     if not tla:
         return None
-    team = db.query(models.WmtTeam).filter_by(tla=tla).first()
     name = team_data.get("name") or "Unknown"
     short_name = team_data.get("shortName") or name
     api_id = team_data.get("id")
+    team = db.query(models.WmtTeam).filter_by(tla=tla).first()
+    if not team and api_id:
+        # football-data.org kann die TLA eines Teams nachträglich ändern; die
+        # api_id ist der stabile Schlüssel. Ohne diesen Fallback würde ein
+        # Re-Insert die Unique-Constraint auf api_id verletzen.
+        team = db.query(models.WmtTeam).filter_by(api_id=api_id).first()
     if not team:
         team = models.WmtTeam(
             api_id=api_id,
@@ -109,10 +114,18 @@ def _upsert_fdorg_team(db: Session, team_data: dict) -> Optional[models.WmtTeam]
         db.flush()
     else:
         team.name = name
+        team.tla = tla
         if short_name:
             team.short_name = short_name
-        if api_id:
-            team.api_id = api_id
+        if api_id and team.api_id != api_id:
+            holder = db.query(models.WmtTeam).filter_by(api_id=api_id).first()
+            if holder is None:
+                team.api_id = api_id
+            else:
+                logger.warning(
+                    "WMT: api_id %s für %s bereits von Team #%s belegt — nicht übernommen",
+                    api_id, tla, holder.id,
+                )
     return team
 
 


### PR DESCRIPTION
The surfaced error from #259's diagnostics revealed the actual root cause of the refresh failures since real match data arrived:

```
IntegrityError: (psycopg2.errors.UniqueViolation) duplicate key value violates
unique constraint "wmt_teams_api_id_key"  DETAIL: Key (api_id)=(9460) already exists.
[SQL: INSERT INTO wmt_teams ...]
```

`_upsert_fdorg_team` resolved teams **by TLA only**. football-data.org changed at least one team's TLA after go-live; the TLA lookup then missed the existing row and the code tried to INSERT a "new" team with the same `api_id` — unique violation, full transaction rollback, no data updated. Intermittent because the failure only occurs on refreshes that reach the team-insert flush before other changes.

**Fix:** the upsert now falls back to an `api_id` lookup before inserting (api_id is the stable key) and updates the stored TLA from the API, so the row self-heals while keeping its ELO, `matches_played` bookkeeping and all FK references (matches, factors, predictions). Assigning an api_id to a TLA-matched row is also guarded so it never steals an api_id already held by another row (warning logged instead).

Verified with a regression test against PostgreSQL: seeded a team as `api_id=9460, tla=CUW`, refreshed with a payload sending `api_id=9460, tla=CUR` — previously crashed with the exact production error; now updates the row in place (TLA → CUR, ELO/bookkeeping unchanged, no duplicate row).

Backend-only — no wmt version bump.

https://claude.ai/code/session_01Nb1JYTrBt7rUVBZtKavuEq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nb1JYTrBt7rUVBZtKavuEq)_