### PR TITLE
drv: persist rides server-side so they survive the app being discarded

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -17,7 +17,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 
 from .database import engine, Base, SessionLocal
 from .models import TtsEntry
-from .routers import tts, cal, idx, strings, bpm, scan, wmt
+from .routers import tts, cal, idx, strings, bpm, scan, wmt, drv
 from .routers.wmt import (
     do_refresh as _wmt_do_refresh,
     do_generate_summary as _wmt_do_summary,
@@ -181,6 +181,7 @@ app.include_router(strings.router, prefix="/api/str", tags=["str"])
 app.include_router(bpm.router,      prefix="/api/bpm",      tags=["bpm"])
 app.include_router(scan.router,     prefix="/api/bpm/scan", tags=["scan"])
 app.include_router(wmt.router,      prefix="/api/wmt",      tags=["wmt"])
+app.include_router(drv.router,      prefix="/api/drv",      tags=["drv"])
 
 FRONTEND_DIST = Path(__file__).parent.parent / "frontend" / "dist"
 GAMES_DIR = Path(__file__).parent.parent / "games"

--- a/backend/models.py
+++ b/backend/models.py
@@ -184,3 +184,21 @@ class WmtRankingSnapshot(Base):
     snapshot_time = Column(DateTime, nullable=True)
 
 
+# ── drv ────────────────────────────────────────────────────────────────────────
+
+class DrvRide(Base):
+    """A driving session. The active ride (ended_at IS NULL) is the source of
+    truth so timers survive the page being discarded (e.g. switching apps).
+    drive_ms/wait_ms hold committed time; the in-progress segment is computed
+    from seg_start on read."""
+    __tablename__ = "drv_rides"
+    id           = Column(BigInteger, primary_key=True, autoincrement=True)
+    started_at   = Column(DateTime, default=datetime.utcnow, nullable=False)
+    ended_at     = Column(DateTime, nullable=True)
+    drive_ms     = Column(BigInteger, nullable=False, default=0)
+    wait_ms      = Column(BigInteger, nullable=False, default=0)
+    mode         = Column(String, nullable=True)   # 'drive' | 'wait' | None
+    seg_start    = Column(DateTime, nullable=True)  # start of the current segment
+    alternations = Column(Integer, nullable=False, default=0)
+
+

--- a/backend/routers/drv.py
+++ b/backend/routers/drv.py
@@ -1,0 +1,112 @@
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from .. import models, schemas
+from ..database import SessionLocal
+
+router = APIRouter()
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def _active_ride(db: Session) -> models.DrvRide | None:
+    return (
+        db.query(models.DrvRide)
+        .filter(models.DrvRide.ended_at.is_(None))
+        .order_by(models.DrvRide.started_at.desc())
+        .first()
+    )
+
+
+def _serialize(ride: models.DrvRide) -> dict:
+    """Build the API view, computing the in-progress segment from seg_start so
+    the client can tick locally from this baseline without clock-skew issues."""
+    active = ride.ended_at is None
+    seg_ms = 0
+    if active and ride.seg_start is not None:
+        seg_ms = max(0, int((datetime.utcnow() - ride.seg_start).total_seconds() * 1000))
+    return {
+        "id": ride.id,
+        "active": active,
+        "mode": ride.mode,
+        "drive_ms": ride.drive_ms,
+        "wait_ms": ride.wait_ms,
+        "alternations": ride.alternations,
+        "current_segment_ms": seg_ms,
+        "started_at": ride.started_at,
+        "ended_at": ride.ended_at,
+    }
+
+
+def _commit_segment(ride: models.DrvRide, now: datetime) -> None:
+    """Fold the elapsed time of the current segment into its accumulator."""
+    if ride.mode is None or ride.seg_start is None:
+        return
+    elapsed = max(0, int((now - ride.seg_start).total_seconds() * 1000))
+    if ride.mode == "drive":
+        ride.drive_ms += elapsed
+    else:
+        ride.wait_ms += elapsed
+
+
+@router.get("/ride/active", response_model=schemas.DrvRideOut | None)
+def get_active(db: Session = Depends(get_db)):
+    ride = _active_ride(db)
+    return _serialize(ride) if ride else None
+
+
+@router.post("/ride/start", response_model=schemas.DrvRideOut)
+def start_ride(db: Session = Depends(get_db)):
+    now = datetime.utcnow()
+    # abandon any ride still open (e.g. never stopped) before starting fresh
+    for stale in db.query(models.DrvRide).filter(models.DrvRide.ended_at.is_(None)).all():
+        stale.ended_at = now
+    ride = models.DrvRide(
+        started_at=now, ended_at=None,
+        drive_ms=0, wait_ms=0,
+        mode="drive", seg_start=now,   # a new ride always starts in drive mode
+        alternations=0,
+    )
+    db.add(ride)
+    db.commit()
+    db.refresh(ride)
+    return _serialize(ride)
+
+
+@router.post("/ride/mode", response_model=schemas.DrvRideOut)
+def set_mode(body: schemas.DrvModeIn, db: Session = Depends(get_db)):
+    ride = _active_ride(db)
+    if not ride:
+        raise HTTPException(404, "no active ride")
+    now = datetime.utcnow()
+    _commit_segment(ride, now)
+    if ride.mode != body.mode:
+        ride.alternations += 1
+    ride.mode = body.mode
+    ride.seg_start = now
+    db.commit()
+    db.refresh(ride)
+    return _serialize(ride)
+
+
+@router.post("/ride/stop", response_model=schemas.DrvRideOut)
+def stop_ride(db: Session = Depends(get_db)):
+    ride = _active_ride(db)
+    if not ride:
+        raise HTTPException(404, "no active ride")
+    now = datetime.utcnow()
+    _commit_segment(ride, now)
+    ride.ended_at = now
+    ride.mode = None
+    ride.seg_start = None
+    db.commit()
+    db.refresh(ride)
+    return _serialize(ride)

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -330,3 +330,20 @@ class WmtStatusOut(BaseModel):
     md3_done: bool = False
     rd32_done: bool = False
 
+
+# ── drv ───────────────────────────────────────────────────────────────────────
+
+class DrvModeIn(BaseModel):
+    mode: str = Field(..., pattern=r'^(drive|wait)$')
+
+class DrvRideOut(BaseModel):
+    id: int
+    active: bool
+    mode: Optional[str]
+    drive_ms: int
+    wait_ms: int
+    alternations: int
+    current_segment_ms: int   # elapsed in the in-progress segment (0 if not active)
+    started_at: UtcDt
+    ended_at: UtcDtOpt
+

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -92,3 +92,11 @@ export const wmt = {
   fakeAll: ()                => post('/wmt/debug/fake-all'),
 }
 
+// ── drv ───────────────────────────────────────────────────────
+export const drv = {
+  getActive: ()              => get('/drv/ride/active'),
+  start: ()                  => post('/drv/ride/start'),
+  setMode: (mode)            => post('/drv/ride/mode', { mode }),
+  stop: ()                   => post('/drv/ride/stop'),
+}
+

--- a/frontend/src/pages/DrivingTracker.jsx
+++ b/frontend/src/pages/DrivingTracker.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
 import { Link } from 'react-router-dom'
+import { drv } from '../api'
 
 const DRIVE = '#2ecc71'
 const WAIT  = '#e8a33d'
@@ -14,65 +15,58 @@ function fmt(ms) {
 }
 
 export default function DrivingTracker() {
-  const [driveMs, setDriveMs]           = useState(0)
-  const [waitMs, setWaitMs]             = useState(0)
-  const [mode, setMode]                 = useState(null)   // 'drive' | 'wait' | null
-  const [active, setActive]             = useState(false)
-  const [alternations, setAlternations] = useState(0)
-  const [result, setResult]             = useState(null)   // { driveMs, waitMs, alternations }
-  const segStart                        = useRef(null)
-  const [, setTick]                     = useState(0)
+  const [ride, setRide]     = useState(null)   // active server ride, or null
+  const [result, setResult] = useState(null)   // finished-ride overlay data
+  const [, setTick]         = useState(0)
+  // baseline for local ticking: time we received `ride` + its segment elapsed
+  const base  = useRef({ t: 0, segMs: 0 })
+  const chain = useRef(Promise.resolve())       // serialises mutations in order
+
+  // store a server ride and capture the tick baseline from it
+  function apply(r) {
+    setRide(r && r.active ? r : null)
+    base.current = { t: Date.now(), segMs: r && r.active ? r.current_segment_ms : 0 }
+  }
+
+  async function refresh() {
+    try { apply(await drv.getActive()) } catch (e) { console.error(e) }
+  }
+
+  // run a mutation serialised after any in-flight one, preserving order
+  function run(fn) {
+    const next = chain.current.then(fn).catch(e => console.error(e))
+    chain.current = next.catch(() => {})
+    return next
+  }
+
+  // resume an in-progress ride on load, and resync whenever the app returns to view
+  useEffect(() => {
+    refresh()
+    function onVisible() { if (document.visibilityState === 'visible') refresh() }
+    document.addEventListener('visibilitychange', onVisible)
+    return () => document.removeEventListener('visibilitychange', onVisible)
+  }, [])
 
   // tick to refresh the live timer while a ride is active
   useEffect(() => {
-    if (!active) return
+    if (!ride?.active) return
     const id = setInterval(() => setTick(t => t + 1), 200)
     return () => clearInterval(id)
-  }, [active])
+  }, [ride?.active])
 
-  // commit the elapsed time of the current segment into its accumulator
-  function flush() {
-    if (!active || !mode || segStart.current == null) return
-    const elapsed = Date.now() - segStart.current
-    if (mode === 'drive') setDriveMs(d => d + elapsed)
-    else                  setWaitMs(w => w + elapsed)
-    segStart.current = Date.now()
-  }
+  const start = () => run(async () => { setResult(null); apply(await drv.start()) })
+  const switchMode = next => run(async () => { if (ride?.active) apply(await drv.setMode(next)) })
+  const stop = () => run(async () => {
+    const r = await drv.stop()
+    setResult({ driveMs: r.drive_ms, waitMs: r.wait_ms, alternations: r.alternations })
+    apply(null)
+  })
 
-  function start() {
-    setDriveMs(0)
-    setWaitMs(0)
-    setAlternations(0)
-    setResult(null)
-    setMode('drive')          // a new ride always starts in drive mode
-    setActive(true)
-    segStart.current = Date.now()
-  }
-
-  function switchMode(next) {
-    if (!active) return
-    flush()
-    if (mode !== next) setAlternations(a => a + 1)
-    setMode(next)
-  }
-
-  function stop() {
-    if (!active) return
-    const elapsed = segStart.current != null ? Date.now() - segStart.current : 0
-    const finalDrive = driveMs + (mode === 'drive' ? elapsed : 0)
-    const finalWait  = waitMs  + (mode === 'wait'  ? elapsed : 0)
-    setDriveMs(finalDrive)
-    setWaitMs(finalWait)
-    setResult({ driveMs: finalDrive, waitMs: finalWait, alternations })
-    setActive(false)
-    setMode(null)
-    segStart.current = null
-  }
-
-  // live values (committed accumulator + the running segment)
-  const running = active && segStart.current != null
-  const liveDrive = driveMs + (running && mode === 'drive' ? Date.now() - segStart.current : 0)
-  const liveWait  = waitMs  + (running && mode === 'wait'  ? Date.now() - segStart.current : 0)
+  const active = !!ride?.active
+  const mode = ride?.mode
+  const segNow = active ? base.current.segMs + (Date.now() - base.current.t) : 0
+  const liveDrive = (ride?.drive_ms ?? 0) + (active && mode === 'drive' ? segNow : 0)
+  const liveWait  = (ride?.wait_ms  ?? 0) + (active && mode === 'wait'  ? segNow : 0)
 
   const timerBox = (label, value, accent, on) => (
     <div style={{
@@ -121,7 +115,7 @@ export default function DrivingTracker() {
           <span className="topbar-title">drv</span>
         </div>
         <div className="topbar-right">
-          <span className="topbar-version">v1.0</span>
+          <span className="topbar-version">v1.1</span>
         </div>
       </div>
 


### PR DESCRIPTION
Adds a backend for the `drv` driving time tracker so a ride's timers and state survive the page being discarded — e.g. when you switch to Spotify to change music on mobile and the browser evicts the tab.

## Why
The previous version kept the ride entirely in React state. It already computed elapsed time from wall-clock timestamps (so a merely throttled background tab was fine), but if the mobile browser fully discarded the page, the ride was lost on reload. The server is now the source of truth.

## Backend
- **`DrvRide` model** (`drv_rides` table) — one row per ride; the active ride is `ended_at IS NULL`. `drive_ms`/`wait_ms` hold committed time; the in-progress segment is derived from `seg_start`. Table is auto-created via `Base.metadata.create_all` (no manual migration needed).
- **Schemas** — `DrvModeIn`, `DrvRideOut` (includes a computed `current_segment_ms`).
- **Router** (`/api/drv`):
  - `GET /ride/active` — current active ride, or `null`
  - `POST /ride/start` — abandons any open ride, starts a fresh one in **drive** mode
  - `POST /ride/mode` `{mode}` — commits the current segment, switches mode, counts an alternation on change
  - `POST /ride/stop` — commits the final segment, ends the ride, returns totals
- Segment accumulation happens server-side; responses carry `current_segment_ms` so the client can tick locally **without clock-skew** between browser and server.

## Frontend
- `drv` api namespace (`getActive` / `start` / `setMode` / `stop`).
- `DrivingTracker` now resumes the active ride on load, **resyncs on `visibilitychange`** when the app returns to the foreground, and ticks from the server-provided segment baseline.
- Mutations are serialised through a small promise chain to preserve order.
- Bumped `drv` to **v1.1**.

UI and behaviour are otherwise unchanged from v1.0.

https://claude.ai/code/session_01TqM88aXKLdhZ9XDLoSR5kU

---
_Generated by [Claude Code](https://claude.ai/code/session_01TqM88aXKLdhZ9XDLoSR5kU)_