### PR TITLE
meeting skill: store notes in-repo and open branch + PR on wrap-up

### DIFF
--- a/.claude/skills/meeting/README.md
+++ b/.claude/skills/meeting/README.md
@@ -2,7 +2,8 @@
 
 Live meeting capture for Claude Code: start a meeting, drop notes/facts/decisions/action
 items as it runs, get a structured wrap-up when you're done. Notes are stored as one
-markdown file per meeting under `~/meeting-notes/`.
+markdown file per meeting under `meeting-notes/` **in the repo**, and each meeting is
+published as its own branch + pull request on wrap-up.
 
 ## Use it
 
@@ -10,7 +11,8 @@ markdown file per meeting under `~/meeting-notes/`.
 - **Capture:** just type notes as they come — each line is filed into Notes / Facts /
   Decisions / Action items automatically.
 - **Finish:** `meeting done` → you get a summary + consolidated action items in chat,
-  and the full record saved to `~/meeting-notes/`.
+  the full record saved to `meeting-notes/`, and a dedicated branch + PR opened for it
+  (`meeting-notes/YYYY-MM-DD-HHMM-<slug>`).
 
 ## Install it at work (global)
 
@@ -23,4 +25,5 @@ cp .claude/skills/meeting/SKILL.md ~/.claude/skills/meeting/SKILL.md
 ```
 
 After that, `/meeting` is available in every Claude Code session on that machine.
-Notes always land in `~/meeting-notes/` regardless of which repo you're in.
+In any git repo, notes land in that repo's `meeting-notes/` and wrap-up opens a branch + PR;
+outside a git repo it falls back to `~/meeting-notes/` and skips the PR step.

--- a/.claude/skills/meeting/SKILL.md
+++ b/.claude/skills/meeting/SKILL.md
@@ -9,15 +9,19 @@ A lightweight, stateful note-taker for live meetings. The user runs three phases
 
 ## Where notes live
 
-All meetings are stored as markdown under `~/meeting-notes/`. One file per meeting:
+Meetings are stored as markdown **inside the current repository**, under a `meeting-notes/`
+directory at the repo root. One file per meeting:
 
 ```
-~/meeting-notes/YYYY-MM-DD-HHMM-<slug>.md
+<repo-root>/meeting-notes/YYYY-MM-DD-HHMM-<slug>.md
 ```
 
+- Resolve `<repo-root>` with `git rev-parse --show-toplevel`. Create `meeting-notes/` there if it does not exist (`mkdir -p`).
+- **Fallback (no git repo):** if `git rev-parse` fails (the session is not inside a git repository), fall back to `~/meeting-notes/` and skip the branch/PR steps in Phase 3 — there is nowhere to push.
 - `<slug>` = the meeting title, lowercased, spaces → hyphens, non-alphanumerics stripped (e.g. "Q3 Roadmap Sync" → `q3-roadmap-sync`).
-- Create the `~/meeting-notes/` directory if it does not exist (`mkdir -p`).
-- **Remember the active file path for the whole session.** If you are ever unsure which file is active (e.g. after a long gap), list `~/meeting-notes/` sorted by modification time and Read the newest file before continuing — never start a second file for the same meeting.
+- **Remember the active file path for the whole session.** If you are ever unsure which file is active (e.g. after a long gap), list the `meeting-notes/` directory sorted by modification time and Read the newest file before continuing — never start a second file for the same meeting.
+
+Keeping notes in-repo means every meeting record is versioned and, on wrap-up, lands in a pull request (see Phase 3) so it survives beyond this ephemeral session.
 
 ## Phase 1 — Start
 
@@ -82,12 +86,31 @@ Trigger: "meeting done", "wrap up", "end meeting", "/meeting done".
 <anything unresolved or flagged "?".>
 ```
 
-3. Then post the **same wrap-up in chat** so the user can copy/paste it into email or a tracker immediately. Lead with the action items, since those are what people act on.
-4. End with the file path so they know where the full record lives.
+3. **Publish the record as a pull request** (skip this whole step only in the no-git fallback). The goal is one branch + one PR per meeting, containing just this meeting's notes file:
+   1. Find the default branch (usually `main`): `git remote show origin | grep 'HEAD branch'`, or assume `main`.
+   2. Create a dedicated branch off the up-to-date default branch so the PR contains only the meeting note:
+      ```bash
+      git fetch origin <default>
+      git checkout -b meeting-notes/YYYY-MM-DD-HHMM-<slug> origin/<default>
+      ```
+      The notes file is untracked, so it carries over to the new branch. If the checkout fails (e.g. conflicting tracked changes in the working tree), fall back to branching off the current HEAD: `git checkout -b meeting-notes/YYYY-MM-DD-HHMM-<slug>`.
+   3. Stage **only** the meeting note (never `git add -A` — don't sweep in unrelated work) and commit:
+      ```bash
+      git add meeting-notes/YYYY-MM-DD-HHMM-<slug>.md
+      git commit -m "Add meeting notes: <Title> (YYYY-MM-DD)"
+      ```
+   4. Push with upstream tracking, retrying on network errors with exponential backoff (2s, 4s, 8s, 16s):
+      ```bash
+      git push -u origin meeting-notes/YYYY-MM-DD-HHMM-<slug>
+      ```
+   5. Open a PR against the default branch. Prefer the GitHub MCP tool `create_pull_request` (title = `Meeting notes: <Title> (YYYY-MM-DD)`, body = the wrap-up summary + action items). If no GitHub MCP/`gh` access is available, push anyway and tell the user the branch is ready and they can open the PR manually.
+4. Then post the **same wrap-up in chat** so the user can copy/paste it into email or a tracker immediately. Lead with the action items, since those are what people act on.
+5. End with the file path **and the PR link** (or the branch name if the PR couldn't be created automatically) so they know where the full record lives.
 
 ## Conventions
 
 - Times and dates are the user's **local** time. Get the real current time (`date`) rather than guessing.
-- One meeting = one file. Multiple meetings the same day get distinct `HHMM` prefixes and slugs.
-- Never delete past meeting files. To review history, list/Read under `~/meeting-notes/`.
+- One meeting = one file = one branch = one PR. Multiple meetings the same day get distinct `HHMM` prefixes and slugs (and therefore distinct branches).
+- Never delete past meeting files. To review history, list/Read under `<repo-root>/meeting-notes/`.
+- During capture (Phase 2) the notes file stays uncommitted in the working tree on whatever branch is checked out — only Phase 3 creates the branch, commit, and PR. This keeps note-taking fast and non-disruptive to any other work in progress.
 - If the user asks mid-session for "what do we have so far", Read the file and give a quick interim summary without changing Status.

--- a/meeting-notes/2026-06-13-2242-test123.md
+++ b/meeting-notes/2026-06-13-2242-test123.md
@@ -1,0 +1,39 @@
+# test123
+
+- **Date:** 2026-06-13 22:42
+- **Status:** done
+
+## Notes
+
+- Verguss kann erst nach Versuchen bewertet werden
+
+## Facts
+
+- Angebot für die Gesamtbaugruppe kommt nächsten Dienstag (2026-06-16)
+- ISO-Bauteile haben 16 Wochen Lieferzeit
+
+## Decisions
+
+## Action items
+
+- [ ] Angebot für Dummy-Leiterplatten einholen — **Herr Bauer** (due: ?)
+- [ ] LP-Daten für Verguss-Versuche übergeben — **Santiago** (due: ?)
+- [ ] Broker für ISO-Bauteile anfragen — **TQS** (due: ?)
+- [ ] Mit Einkauf checken, ob Konsilager für FPGAs möglich ist — **?** (due: ?)
+
+## Summary
+Besprechung zum Status der Gesamtbaugruppe mit Fokus auf Beschaffung und Vergussthematik. Das Angebot für die Gesamtbaugruppe wird für nächsten Dienstag (2026-06-16) erwartet. Bei der Materialbeschaffung sind die ISO-Bauteile mit 16 Wochen Lieferzeit ein kritischer Punkt; hier wird parallel ein Broker über TQS angefragt. Für die Vergussbewertung müssen erst Versuche durchgeführt werden, wofür Santiago die LP-Daten liefert und Herr Bauer ein Angebot für Dummy-Leiterplatten einholt. Zusätzlich wird geprüft, ob für die FPGAs ein Konsignationslager möglich ist.
+
+## Key decisions
+- Verguss wird erst nach Durchführung der Versuche bewertet (keine Vorabbewertung).
+
+## Action items
+- [ ] Angebot für Dummy-Leiterplatten einholen — **Herr Bauer** (due: ?)
+- [ ] LP-Daten für Verguss-Versuche übergeben — **Santiago** (due: ?)
+- [ ] Broker für ISO-Bauteile anfragen — **TQS** (due: ?)
+- [ ] Mit Einkauf checken, ob Konsilager für FPGAs möglich ist — **?** (due: ?)
+
+## Open questions
+- Wer übernimmt die Konsilager-Abklärung für FPGAs mit dem Einkauf?
+- Fälligkeiten/Termine für alle Action Items noch offen.
+- Reicht die 16-Wochen-Lieferzeit der ISO-Bauteile für den Projektplan, bzw. löst der Broker das?


### PR DESCRIPTION
## Was

Passt den `meeting`-Skill an, damit Meeting-Notizen versioniert werden und jedes Meeting beim Wrap-up als eigener Branch + PR landet.

### Änderungen

- **Notizen liegen jetzt im Repo** unter `meeting-notes/YYYY-MM-DD-HHMM-<slug>.md` (statt `~/meeting-notes/`). Fallback auf `~/meeting-notes/` ohne PR-Schritt, falls die Session nicht in einem Git-Repo läuft.
- **Wrap-up (`meeting done`)** erstellt automatisch einen dedizierten Branch `meeting-notes/<…>` vom aktuellen `main`, committet **nur** die Notiz-Datei, pusht mit Retry/Backoff und öffnet einen PR gegen `main`. PR-Link wird im Chat ausgegeben.
- Während des Meetings bleibt die Datei uncommitted im Working Tree — Branch/Commit/PR passieren erst beim Wrap-up.
- README des Skills entsprechend aktualisiert.

### Enthält außerdem

- Die Notizdatei des Test-Meetings `test123` (`meeting-notes/2026-06-13-2242-test123.md`), aus dem alten `~/meeting-notes/`-Pfad ins Repo verschoben.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MQzapfacuCc2M7wFpphtci)_