### PR TITLE
wmt: hide import empty-state on matthiasweigel.com

### DIFF
--- a/frontend/src/pages/Wmt.jsx
+++ b/frontend/src/pages/Wmt.jsx
@@ -997,7 +997,7 @@ export default function Wmt() {
               {anyBusy ? '…' : '☰'}
             </button>
           )}
-          <span className="topbar-version">v3.23</span>
+          <span className="topbar-version">v3.24</span>
         </div>
       </div>
 
@@ -2063,12 +2063,16 @@ function KonkurrenzView({ matches, opponentTips, rankingSnapshots }) {
       {matchIds.length > 0 && <TipLegend />}
 
       {matchIds.length === 0 ? (
-        <div style={{ background: 'var(--surface)', border: '1px solid var(--border)', borderRadius: 10, padding: 24, textAlign: 'center' }}>
-          <div style={{ fontSize: 13, color: 'var(--text-secondary)' }}>Noch keine Tipps der Mitspieler importiert.</div>
-          <div style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 6 }}>
-            Sobald die Tipps in der Tipprunde sichtbar sind, können Screenshots zum Import übergeben werden.
+        // Opponents-only mirror: don't leak the screenshot-import workflow —
+        // just show nothing until tips exist (e.g. during a Railway deploy).
+        wmtOnly ? null : (
+          <div style={{ background: 'var(--surface)', border: '1px solid var(--border)', borderRadius: 10, padding: 24, textAlign: 'center' }}>
+            <div style={{ fontSize: 13, color: 'var(--text-secondary)' }}>Noch keine Tipps der Mitspieler importiert.</div>
+            <div style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 6 }}>
+              Sobald die Tipps in der Tipprunde sichtbar sind, können Screenshots zum Import übergeben werden.
+            </div>
           </div>
-        </div>
+        )
       ) : matchIds.map(mid => {
         const m = matchById[mid]
         const tips = tipsByMatch[mid]


### PR DESCRIPTION
When no opponent tips exist (e.g. transiently while Railway is rebuilding/redeploying), `matthiasweigel.com` showed the empty-state card *"Noch keine Tipps der Mitspieler importiert. Sobald die Tipps … können Screenshots zum Import übergeben werden."* — which leaks the internal screenshot-import workflow to fellow players.

This hides that card on the opponents-only mirror (renders nothing until tips exist). The full site (`matmaxx.org` / `/wmt`) still shows it.

Bumps wmt `v3.23 → v3.24`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNrtkef5W64ZDysPNrHLU1)_