### PR TITLE
backend: pin tzlocal to fix deploy crash

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,5 +4,6 @@ sqlalchemy==2.0.35
 psycopg2-binary==2.9.10
 pydantic==2.9.2
 apscheduler==3.11.2
+tzlocal==5.2
 httpx==0.27.2
 anthropic==0.40.0


### PR DESCRIPTION
The Railway deploy crashed on startup with `ModuleNotFoundError: No module named 'tzlocal'`.

APScheduler 3.11 needs `tzlocal` at runtime, but it wasn't installed in the fresh Railway build (it's a transitive dep that didn't get pulled). This declares `tzlocal==5.2` explicitly in `backend/requirements.txt` so startup no longer crashes.

No code changes — backend dependency only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNrtkef5W64ZDysPNrHLU1)_