### PR TITLE
Add global back-to-top flyout

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import { ThemeProvider } from './context/ThemeContext'
 import ThemeToggle from './components/ThemeToggle'
+import BackToTop from './components/BackToTop'
 import { isWmtOnlyDomain } from './domain'
 import Home from './pages/Home'
 import Productivity from './pages/Productivity'
@@ -22,6 +23,7 @@ export default function App() {
   return (
     <ThemeProvider>
       <ThemeToggle />
+      <BackToTop />
       <BrowserRouter>
         <Routes>
           {wmtOnly ? (

--- a/frontend/src/components/BackToTop.jsx
+++ b/frontend/src/components/BackToTop.jsx
@@ -1,0 +1,41 @@
+import { useState, useEffect } from 'react'
+
+function ArrowUpIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M8 13V3" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round"/>
+      <path d="M3.5 7.5 8 3l4.5 4.5" stroke="currentColor" strokeWidth="1.6"
+        strokeLinecap="round" strokeLinejoin="round"/>
+    </svg>
+  )
+}
+
+// Show the flyout once the user has scrolled far enough that the top sections
+// have left the viewport.
+const SHOW_THRESHOLD = 400
+
+export default function BackToTop() {
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    function onScroll() {
+      setVisible(window.scrollY > SHOW_THRESHOLD)
+    }
+    onScroll()
+    window.addEventListener('scroll', onScroll, { passive: true })
+    return () => window.removeEventListener('scroll', onScroll)
+  }, [])
+
+  if (!visible) return null
+
+  return (
+    <button
+      className="back-to-top"
+      title="Back to top"
+      aria-label="Back to top"
+      onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+    >
+      <ArrowUpIcon />
+    </button>
+  )
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1067,3 +1067,25 @@ input, textarea, select {
   background: var(--text-secondary);
   border-color: var(--text-secondary);
 }
+
+/* ── Back-to-top flyout ──────────────────────────────────────── */
+.back-to-top {
+  position: fixed;
+  right: 16px;
+  bottom: 16px;
+  bottom: calc(16px + env(safe-area-inset-bottom, 0px));
+  width: 40px; height: 40px;
+  display: flex; align-items: center; justify-content: center;
+  background: var(--surface);
+  color: var(--text-secondary);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.25);
+  z-index: 200;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+.back-to-top:hover {
+  color: var(--text-primary);
+  border-color: var(--border-hover);
+  background: var(--surface-alt);
+}


### PR DESCRIPTION
Adds a site-wide "back to top" flyout.

## What
- **`frontend/src/components/BackToTop.jsx`** — new component that watches the window scroll position and appears once the page is scrolled past the top sections (~400px). It's a rounded-rectangle button with an upward arrow pinned to the bottom-right corner. Clicking it smooth-scrolls to the top; it auto-hides when the top is reached (by click or manual scroll-up).
- **`frontend/src/App.jsx`** — renders `<BackToTop />` globally next to `<ThemeToggle />`, outside the router, so it appears on every page.
- **`frontend/src/index.css`** — `.back-to-top` styling using theme CSS variables (works in dark + light mode), hover state, and iOS safe-area inset handling.

## Notes
- No per-tool version bumped — this is a site-wide component, not a change to a specific tool.
- Uses a 400px scroll threshold for "far enough."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015pCt9cqAwbgut6tHgwwdXf)_