### PR TITLE
Fix scheduler startup crash: use timezone.utc object instead of "utc" string

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -206,7 +206,10 @@ async def lifespan(app: FastAPI):
         logger.error("DB init failed after 5 attempts — running without DB")
 
     global scheduler
-    scheduler = AsyncIOScheduler(timezone="utc")
+    # Pass a tzinfo object, not "utc"/"UTC": APScheduler resolves timezone
+    # strings via zoneinfo, which raises ZoneInfoNotFoundError on containers
+    # without the IANA tz database. timezone.utc avoids that lookup entirely.
+    scheduler = AsyncIOScheduler(timezone=timezone.utc)
     scheduler.add_job(
         _close_open_tts_entries,
         CronTrigger(hour=23, minute=0),


### PR DESCRIPTION
## Problem

The latest deploy crashed on startup with:

```
zoneinfo._common.ZoneInfoNotFoundError: 'No time zone found with key utc'
```

This came from `AsyncIOScheduler(timezone="utc")`, introduced with the adaptive WMT scheduler. APScheduler resolves timezone **strings** through Python's `zoneinfo`, which requires the IANA tz database — the Railway container doesn't ship one. The key is also case-sensitive, so `"utc"` never matches (and even `"UTC"` would be fragile without tzdata).

## Fix

Pass the `datetime.timezone.utc` **object** instead of a string. A `tzinfo` object bypasses the `zoneinfo` lookup entirely, so it works whether or not tzdata is present. The resulting scheduler is still UTC.

## Verification

- Reproduced the exact crash locally: `"utc"` → `ZoneInfoNotFoundError`; `timezone.utc` → resolves to `UTC`.
- Confirmed both the `CronTrigger` (EOD / summary / news jobs) and the `DateTrigger` (self-rescheduling WMT refresh) build cleanly under `timezone.utc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QaT3YTvYVvhov9HVB4FNyJ)_