### PR TITLE
Fix update-log domain gate: matmaxx.org instead of mitmachen.org

### DIFF
--- a/frontend/src/domain.js
+++ b/frontend/src/domain.js
@@ -6,8 +6,8 @@ export function isWmtOnlyDomain() {
   return WMT_ONLY_HOSTS.includes(window.location.hostname)
 }
 
-// The update log (scheduler run history) is only exposed on mitmachen.org.
-const UPDATE_LOG_HOSTS = ['mitmachen.org', 'www.mitmachen.org']
+// The update log (scheduler run history) is only exposed on matmaxx.org.
+const UPDATE_LOG_HOSTS = ['matmaxx.org', 'www.matmaxx.org']
 
 export function isUpdateLogDomain() {
   return UPDATE_LOG_HOSTS.includes(window.location.hostname)


### PR DESCRIPTION
## Problem

The `/update-log` page and its Home-page link were gated to `mitmachen.org` — a typo (iPhone autocorrect). The page therefore never showed on the real domain.

## Fix

Point `UPDATE_LOG_HOSTS` in `frontend/src/domain.js` at the correct domain: `matmaxx.org` / `www.matmaxx.org`.

## Verification

- `grep` confirms no remaining references to the wrong host.
- `npm run build` passes.

After deploy, the update log will be reachable at `https://matmaxx.org/update-log` (and via the "update log" link on the matmaxx.org home page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QaT3YTvYVvhov9HVB4FNyJ)_