### PR TITLE
Make update-log a visible nav-card button on the Home page

### DIFF
--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -41,6 +41,13 @@ export default function Home() {
             <div className="nav-card-arrow">→</div>
           </Link>
         ))}
+        {isUpdateLogDomain() && (
+          <Link to="/update-log" className="nav-card">
+            <div className="nav-card-label">sys</div>
+            <div className="nav-card-name">update log</div>
+            <div className="nav-card-arrow">→</div>
+          </Link>
+        )}
       </nav>
       {deployLabel && (
         <div className="landing-deploy">
@@ -48,11 +55,6 @@ export default function Home() {
             ? <a href={deployUrl} target="_blank" rel="noopener noreferrer">{deployLabel}</a>
             : <span>{deployLabel}</span>
           }
-        </div>
-      )}
-      {isUpdateLogDomain() && (
-        <div className="landing-deploy">
-          <Link to="/update-log">update log</Link>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Problem

The update-log feature is correctly deployed and the page works (`/update-log` returns 200 on matmaxx.org), but there was no discoverable entry point. I'd implemented the link as a tiny, dim element at the very bottom of the home page, styled identically to the "deployed …" timestamp — easy to miss and not recognisable as a button.

## Fix

Promote it to a proper `.nav-card` inside the home landing grid, alongside productivity / personal / games (label `sys`, name `update log`). Still gated to `matmaxx.org` via `isUpdateLogDomain()`.

The redeploy also produces a fresh JS hash, busting any stale browser cache.

## Verification

- `npm run build` passes.
- The page itself is unchanged and already reachable at `https://matmaxx.org/update-log`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QaT3YTvYVvhov9HVB4FNyJ)_