### PR TITLE
Make update-log status colors readable in light mode

### DIFF
--- a/frontend/src/components/UpdateLogList.jsx
+++ b/frontend/src/components/UpdateLogList.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import { log } from '../api'
+import { useTheme } from '../context/ThemeContext'
 
 function fmt(iso) {
   if (!iso) return '—'
@@ -8,15 +9,19 @@ function fmt(iso) {
   return `${pad(d.getDate())}.${pad(d.getMonth() + 1)}.${d.getFullYear()} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`
 }
 
-function resultColor(result) {
-  if (/^error|^exception/i.test(result)) return '#ff6b6b'
-  if (/updated/i.test(result)) return '#7effa0'
+// Theme-aware status colours: the bright dark-mode green/red are illegible on
+// the light theme's white cards, so use darker shades there.
+function resultColor(result, theme) {
+  const light = theme === 'light'
+  if (/^error|^exception/i.test(result)) return light ? '#c0392b' : '#ff6b6b'
+  if (/updated/i.test(result)) return light ? '#1a7a3e' : '#7effa0'
   return 'var(--text-secondary)'
 }
 
 // Scheduler run log, newest first. Self-contained (fetches on mount), so it can
 // be dropped into any container — currently the WMT "Update-Log" tab.
 export default function UpdateLogList() {
+  const { theme }         = useTheme()
   const [rows, setRows]   = useState(null)   // null = loading
   const [error, setError] = useState(null)
 
@@ -68,7 +73,7 @@ export default function UpdateLogList() {
                 <span style={{ color: 'var(--text-primary)', fontSize: '0.85rem', fontWeight: 500 }}>
                   {fmt(r.ran_at)}
                 </span>
-                <span style={{ color: resultColor(r.result), fontSize: '0.8rem', textAlign: 'right' }}>
+                <span style={{ color: resultColor(r.result, theme), fontSize: '0.8rem', textAlign: 'right' }}>
                   {r.result}
                 </span>
               </div>

--- a/frontend/src/pages/Wmt.jsx
+++ b/frontend/src/pages/Wmt.jsx
@@ -998,7 +998,7 @@ export default function Wmt() {
               {anyBusy ? '…' : '☰'}
             </button>
           )}
-          <span className="topbar-version">v3.26</span>
+          <span className="topbar-version">v3.27</span>
         </div>
       </div>
 


### PR DESCRIPTION
## Problem

In the WMT Update-Log tab, the `N matches updated` text uses a bright green (`#7effa0`) tuned for the dark theme — on the light theme's white cards it's nearly illegible (see screenshot). The error red (`#ff6b6b`) has the same issue.

## Fix

Make `resultColor` theme-aware via `useTheme()`:

| State | Dark | Light |
|-------|------|-------|
| updated | `#7effa0` (unchanged) | `#1a7a3e` |
| error | `#ff6b6b` (unchanged) | `#c0392b` |

Dark mode is untouched; light mode now uses darker shades with proper contrast on white.

`wmt` v3.26 → v3.27.

## Verification

- `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QaT3YTvYVvhov9HVB4FNyJ)_