### PR TITLE
wmt: rotating-sun loading overlay on the opponents mirror

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1089,3 +1089,22 @@ input, textarea, select {
   border-color: var(--border-hover);
   background: var(--surface-alt);
 }
+
+/* WMT loading sun — full-screen rotating sun overlay shown on the
+   opponents-only mirror (matthiasweigel.com) while data loads. */
+.wmt-loading-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--overlay-bg);
+  z-index: 150;
+}
+.wmt-sun-spin {
+  animation: wmt-sun-spin 9s linear infinite;
+  transform-origin: 50% 50%;
+}
+@keyframes wmt-sun-spin {
+  to { transform: rotate(360deg); }
+}

--- a/frontend/src/pages/Wmt.jsx
+++ b/frontend/src/pages/Wmt.jsx
@@ -998,7 +998,7 @@ export default function Wmt() {
               {anyBusy ? '…' : '☰'}
             </button>
           )}
-          <span className="topbar-version">v3.34</span>
+          <span className="topbar-version">v3.35</span>
         </div>
       </div>
 
@@ -1151,9 +1151,26 @@ export default function Wmt() {
         )}
 
         {loading && view !== 'import' && view !== 'updatelog' && (
-          <div style={{ color: 'var(--text-dim)', fontSize: 12 }}>
-            {wmtOnly ? 'Daten werden geladen…' : '…'}
-          </div>
+          wmtOnly ? (
+            <div className="wmt-loading-overlay" role="status" aria-label="Daten werden geladen">
+              <svg className="wmt-sun-spin" width="96" height="96" viewBox="-50 -50 100 100">
+                <circle cx="0" cy="0" r="20" fill="#ffb300" />
+                {Array.from({ length: 12 }).map((_, i) => {
+                  const a = (i * 30) * Math.PI / 180
+                  return (
+                    <line
+                      key={i}
+                      x1={Math.cos(a) * 28} y1={Math.sin(a) * 28}
+                      x2={Math.cos(a) * 42} y2={Math.sin(a) * 42}
+                      stroke="#f5a623" strokeWidth="5" strokeLinecap="round"
+                    />
+                  )
+                })}
+              </svg>
+            </div>
+          ) : (
+            <div style={{ color: 'var(--text-dim)', fontSize: 12 }}>…</div>
+          )
         )}
 
         {/* ── Update-Log view (matmaxx.org only) ─────────────────────────── */}


### PR DESCRIPTION
On matthiasweigel.com (the opponents-only mirror) show a slowly rotating
sun (SVG circle + 12 rays) centered in a full-screen overlay while data
loads, instead of the "Daten werden geladen…" text. matmaxx.org keeps its
existing minimal "…" indicator and is unaffected.

Bump wmt to v3.35.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BYra5SjCBmbp8wUoQpoHNB