### PR TITLE
wmt: classic ticking spinner over the empty opponents page

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1090,21 +1090,23 @@ input, textarea, select {
   background: var(--surface-alt);
 }
 
-/* WMT loading sun — full-screen rotating sun overlay shown on the
-   opponents-only mirror (matthiasweigel.com) while data loads. */
+/* WMT loading spinner — classic ticking throbber centered over the page,
+   shown on the opponents-only mirror (matthiasweigel.com) while data loads.
+   The overlay has no backdrop and ignores pointer events so the (empty)
+   opponents page stays visible behind it. */
 .wmt-loading-overlay {
   position: fixed;
   inset: 0;
   display: flex;
   align-items: center;
   justify-content: center;
-  background: var(--overlay-bg);
   z-index: 150;
+  pointer-events: none;
 }
-.wmt-sun-spin {
-  animation: wmt-sun-spin 9s linear infinite;
+.wmt-spinner {
+  animation: wmt-spinner-spin 0.9s steps(8) infinite;
   transform-origin: 50% 50%;
 }
-@keyframes wmt-sun-spin {
+@keyframes wmt-spinner-spin {
   to { transform: rotate(360deg); }
 }

--- a/frontend/src/pages/Wmt.jsx
+++ b/frontend/src/pages/Wmt.jsx
@@ -998,7 +998,7 @@ export default function Wmt() {
               {anyBusy ? '…' : '☰'}
             </button>
           )}
-          <span className="topbar-version">v3.35</span>
+          <span className="topbar-version">v3.36</span>
         </div>
       </div>
 
@@ -1153,16 +1153,16 @@ export default function Wmt() {
         {loading && view !== 'import' && view !== 'updatelog' && (
           wmtOnly ? (
             <div className="wmt-loading-overlay" role="status" aria-label="Daten werden geladen">
-              <svg className="wmt-sun-spin" width="96" height="96" viewBox="-50 -50 100 100">
-                <circle cx="0" cy="0" r="20" fill="#ffb300" />
-                {Array.from({ length: 12 }).map((_, i) => {
-                  const a = (i * 30) * Math.PI / 180
+              <svg className="wmt-spinner" width="72" height="72" viewBox="-50 -50 100 100">
+                {Array.from({ length: 8 }).map((_, i) => {
+                  const a = (i * 45) * Math.PI / 180
                   return (
                     <line
                       key={i}
-                      x1={Math.cos(a) * 28} y1={Math.sin(a) * 28}
-                      x2={Math.cos(a) * 42} y2={Math.sin(a) * 42}
-                      stroke="#f5a623" strokeWidth="5" strokeLinecap="round"
+                      x1={Math.cos(a) * 22} y1={Math.sin(a) * 22}
+                      x2={Math.cos(a) * 40} y2={Math.sin(a) * 40}
+                      stroke="var(--text-secondary)" strokeWidth="8" strokeLinecap="round"
+                      opacity={(i + 1) / 8}
                     />
                   )
                 })}


### PR DESCRIPTION
Replace the rotating sun with the classic throbber — 8 rounded spokes
with opacity fading around the ring, ticking via steps(8) — matching the
requested look. Drop the overlay backdrop and set pointer-events: none so
the (empty) opponents page stays visible behind the centered spinner
instead of a blank dimmed screen. Spokes use var(--text-secondary) so the
spinner reads in both themes. matmaxx.org keeps its "…" indicator.

Bump wmt to v3.36.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BYra5SjCBmbp8wUoQpoHNB