### PR TITLE
wmt: compact Tipp-Zwillinge matrix into a square

### DIFF
--- a/frontend/src/pages/Wmt.jsx
+++ b/frontend/src/pages/Wmt.jsx
@@ -998,7 +998,7 @@ export default function Wmt() {
               {anyBusy ? '…' : '☰'}
             </button>
           )}
-          <span className="topbar-version">v3.40</span>
+          <span className="topbar-version">v3.41</span>
         </div>
       </div>
 
@@ -2583,7 +2583,7 @@ function TwinsHeatmap({ opponentTips }) {
     return common === 0 ? null : { rate: same / common, common }
   }
 
-  const cell = { width: 34, height: 24, fontSize: 10, textAlign: 'center', fontVariantNumeric: 'tabular-nums' }
+  const cell = { width: 26, height: 26, fontSize: 9, textAlign: 'center', fontVariantNumeric: 'tabular-nums' }
 
   return (
     <StatCard title="Tipp-Zwillinge" hint="Anteil gemeinsam getippter Spiele mit identischem Ergebnis-Tipp. Kräftiger = tippt ähnlicher.">


### PR DESCRIPTION
Make the matrix cells square (26×26, was 34×24) so the NxN grid reads as
a square instead of a wide rectangle. Slightly smaller cell font to suit.

Bump wmt to v3.41.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BYra5SjCBmbp8wUoQpoHNB