### PR TITLE
wmt: fit Tipp-Zwillinge to viewport width + green→red heat palette

### DIFF
--- a/frontend/src/pages/Wmt.jsx
+++ b/frontend/src/pages/Wmt.jsx
@@ -998,7 +998,7 @@ export default function Wmt() {
               {anyBusy ? '…' : '☰'}
             </button>
           )}
-          <span className="topbar-version">v3.43</span>
+          <span className="topbar-version">v3.44</span>
         </div>
       </div>
 
@@ -1836,6 +1836,12 @@ function RankingChart({ snapshots, matches }) {
     const recompute = () => {
       const sc = scrollRef.current
       if (!sc) return
+      const vv = window.visualViewport
+      // When the page is pinch-zoomed (scale > 1) the visual viewport height and
+      // the layout-based getBoundingClientRect().top live in different reference
+      // frames, so the math below produces a garbage height that collapsed the
+      // chart. Skip re-fitting while zoomed and keep the last good height.
+      if (vv && vv.scale > 1.01) return
       const top = sc.getBoundingClientRect().top
       const below = belowRef.current ? belowRef.current.offsetHeight : 0
       // Size against the *visual* viewport (window.visualViewport), which
@@ -1844,9 +1850,9 @@ function RankingChart({ snapshots, matches }) {
       // the back button / address bar. 16 = card's bottom padding; 36 =
       // clearance so the clickable legend stays clear of browser chrome and
       // the iOS home indicator.
-      const vh = window.visualViewport ? window.visualViewport.height : window.innerHeight
+      const vh = vv ? vv.height : window.innerHeight
       const avail = vh - top - below - 16 - 36
-      setSvgH(Math.max(320, avail))
+      setSvgH(Math.max(320, Math.min(1000, avail)))
     }
     recompute()
     // Only re-fit when the viewport *width* changes (real resize / rotation).

--- a/frontend/src/pages/Wmt.jsx
+++ b/frontend/src/pages/Wmt.jsx
@@ -998,7 +998,7 @@ export default function Wmt() {
               {anyBusy ? '…' : '☰'}
             </button>
           )}
-          <span className="topbar-version">v3.42</span>
+          <span className="topbar-version">v3.43</span>
         </div>
       </div>
 
@@ -2583,46 +2583,57 @@ function TwinsHeatmap({ opponentTips }) {
     return common === 0 ? null : { rate: same / common, common }
   }
 
-  // Fixed square size for every matrix cell. We force the square with an inner
-  // flex div (table-cell `height` isn't reliably honored under border-collapse,
-  // which made the grid render as flat rectangles).
-  const SIZE = 24
-  const square = extra => ({ width: SIZE, height: SIZE, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 9, fontVariantNumeric: 'tabular-nums', ...extra })
+  // Green → yellow → red heat scale; red marks the highest similarity.
+  const heat = t => {
+    const stops = [[46, 204, 113], [241, 196, 15], [231, 76, 60]] // grün, gelb, rot
+    const seg = t < 0.5 ? 0 : 1
+    const f = t < 0.5 ? t / 0.5 : (t - 0.5) / 0.5
+    const c0 = stops[seg], c1 = stops[seg + 1]
+    const ch = i => Math.round(c0[i] + (c1[i] - c0[i]) * f)
+    return `rgb(${ch(0)}, ${ch(1)}, ${ch(2)})`
+  }
+
+  // The matrix fills 100% of the card width (table-layout: fixed) and every
+  // cell is forced square via aspect-ratio, so the whole grid fits the viewport
+  // horizontally and stays square regardless of player count.
+  const cellDiv = extra => ({ width: '100%', aspectRatio: '1', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 9, fontVariantNumeric: 'tabular-nums', ...extra })
 
   return (
-    <StatCard title="Tipp-Zwillinge" hint="Anteil gemeinsam getippter Spiele mit identischem Ergebnis-Tipp. Kräftiger = tippt ähnlicher.">
-      <div style={{ overflowX: 'auto' }}>
-        <table style={{ borderCollapse: 'collapse' }}>
-          <thead>
-            <tr>
-              <th style={{ position: 'sticky', left: 0, background: 'var(--surface)' }} />
-              {players.map(p => (
-                <th key={p} title={p} style={{ width: SIZE, verticalAlign: 'bottom', padding: '0 0 6px', fontWeight: 400 }}>
-                  <div style={{ writingMode: 'vertical-rl', transform: 'rotate(180deg)', fontSize: 10, color: 'var(--text-dim)', whiteSpace: 'nowrap', margin: '0 auto' }}>{p}</div>
-                </th>
-              ))}
-            </tr>
-          </thead>
-          <tbody>
-            {players.map(a => (
-              <tr key={a}>
-                <td style={{ position: 'sticky', left: 0, background: 'var(--surface)', fontSize: 12, color: 'var(--text-secondary)', padding: '2px 8px 2px 0', whiteSpace: 'nowrap' }}>{a}</td>
-                {players.map(b => {
-                  if (a === b) return <td key={b} style={{ padding: 0 }}><div style={square({ background: 'var(--surface-alt)' })} /></td>
-                  const s = sim(a, b)
-                  return (
-                    <td key={b} style={{ padding: 0 }} title={s ? `${a} ↔ ${b}: ${Math.round(s.rate * 100)}% von ${s.common} Spielen` : 'keine gemeinsamen Spiele'}>
-                      <div style={square({ color: s && s.rate > 0.5 ? 'var(--text-primary)' : 'var(--text-secondary)', background: s ? `rgba(110, 130, 255, ${0.12 + 0.7 * s.rate})` : 'transparent' })}>
-                        {s ? Math.round(s.rate * 100) : '–'}
-                      </div>
-                    </td>
-                  )
-                })}
-              </tr>
+    <StatCard title="Tipp-Zwillinge" hint="Anteil gemeinsam getippter Spiele mit identischem Ergebnis-Tipp. Grün → Gelb → Rot: Rot = tippt am ähnlichsten.">
+      <table style={{ width: '100%', tableLayout: 'fixed', borderCollapse: 'collapse' }}>
+        <colgroup>
+          <col style={{ width: 84 }} />
+          {players.map(p => <col key={p} />)}
+        </colgroup>
+        <thead>
+          <tr>
+            <th />
+            {players.map(p => (
+              <th key={p} title={p} style={{ verticalAlign: 'bottom', padding: '0 0 6px', fontWeight: 400 }}>
+                <div style={{ writingMode: 'vertical-rl', transform: 'rotate(180deg)', fontSize: 10, color: 'var(--text-dim)', whiteSpace: 'nowrap', margin: '0 auto' }}>{p}</div>
+              </th>
             ))}
-          </tbody>
-        </table>
-      </div>
+          </tr>
+        </thead>
+        <tbody>
+          {players.map(a => (
+            <tr key={a}>
+              <td style={{ fontSize: 11, color: 'var(--text-secondary)', padding: '0 6px 0 0', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{a}</td>
+              {players.map(b => {
+                if (a === b) return <td key={b} style={{ padding: 0 }}><div style={cellDiv({ background: 'var(--surface-alt)' })} /></td>
+                const s = sim(a, b)
+                return (
+                  <td key={b} style={{ padding: 0 }} title={s ? `${a} ↔ ${b}: ${Math.round(s.rate * 100)}% von ${s.common} Spielen` : 'keine gemeinsamen Spiele'}>
+                    <div style={cellDiv({ color: s ? '#15202b' : 'var(--text-dim)', background: s ? heat(s.rate) : 'transparent' })}>
+                      {s ? Math.round(s.rate * 100) : '–'}
+                    </div>
+                  </td>
+                )
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </StatCard>
   )
 }


### PR DESCRIPTION
- The matrix now fills 100% of the card width (table-layout: fixed) with
  each cell forced square via aspect-ratio, so the whole grid fits the
  viewport horizontally (no scroll) and shrinks the cells to stay square
  instead of growing — adapts to any player count / screen width.
- Replace the blue intensity ramp with a green→yellow→red heat scale;
  red marks the highest similarity. Dark cell text for legibility on the
  bright heat colours.

Bump wmt to v3.43.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BYra5SjCBmbp8wUoQpoHNB