### PR TITLE
wmt: make Punkte-Rückstand chart taller

### DIFF
--- a/frontend/src/pages/Wmt.jsx
+++ b/frontend/src/pages/Wmt.jsx
@@ -998,7 +998,7 @@ export default function Wmt() {
               {anyBusy ? '…' : '☰'}
             </button>
           )}
-          <span className="topbar-version">v3.46</span>
+          <span className="topbar-version">v3.47</span>
         </div>
       </div>
 
@@ -2391,7 +2391,7 @@ function PointsGapChart({ snapshots, matches }) {
     })
   }
 
-  const H = 240, padL = 34, padR = 84, padT = 12, padB = 22
+  const H = 320, padL = 34, padR = 84, padT = 12, padB = 22
   const W = 700
   const plotW = W - padL - padR, plotH = H - padT - padB
   const axisMax = totalMatches + 8


### PR DESCRIPTION
Raise the gap-to-leader chart height from 240 to 320 so the lines have
more vertical room and look less crowded.

Bump wmt to v3.47.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BYra5SjCBmbp8wUoQpoHNB