### PR TITLE
Fix Rangverlauf auto-scroll to show latest data points, not empty area

### DIFF
--- a/frontend/src/pages/Wmt.jsx
+++ b/frontend/src/pages/Wmt.jsx
@@ -1018,7 +1018,7 @@ export default function Wmt() {
               {anyBusy ? '…' : '☰'}
             </button>
           )}
-          <span className="topbar-version">v3.62</span>
+          <span className="topbar-version">v3.63</span>
         </div>
       </div>
 
@@ -1910,8 +1910,15 @@ function RankingChart({ snapshots, matches }) {
     if (didAutoScroll.current) return
     const sc = scrollRef.current
     if (!sc || sc.scrollWidth <= sc.clientWidth) return
+    const circles = sc.querySelectorAll('circle')
+    if (circles.length === 0) return
     didAutoScroll.current = true
-    sc.scrollLeft = sc.scrollWidth - sc.clientWidth
+    let maxCx = 0
+    circles.forEach(c => {
+      const cx = parseFloat(c.getAttribute('cx'))
+      if (cx > maxCx) maxCx = cx
+    })
+    sc.scrollLeft = Math.max(0, maxCx + 80 - sc.clientWidth)
   })
 
   // Each snapshot represents a moment in time — an exact `snapshot_time` if set,


### PR DESCRIPTION
Instead of scrolling to the SVG's right edge (which shows future empty slots), find the rightmost actual data circle and scroll so it plus the player name labels are visible.

refs wmt v3.63


Claude-Session: https://claude.ai/code/session_01BYra5SjCBmbp8wUoQpoHNB