### PR TITLE
Remove total-sum column from Punkte pro Spieltag (wmt v4.0)

### DIFF
--- a/frontend/src/pages/Wmt.jsx
+++ b/frontend/src/pages/Wmt.jsx
@@ -1018,7 +1018,7 @@ export default function Wmt() {
               {anyBusy ? '…' : '☰'}
             </button>
           )}
-          <span className="topbar-version">v3.65</span>
+          <span className="topbar-version">v3.66</span>
         </div>
       </div>
 
@@ -2735,11 +2735,10 @@ function PointsPerDayHeatmap({ matches, opponentTips }) {
               {days.map(d => (
                 <th key={d} style={{ ...cell, fontSize: 9, color: 'var(--text-dim)', fontWeight: 400, paddingBottom: 6 }}>{ddmm(d)}</th>
               ))}
-              <th style={{ ...cell, fontSize: 9, color: 'var(--text-dim)', fontWeight: 400, paddingBottom: 6 }}>Σ</th>
             </tr>
           </thead>
           <tbody>
-            {order.map(({ p, total }) => (
+            {order.map(({ p }) => (
               <tr key={p}>
                 <td style={{ position: 'sticky', left: 0, background: 'var(--surface)', fontSize: 12, color: 'var(--text-secondary)', padding: '2px 8px 2px 0', whiteSpace: 'nowrap' }}>{p}</td>
                 {days.map(d => {
@@ -2748,7 +2747,6 @@ function PointsPerDayHeatmap({ matches, opponentTips }) {
                     <td key={d} style={{ ...cell, color: '#15202b', background: heat(v / maxDay) }}>{v}</td>
                   )
                 })}
-                <td style={{ ...cell, color: 'var(--text-primary)', fontWeight: 500 }}>{total}</td>
               </tr>
             ))}
           </tbody>

--- a/frontend/src/pages/Wmt.jsx
+++ b/frontend/src/pages/Wmt.jsx
@@ -1018,7 +1018,7 @@ export default function Wmt() {
               {anyBusy ? '…' : '☰'}
             </button>
           )}
-          <span className="topbar-version">v3.66</span>
+          <span className="topbar-version">v4.0</span>
         </div>
       </div>
 


### PR DESCRIPTION
Removes the Σ total-sum column from the **Punkte pro Spieltag** heatmap. Players stay sorted by their total points, just without the column shown.

Bumps wmt to v4.0 (major bump requested).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BYra5SjCBmbp8wUoQpoHNB)_