### PR TITLE
Restore data-point dots on Rangverlauf only (wmt v4.5)

### DIFF
--- a/frontend/src/pages/Wmt.jsx
+++ b/frontend/src/pages/Wmt.jsx
@@ -1087,7 +1087,7 @@ export default function Wmt() {
               {anyBusy ? '…' : '☰'}
             </button>
           )}
-          <span className="topbar-version">v4.4</span>
+          <span className="topbar-version">v4.5</span>
         </div>
       </div>
 
@@ -2130,6 +2130,9 @@ function RankingChart({ snapshots, matches }) {
               return (
                 <g key={p}>
                   <polyline points={pts} fill="none" stroke={color} strokeWidth={1.5} opacity={0.85} />
+                  {points.map((pt, i) => (
+                    <circle key={i} cx={pt.x} cy={pt.y} r={2.5} fill={color} />
+                  ))}
                 </g>
               )
             })


### PR DESCRIPTION
Brings back the per-data-point circles on **Rangverlauf** only. **Punkte-Rückstand zum Spitzenreiter** and **Punkteverlauf** stay dot-free.

Bumps wmt to v4.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BYra5SjCBmbp8wUoQpoHNB)_