### PR TITLE
Recolor heatmaps yellow→orange→red, scroll-to-current-day, reorder stats (wmt v4.7)

### DIFF
--- a/frontend/src/pages/Wmt.jsx
+++ b/frontend/src/pages/Wmt.jsx
@@ -1087,7 +1087,7 @@ export default function Wmt() {
               {anyBusy ? '…' : '☰'}
             </button>
           )}
-          <span className="topbar-version">v4.6</span>
+          <span className="topbar-version">v4.7</span>
         </div>
       </div>
 
@@ -2885,14 +2885,12 @@ function TwinsHeatmap({ opponentTips }) {
     return common === 0 ? null : { rate: same / common, common }
   }
 
-  // Green → yellow → red heat scale; red marks the highest similarity. The
-  // input is biased upward (pow < 1) so the green band stays small and most
-  // cells read yellow → red.
+  // Yellow → orange → red heat scale: low similarity yellow, high red — so the
+  // closest tip-twins draw the most attention.
   const heat = t => {
-    const b = Math.pow(t, 0.55)
-    const stops = [[46, 204, 113], [241, 196, 15], [231, 76, 60]] // grün, gelb, rot
-    const seg = b < 0.5 ? 0 : 1
-    const f = b < 0.5 ? b / 0.5 : (b - 0.5) / 0.5
+    const stops = [[241, 196, 15], [230, 126, 34], [231, 76, 60]] // gelb, orange, rot
+    const seg = t < 0.5 ? 0 : 1
+    const f = t < 0.5 ? t / 0.5 : (t - 0.5) / 0.5
     const c0 = stops[seg], c1 = stops[seg + 1]
     const ch = i => Math.round(c0[i] + (c1[i] - c0[i]) * f)
     return `rgb(${ch(0)}, ${ch(1)}, ${ch(2)})`
@@ -2904,7 +2902,7 @@ function TwinsHeatmap({ opponentTips }) {
   const cellDiv = extra => ({ width: '100%', aspectRatio: '1', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 9, fontVariantNumeric: 'tabular-nums', ...extra })
 
   return (
-    <StatCard title="Tipp-Zwillinge" hint="Anteil gemeinsam getippter Spiele mit identischem Ergebnis-Tipp. Grün → Gelb → Rot: Rot = tippt am ähnlichsten.">
+    <StatCard title="Tipp-Zwillinge" hint="Anteil gemeinsam getippter Spiele mit identischem Ergebnis-Tipp. Gelb → Orange → Rot: Rot = tippt am ähnlichsten.">
       <table style={{ width: '100%', tableLayout: 'fixed', borderCollapse: 'collapse' }}>
         <colgroup>
           <col style={{ width: 84 }} />
@@ -3290,16 +3288,16 @@ function KonkurrenzView({ matches, opponentTips, rankingSnapshots }) {
 
       <PointsProgressChart snapshots={rankingSnapshots} matches={matches} />
 
-      <DayWinnerLoserCard matches={matches} opponentTips={opponentTips} />
-
       <TrefferguteCard matches={matches} opponentTips={opponentTips} />
 
       <PointsPerDayHeatmap matches={matches} opponentTips={opponentTips} />
       <TwinsHeatmap opponentTips={opponentTips} />
-      <RiskProfile opponentTips={opponentTips} />
       <ScoreDiversityCard opponentTips={opponentTips} />
-      <BoldnessCard matches={matches} opponentTips={opponentTips} />
       <UpsetRadarCard matches={matches} opponentTips={opponentTips} />
+
+      <RiskProfile opponentTips={opponentTips} />
+      <BoldnessCard matches={matches} opponentTips={opponentTips} />
+      <DayWinnerLoserCard matches={matches} opponentTips={opponentTips} />
       </>)}
 
       {sub === 'results' && (<>

--- a/frontend/src/pages/Wmt.jsx
+++ b/frontend/src/pages/Wmt.jsx
@@ -1087,7 +1087,7 @@ export default function Wmt() {
               {anyBusy ? '…' : '☰'}
             </button>
           )}
-          <span className="topbar-version">v4.5</span>
+          <span className="topbar-version">v4.6</span>
         </div>
       </div>
 
@@ -2801,6 +2801,18 @@ function TrefferguteCard({ matches, opponentTips }) {
 
 // ── 4. Punkte pro Spieltag (heatmap) ──────────────────────────────────────
 function PointsPerDayHeatmap({ matches, opponentTips }) {
+  // Scroll the table to its right edge on load so the current (latest) day is
+  // in view — days run chronologically left→right.
+  const scrollRef = useRef(null)
+  const didScroll = useRef(false)
+  useEffect(() => {
+    if (didScroll.current) return
+    const sc = scrollRef.current
+    if (!sc || sc.scrollWidth <= sc.clientWidth) return
+    didScroll.current = true
+    sc.scrollLeft = sc.scrollWidth - sc.clientWidth
+  })
+
   const { days, players, pts } = dailyPointsMatrix(matches, opponentTips)
   if (days.length === 0 || players.length === 0) return null
 
@@ -2808,9 +2820,10 @@ function PointsPerDayHeatmap({ matches, opponentTips }) {
     .sort((a, b) => b.total - a.total || a.p.localeCompare(b.p))
   const maxDay = Math.max(1, ...players.flatMap(p => days.map(d => pts[p][d])))
 
-  // Red → yellow → green heat scale: low score red, high score green.
+  // Yellow → orange → red heat scale: low score (incl. 0) yellow, high score
+  // red — so the strongest days draw the most attention, not the empty ones.
   const heat = t => {
-    const stops = [[231, 76, 60], [241, 196, 15], [46, 204, 113]] // rot, gelb, grün
+    const stops = [[241, 196, 15], [230, 126, 34], [231, 76, 60]] // gelb, orange, rot
     const seg = t < 0.5 ? 0 : 1
     const f = t < 0.5 ? t / 0.5 : (t - 0.5) / 0.5
     const c0 = stops[seg], c1 = stops[seg + 1]
@@ -2821,8 +2834,8 @@ function PointsPerDayHeatmap({ matches, opponentTips }) {
   const cell = { width: 30, height: 22, fontSize: 11, textAlign: 'center', fontVariantNumeric: 'tabular-nums' }
 
   return (
-    <StatCard title="Punkte pro Spieltag" hint="Punkteausbeute je Spieler und Spieltag — Rot = wenig, Grün = viele Punkte.">
-      <div style={{ overflowX: 'auto' }}>
+    <StatCard title="Punkte pro Spieltag" hint="Punkteausbeute je Spieler und Spieltag — Gelb = wenig, Rot = viele Punkte.">
+      <div ref={scrollRef} style={{ overflowX: 'auto' }}>
         <table style={{ borderCollapse: 'collapse' }}>
           <thead>
             <tr>


### PR DESCRIPTION
**Punkte pro Spieltag**
- Recolored the heatmap to yellow→orange→red (low scores incl. 0 are yellow, mid orange, high red) so the strongest days draw attention instead of the empty ones.
- The table now scrolls to its right edge on load so the latest match day is in view.

**Tipp-Zwillinge**
- Recolored to the same yellow→orange→red scale (low similarity yellow, high red), dropping the old green/biased scale.

**Statistiken layout**
- Moved Risikoprofil, Mut zum Risiko and Tageswertung to the very bottom of the subpage.

Bumps wmt to v4.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BYra5SjCBmbp8wUoQpoHNB)_