### PR TITLE
Fix penalty rule for close KO matches

### DIFF
--- a/frontend/src/pages/Wmt.jsx
+++ b/frontend/src/pages/Wmt.jsx
@@ -138,8 +138,17 @@ function bestTip(p, isKnockout) {
   )
   const best = cands[0]
   let penalty = null
-  if (isKnockout && best.th === best.ta) {
-    penalty = generatePenalty(p.home_win_prob ?? 0.5, p.away_win_prob ?? 0.5)
+  if (isKnockout) {
+    const gap = Math.abs((p.home_win_prob ?? 0) - (p.away_win_prob ?? 0))
+    if (gap < 0.10 && best.th !== best.ta) {
+      const bestDraw = cands.filter(c => c.th === c.ta).sort((x, y) => y.ev - x.ev || y.cellPr - x.cellPr)[0]
+      if (bestDraw) {
+        return [bestDraw.th, bestDraw.ta, generatePenalty(p.home_win_prob ?? 0.5, p.away_win_prob ?? 0.5)]
+      }
+    }
+    if (best.th === best.ta) {
+      penalty = generatePenalty(p.home_win_prob ?? 0.5, p.away_win_prob ?? 0.5)
+    }
   }
   return [best.th, best.ta, penalty]
 }
@@ -1127,7 +1136,7 @@ export default function Wmt() {
               {anyBusy ? '…' : '☰'}
             </button>
           )}
-          <span className="topbar-version">v4.11</span>
+          <span className="topbar-version">v4.12</span>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

- When two KO teams have a win probability gap < 10% (e.g. AUS 39% vs EGY 43%), the EV optimization was still picking a decisive result (0:1) instead of a draw + penalty tip
- Now forces the best draw candidate with penalty shootout result when win probs are close, regardless of what the EV math prefers
- Existing behavior unchanged: if the gap is ≥ 10% or the EV already picks a draw, everything works as before

refs #336

---
_Generated by [Claude Code](https://claude.ai/code/session_01BYra5SjCBmbp8wUoQpoHNB)_