### PR TITLE
Fix LAST_16 teams being reset to TBD on each refresh

### DIFF
--- a/backend/routers/wmt.py
+++ b/backend/routers/wmt.py
@@ -737,14 +737,15 @@ def _do_refresh_fdorg(db: Session) -> tuple[list[str], str]:
             was_finished = match.status == "FINISHED"
             match.status = status
             match.last_fetched = datetime.utcnow()
-            if stage != "GROUP_STAGE":
-                match.home_team_id = home_team.id if home_team else None
-                match.away_team_id = away_team.id if away_team else None
-            else:
-                if home_team:
-                    match.home_team_id = home_team.id
-                if away_team:
-                    match.away_team_id = away_team.id
+            # For both group and KO stages: only overwrite a team assignment
+            # when the API actually returns a team.  If the API still shows a
+            # placeholder (null TLA → home_team is None) we leave the existing
+            # assignment untouched so _auto_assign_next_round's pairings survive
+            # subsequent refreshes.
+            if home_team:
+                match.home_team_id = home_team.id
+            if away_team:
+                match.away_team_id = away_team.id
             if status == "FINISHED" and score_home is not None and score_away is not None:
                 if not was_finished:
                     match.score_home = score_home


### PR DESCRIPTION
## Summary

- **Root cause:** `_do_refresh_fdorg` was unconditionally setting `home_team_id = None` / `away_team_id = None` for KO matches whenever football-data.org returned a placeholder (null TLA). This wiped out the correct Spain/Portugal pairing that `_auto_assign_next_round` had set after LAST_32 finished.
- **Fix:** Only update a team assignment when the API actually provides a non-null team — the same logic that was already used for GROUP_STAGE matches. If the API still shows a placeholder, the existing assignment is left untouched.
- After deploying, a single "Spielplan aktualisieren" refresh will pick up the API teams (if fdorg now knows them) or leave the auto-assigned ones in place — either way the match will no longer revert to TBD.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BYra5SjCBmbp8wUoQpoHNB)_