### PR TITLE
Fix KO duplicate team assignments (ENG/FRA/BRA in multiple matches)

### DIFF
--- a/backend/routers/wmt.py
+++ b/backend/routers/wmt.py
@@ -2117,11 +2117,25 @@ def _auto_assign_next_round(db: Session) -> None:
             .order_by(models.WmtMatch.utc_date)
             .all()
         )
-        if not slots or len(team_ids) < len(slots) * 2:
+        if not slots:
+            return
+        # Exclude teams already placed in any match in this stage (API-assigned slots)
+        # so we never assign the same team to two different matches.
+        already_placed: set[int] = set()
+        for m in db.query(models.WmtMatch).filter(
+            models.WmtMatch.stage == stage,
+            models.WmtMatch.home_team_id.isnot(None),
+        ).all():
+            if m.home_team_id:
+                already_placed.add(m.home_team_id)
+            if m.away_team_id:
+                already_placed.add(m.away_team_id)
+        available = [tid for tid in team_ids if tid not in already_placed]
+        if len(available) < len(slots) * 2:
             return
         # Pair strongest vs weakest by ELO (same logic as do_fake_rd32 / do_fake_knockout_round)
         sorted_ids = sorted(
-            team_ids, key=lambda t: -(all_teams[t].elo if all_teams.get(t) else DEFAULT_ELO)
+            available, key=lambda t: -(all_teams[t].elo if all_teams.get(t) else DEFAULT_ELO)
         )
         n = len(slots)
         for i, m in enumerate(slots):
@@ -2932,3 +2946,44 @@ def fake_all_results(db: Session = Depends(get_db)):
     """Alle Phasen MD1–Finale in einem Schritt faken (nur für Tests)."""
     n, msg = do_fake_all(db)
     return schemas.WmtRefreshOut(message=msg, updated=n)
+
+
+@router.post("/debug/repair-ko-assignments", response_model=schemas.WmtRefreshOut)
+def repair_ko_assignments(db: Session = Depends(get_db)):
+    """Clear duplicate KO team assignments and re-run refresh.
+
+    Fixes the case where _fill_slots (ELO pairing) assigned teams that the
+    football-data.org API had already placed in other slots, causing the same
+    team to appear in multiple matches.  Clears all unfinished KO slots where
+    a team appears more than once, then re-fetches from the API so the correct
+    pairings are restored.
+    """
+    ko_stages = ["LAST_16", "QUARTER_FINALS", "SEMI_FINALS", "FINAL", "THIRD_PLACE"]
+    cleared = 0
+    for stage in ko_stages:
+        from collections import Counter
+        matches = db.query(models.WmtMatch).filter(
+            models.WmtMatch.stage == stage,
+            models.WmtMatch.status != "FINISHED",
+        ).all()
+        counts: Counter = Counter()
+        for m in matches:
+            if m.home_team_id:
+                counts[m.home_team_id] += 1
+            if m.away_team_id:
+                counts[m.away_team_id] += 1
+        dupes = {tid for tid, n in counts.items() if n > 1}
+        if not dupes:
+            continue
+        for m in matches:
+            if m.home_team_id in dupes or m.away_team_id in dupes:
+                m.home_team_id = None
+                m.away_team_id = None
+                cleared += 1
+    db.commit()
+
+    labels, err = do_refresh(db)
+    msg = f"{cleared} fehlerhafte Slot(s) zurückgesetzt, {len(labels)} Spiel(e) aktualisiert."
+    if err:
+        msg += f" Warnung: {err}"
+    return schemas.WmtRefreshOut(message=msg, updated=cleared + len(labels))

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -92,6 +92,7 @@ export const wmt = {
   fakeTp: ()                 => post('/wmt/debug/fake-tp'),
   fakeFinal: ()              => post('/wmt/debug/fake-final'),
   fakeAll: ()                => post('/wmt/debug/fake-all'),
+  repairKoAssignments: ()    => post('/wmt/debug/repair-ko-assignments'),
 }
 
 // ── drv ───────────────────────────────────────────────────────

--- a/frontend/src/pages/Wmt.jsx
+++ b/frontend/src/pages/Wmt.jsx
@@ -658,6 +658,7 @@ export default function Wmt() {
   const [fakingTp, setFakingTp]           = useState(false)
   const [fakingFinal, setFakingFinal]     = useState(false)
   const [fakingAll, setFakingAll]         = useState(false)
+  const [repairingKo, setRepairingKo]     = useState(false)
   const [summaryCalOpen, setSummaryCalOpen]           = useState(false)
   const [generatingSummaryFor, setGeneratingSummaryFor] = useState(null)
   const [logs, setLogs]                   = useState([])
@@ -831,6 +832,21 @@ export default function Wmt() {
       addLog(`Fehler beim Refresh${e?.message ? ` — ${e.message}` : ''}`, 'error')
     } finally {
       setRefreshing(false)
+    }
+  }
+
+  async function handleRepairKo() {
+    setRepairingKo(true)
+    setView('import')
+    addLog('KO-Zuweisung wird repariert…')
+    try {
+      const res = await wmt.repairKoAssignments()
+      addLog(res.message || 'Fertig', 'done')
+      await loadAll()
+    } catch (e) {
+      addLog(`Fehler bei der KO-Reparatur${e?.message ? ` — ${e.message}` : ''}`, 'error')
+    } finally {
+      setRepairingKo(false)
     }
   }
 
@@ -1049,7 +1065,7 @@ export default function Wmt() {
   }
 
   const anyBusy = refreshing || clearing || warming || generatingBonus || adjustingNews ||
-    fakingMd1 || fakingMd2 || fakingMd3 || fakingRd32 ||
+    fakingMd1 || fakingMd2 || fakingMd3 || fakingRd32 || repairingKo ||
     fakingLast16 || fakingQf || fakingSf || fakingTp || fakingFinal || fakingAll
 
   const md1Done = matches.some(m => m.stage === 'GROUP_STAGE' && m.matchday === 1) &&
@@ -1146,7 +1162,7 @@ export default function Wmt() {
               {anyBusy ? '…' : '☰'}
             </button>
           )}
-          <span className="topbar-version">v4.13</span>
+          <span className="topbar-version">v4.14</span>
         </div>
       </div>
 
@@ -1172,6 +1188,11 @@ export default function Wmt() {
               icon="↻" label="Spielplan aktualisieren"
               loading={refreshing} disabled={anyBusy && !refreshing}
               onClick={() => { setMenuOpen(false); setView('import'); handleRefresh() }}
+            />
+            <MenuButton
+              icon="🔧" label="KO-Zuweisung reparieren"
+              loading={repairingKo} disabled={anyBusy && !repairingKo}
+              onClick={() => { setMenuOpen(false); handleRepairKo() }}
             />
             <MenuButton
               icon="📋" label="Morgenbericht erstellen"


### PR DESCRIPTION
## Summary

**Root cause:** `_fill_slots` (ELO-based pairing) took the full pool of previous-round winners — including teams the API had already placed in other LAST_16 slots — and reassigned them to the remaining empty slots, creating duplicates.

**Fix:**
- `_fill_slots` now excludes teams already assigned to any match in the target stage before doing ELO pairing — so the pairing only uses genuinely unplaced teams
- New `POST /api/wmt/debug/repair-ko-assignments` endpoint: finds all KO stages with duplicate team assignments, clears the affected matches, then re-runs refresh so the API restores correct pairings and the fixed `_fill_slots` handles the rest
- **"🔧 KO-Zuweisung reparieren"** button in the burger menu — tap once after deploying to fix the current broken state

**After deploying:** tap "🔧 KO-Zuweisung reparieren" once to clear and rebuild all affected matches correctly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BYra5SjCBmbp8wUoQpoHNB)_